### PR TITLE
Prototype "finiteness" tactic

### DIFF
--- a/PFR/ForMathlib/Finiteness.lean
+++ b/PFR/ForMathlib/Finiteness.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2023 Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Heather Macbeth
+-/
+import PFR.ForMathlib.Finiteness.Attr
+import Mathlib.MeasureTheory.Measure.Typeclasses
+
+/-! # Finiteness tactic
+
+This file implements a basic `finiteness` tactic, designed to solve goals of the form `*** < ∞` and
+(equivalently) `*** ≠ ∞` in the extended nonnegative reals (`ENNReal`, aka `ℝ≥0∞`).
+
+It works recursively according to the syntax of the expression. It is implemented as an `aesop` rule
+set.
+
+TODO: improve `finiteness` to also deal with other situations, such as balls in proper spaces with
+a locally finite measure.
+
+-/
+
+open ENNReal
+
+/-! ## Lemmas -/
+
+theorem ENNReal.ofNat_ne_top (n : ℕ) [Nat.AtLeastTwo n] : no_index (OfNat.ofNat n) ≠ ∞ :=
+  ENNReal.nat_ne_top n
+
+theorem ENNReal.inv_ne_top' (h : a ≠ 0) : a⁻¹ ≠ ∞ := ENNReal.inv_ne_top.2 h
+
+theorem ENNReal.add_ne_top' {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : a + b ≠ ∞ :=
+  ENNReal.add_ne_top.2 ⟨ha, hb⟩
+
+/-! ## Tactic implementation -/
+
+attribute [aesop (rule_sets [Finiteness]) unsafe 20%] ne_top_of_lt
+-- would have been better to implement this as a "safe" "forward" rule, why doesn't this work?
+-- attribute [aesop (rule_sets [Finiteness]) safe forward] ne_top_of_lt
+
+attribute [aesop (rule_sets [Finiteness]) safe apply]
+  Ne.lt_top
+  ENNReal.ofReal_ne_top ENNReal.coe_ne_top ENNReal.nat_ne_top
+  ENNReal.zero_ne_top ENNReal.one_ne_top ENNReal.ofNat_ne_top
+  ENNReal.mul_ne_top ENNReal.add_ne_top' ENNReal.sub_ne_top ENNReal.inv_ne_top'
+  MeasureTheory.measure_ne_top
+
+attribute [aesop (rule_sets [Finiteness]) safe -50] Aesop.BuiltinRules.assumption
+
+open Lean Elab Tactic in
+@[aesop safe tactic (rule_sets [Finiteness])]
+def PositivityForAesop : TacticM Unit :=
+  liftMetaTactic fun g => do Mathlib.Meta.Positivity.positivity g; pure []
+
+/-- Tactic to solve goals of the form `*** < ∞` and (equivalently) `*** ≠ ∞` in the extended
+nonnegative reals (`ℝ≥0∞`). -/
+macro (name := finiteness) "finiteness" c:Aesop.tactic_clause* : tactic =>
+`(tactic|
+  aesop $c*
+    (options := { introsTransparency? := some .default, terminal := true })
+    (simp_options := { enabled := false })
+    (rule_sets [$(Lean.mkIdent `Finiteness):ident, -default, -builtin]))
+
+/-! ## Tests -/
+
+example : (1:ℝ≥0∞) < ∞ := by finiteness
+example : (3:ℝ≥0∞) ≠ ∞ := by finiteness
+
+example (a : ℝ) (b : ℕ) : ENNReal.ofReal a + b < ∞ := by finiteness
+
+example {a : ℝ≥0∞} (ha : a ≠ ∞) : a + 3 < ∞ := by finiteness
+example {a : ℝ≥0∞} (ha : a < ∞) : a + 3 < ∞ := by finiteness
+
+example (a : ℝ) : (ENNReal.ofReal (1 + a ^ 2))⁻¹ < ∞ := by finiteness

--- a/PFR/ForMathlib/Finiteness/Attr.lean
+++ b/PFR/ForMathlib/Finiteness/Attr.lean
@@ -1,0 +1,4 @@
+import Aesop
+
+
+declare_aesop_rule_sets [Finiteness]

--- a/PFR/ForMathlib/Positivity.lean
+++ b/PFR/ForMathlib/Positivity.lean
@@ -1,0 +1,24 @@
+import Mathlib.Tactic.Positivity
+import Mathlib.Data.Fintype.Card
+
+/-!
+
+It has been debated whether to make a positivity extension to show `0 < Fintype.card X` when
+typeclass inference can find the nonemptiness of the fintype `X`.  For example, see
+
+https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Could.20positivity.20handle.20sums.20of.20squares.3F/near/398074551
+
+The consensus seems to be in favour, so let's enable it for this project and see what happens.
+
+-/
+
+namespace Mathlib.Meta.Positivity
+
+open Lean Meta Qq Function
+
+/-- Extension for the `positivity` tactic: cardinalities of nonempty fintypes are positive. -/
+@[positivity Fintype.card _]
+def evalFintypeCard : PositivityExt where eval {_ _} _zα _pα e := do
+  let .app (.app _ a) _ ← whnfR e | throwError "not Fintype.card"
+  let p ← mkAppOptM ``Fintype.card_pos #[a, none, none]
+  pure (.positive p)

