### PR TITLE
Fix webpage

### DIFF
--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -15,9 +15,9 @@
 \input{macro/common}
 \input{macro/web}
 
-%\home{https://github.com/teorth/PFR/}
-\github{https://github.com/teorth/PFR/}
-\dochome{https://teorth.github.io/PFR/docs}
+%\home{https://github.com/teorth/pfr/}
+\github{https://github.com/teorth/pfr/}
+\dochome{https://teorth.github.io/pfr/docs}
 
 \title{PFR}
 \author{}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ title: The Polynomial Freiman-Ruzsa Conjecture
 #email: your-email@example.com
 description: A digitisation of the proof of the Polynomial Freiman-Ruzsa Conjecture in Lean 4
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://teorth.github.io/PFR/" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://teorth.github.io/pfr/" # the base hostname & protocol for your site, e.g. http://example.com
 #twitter_username: jekyllrb
 github_username: teorth
 repository: teorth/pfr

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,6 +31,8 @@ repository: teorth/pfr
 remote_theme: pages-themes/cayman@v0.2.0
 plugins:
   - jekyll-remote-theme
+
+markdown: kramdown
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/docs/_includes/mathjax.html
+++ b/docs/_includes/mathjax.html
@@ -1,0 +1,10 @@
+<!-- for mathjax support -->
+{% if page.usemathjax %}
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+  TeX: { equationNumbers: { autoNumber: "AMS" } }
+  });
+</script>
+<script type="text/javascript" async
+  src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+{% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -13,7 +13,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   {% if jekyll.environment == "production" %}
   <link rel="stylesheet"
-    href="{{ 'PFR/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    href="{{ 'pfr/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   {% else %}
   <link rel="stylesheet" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   {% endif %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,18 +3,21 @@
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 
 # layout: home
+usemathjax: true
 ---
+
+{% include mathjax.html %}
 
 # The Polynomial Freiman-Ruzsa Conjecture
 
-The purpose of this repository is to hold a Lean4 formalization of the proof of the Polynomial Freiman-Ruzsa (PFR) conjecture, recently proven in https://arxiv.org/abs/2311.05762 .  The statement is as follows: if $A$ is a non-empty subset of ${\bf F}_2^n$ such that $|A+A| \leq K|A|$, then $A$ can be covered by at most $2K^{12}$ cosets of a subspace $H$ of ${\bf F}_2^n$ of cardinality at most $|A|$.  The proof relies on the theory of Shannon entropy, so in particular development of the Shannon entropy inequalities will be needed.
+The purpose of this repository is to hold a Lean4 formalization of the proof of the Polynomial Freiman-Ruzsa (PFR) conjecture, recently proven in <https://arxiv.org/abs/2311.05762>.  The statement is as follows: if $$A$$ is a non-empty subset of $${\bf F}_2^n$$ such that $$\vert A+A\vert \leq K\vert A\vert$$, then $$A$$ can be covered by at most $$2K^{12}$$ cosets of a subspace $$H$$ of $${\bf F}_2^n$$ of cardinality at most $$\vert A\vert$$.  The proof relies on the theory of Shannon entropy, so in particular development of the Shannon entropy inequalities will be needed.
 
-Discussion of the project will be held on this Zulip stream: https://leanprover.zulipchat.com/#narrow/stream/412902-Polynomial-Freiman-Ruzsa-conjecture
+Discussion of the project will be held on this Zulip stream: <https://leanprover.zulipchat.com/#narrow/stream/412902-Polynomial-Freiman-Ruzsa-conjecture>
 
-Additional discussion of the project may be found at https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton/
+Additional discussion of the project may be found at <https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton/>
 
 ## Source reference
 
-`[GGMT]`: https://arxiv.org/abs/2311.05762
+`[GGMT]`: <https://arxiv.org/abs/2311.05762>
 
 [GGMT]: https://arxiv.org/abs/2311.05762


### PR DESCRIPTION
Various fixes have been done to make the website look nice.
![image](https://github.com/teorth/pfr/assets/50671761/a5c292ba-df06-4d91-aad8-f02462765cf0)
- There were some capitalisation issues which made the CSS file not load (it was looking in `PFR` not `pfr`).
- MathJax wasn't supported, so I added some code to enable it.
- MathJax expects double `$$` signs to surround math mode content instead of single `$` signs.

Note: because of the interaction between Markdown and MathJax, vertical pipe symbols `|` can't be used directly, because Markdown thinks you're starting a table.
![image](https://github.com/teorth/pfr/assets/50671761/00a2899f-ce25-43b5-ad8a-afa59b70fbc1)
I converted each `|` into `\vert` to fix this issue.