--- a/PFR/MeasureReal.lean
+++ b/PFR/MeasureReal.lean
@@ -1,4 +1,4 @@
-import Mathlib.MeasureTheory.Measure.Typeclasses
+import PFR.ForMathlib.Finiteness
 
 /-!
 # Measures as real valued-functions
@@ -10,11 +10,8 @@ We essentially copy relevant lemmas from the files `MeasureSpaceDef.lean`, `Null
 `MeasureSpace.lean`, and adapt them by replacing in their name `measure` with `measureReal`.
 
 Many lemmas require an assumption that some set has finite measure. These assumptions are written
-in the form `(h : μ s ≠ ∞ := by finiteness)`, where `finiteness` is a tactic that will discharge
-automatically this goal if the ambiant space has finite measure.
-
-TODO: improve `finiteness` to also deal with other situations, such as balls in proper spaces with
-a locally finite measure.
+in the form `(h : μ s ≠ ∞ := by finiteness)`, where `finiteness` is a new tactic (still in prototype
+form) for goals of the form `≠ ∞`.
 
 There are certainly many missing lemmas. The idea is to add the missing ones as we notice that they
 would be useful while doing the project.
@@ -26,8 +23,6 @@ project, but we should probably add them back in the long run if they turn out t
 
 open MeasureTheory Measure Set
 open scoped ENNReal NNReal BigOperators
-
-macro "finiteness" : tactic => `(tactic|intros <;> apply measure_ne_top)
 
 section aux_lemmas
 
@@ -116,7 +111,7 @@ theorem measureReal_univ_pos [IsFiniteMeasure μ] [NeZero μ] : 0 < μ.real Set.
   rw [measureReal_def]
   apply ENNReal.toReal_pos
   exact NeZero.ne (μ Set.univ)
-  exact measure_ne_top μ Set.univ
+  finiteness
 
 theorem measureReal_univ_ne_zero [IsFiniteMeasure μ] [NeZero μ] : μ.real Set.univ ≠ 0 :=
   measureReal_univ_pos.ne'

--- a/PFR/entropy_basic.lean
+++ b/PFR/entropy_basic.lean
@@ -2,6 +2,7 @@ import Mathlib.Probability.ConditionalProbability
 import Mathlib.Probability.Independence.Basic
 import Mathlib.Probability.Notation
 import Mathlib.Probability.IdentDistrib
+import PFR.ForMathlib.Positivity
 import PFR.neg_xlogx
 import PFR.MeasureReal
 
@@ -189,9 +190,8 @@ lemma measureEntropy_eq_card_iff_measureReal_eq_aux [MeasurableSingletonClass S]
   | inr h =>
     -- multiply LHS equation through by `N⁻¹`
     set N := Fintype.card S
-    have hN : 0 < N := Fintype.card_pos
-    have hN''' : (N:ℝ)⁻¹ ≠ 0 := by positivity
-    rw [← mul_right_inj' hN''']
+    have hN : (N:ℝ)⁻¹ ≠ 0 := by positivity
+    rw [← mul_right_inj' hN]
     -- setup to use equality case of Jensen
     let w (_ : S) := (N:ℝ)⁻¹
     have hw1 : ∀ s ∈ Finset.univ, 0 < w s := by intros; positivity
@@ -260,8 +260,7 @@ lemma measureEntropy_eq_card_iff_measure_eq [MeasurableSingletonClass S] [IsFini
   rw [measureReal_def, ← ENNReal.toReal_eq_toReal_iff' (measure_ne_top μ {s})]
   · rw [ENNReal.toReal_mul, ENNReal.toReal_inv]
     rfl
-  · apply ENNReal.mul_ne_top (measure_ne_top μ Set.univ)
-    simp
+  · finiteness
 
 lemma measureEntropy_map_of_injective [MeasurableSingletonClass S] [MeasurableSingletonClass T]
     (μ : Measure S) (f : S → T) (hf : Function.Injective f)  :


### PR DESCRIPTION
This implements a prototype `finiteness` tactic, designed to solve goals of the form `*** < ∞` and
(equivalently) `*** ≠ ∞` in `ENNReal`.  There will be a lot of rough edges, it's not tested much.

See previous Zulip discussions, e.g.

https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/infinity.20in.20positivity.3F

https://leanprover.zulipchat.com/#narrow/stream/412902-Polynomial-Freiman-Ruzsa-conjecture/topic/comments.20on.20FiniteMeasure.20user-friendliness/near/402458215