### PR TITLE
Small fixes + experiments on spelling IsUniform

### DIFF
--- a/PFR/FiniteMeasureFintype.lean
+++ b/PFR/FiniteMeasureFintype.lean
@@ -3,25 +3,11 @@ import Mathlib.MeasureTheory.Measure.Count
 import Mathlib.Tactic
 import PFR.ForMathlib.FiniteMeasureComponent
 import PFR.entropy_basic
+import Mathlib
 
 open MeasureTheory Topology Metric Filter Set ENNReal NNReal Real
 
 open scoped Topology ENNReal NNReal BoundedContinuousFunction
-
-section count
-/-! ### Counting measure as a finite measure and discrete uniform measure as a probability measure
-
--/
-
-variable (Ω : Type*) [MeasurableSpace Ω] [Fintype Ω]
-
-noncomputable def finCount : FiniteMeasure Ω :=
-  ⟨Measure.count, Measure.count.isFiniteMeasure⟩
-
-noncomputable def finUniformProba [Nonempty Ω] : ProbabilityMeasure Ω :=
-  (finCount Ω).normalize
-
-end count -- section
 
 variable {ι : Type _} {Ω : Type _}
 variable [MeasurableSpace Ω] [TopologicalSpace Ω] [OpensMeasurableSpace Ω]
@@ -67,3 +53,124 @@ lemma continuous_measureEntropy_probabilityMeasure [Fintype Ω] [DiscreteTopolog
   exact continuous_probabilityMeasure_apply_of_isClopen (s := {ω}) ⟨isOpen_discrete _, T1Space.t1 _⟩
 
 end entropy -- section
+
+section count
+/-! ### Counting measure as a finite measure and discrete uniform measure as a probability measure
+
+-/
+
+variable (Ω : Type*) [MeasurableSpace Ω] [Fintype Ω]
+
+/-- The counting measure on a finite type as a `FiniteMeasure`. -/
+noncomputable def finCount : FiniteMeasure Ω :=
+  ⟨Measure.count, Measure.count.isFiniteMeasure⟩
+
+/-- The discrete uniform probability measure on a nonempty finite type as a `ProbabilityMeasure`. -/
+noncomputable def finUniformProba [Nonempty Ω] : ProbabilityMeasure Ω :=
+  (finCount Ω).normalize
+
+/-- The counting measure on a finite set as a `FiniteMeasure`. -/
+noncomputable def finCountOn {X : Type*} [MeasurableSpace X] {s : Set X}
+    (s_finite : s.Finite) (s_mble : MeasurableSet s) : FiniteMeasure X :=
+  ⟨Measure.count.restrict s, by
+    refine ⟨?_⟩
+    simp only [MeasurableSet.univ, Measure.restrict_apply, univ_inter,
+               Measure.count_apply_finite' s_finite s_mble]
+    exact coe_lt_top⟩
+
+/-- The discrete uniform probability measure on a nonempty finite type as a `ProbabilityMeasure`. -/
+noncomputable def finUniformProbaOn {X : Type*} [MeasurableSpace X] {s : Set X}
+    (s_nonemp : s.Nonempty) (s_finite : s.Finite) (s_mble : MeasurableSet s) :
+    ProbabilityMeasure X :=
+  @FiniteMeasure.normalize X (Exists.nonempty s_nonemp) _ (finCountOn s_finite s_mble)
+
+-- to Mathlib
+lemma Measure.count_apply_pos (X : Type*) [MeasurableSpace X] {s : Set X}
+    (s_nonemp : s.Nonempty) (s_mble : MeasurableSet s) :
+    0 < Measure.count s := by
+  by_contra maybe_zero
+  have maybe_zero' : Measure.count s = 0 := by aesop
+  rw [Measure.count_eq_zero_iff'] at maybe_zero'
+  · aesop
+  · exact s_mble
+
+-- to Mathlib
+lemma Measure.count_univ_pos (X : Type*) [MeasurableSpace X] [Nonempty X] :
+    0 < Measure.count (univ : Set X) :=
+  Measure.count_apply_pos _ univ_nonempty MeasurableSet.univ
+
+lemma finCount_mass_pos [Nonempty Ω] : 0 < (finCount Ω).mass := by
+  apply ENNReal.toNNReal_pos _ (measure_ne_top _ univ)
+  have obs : 0 < Measure.count (univ : Set Ω) := Measure.count_univ_pos Ω
+  aesop
+
+lemma finCount_mass_nonzero [Nonempty Ω] : (finCount Ω).mass ≠ 0 := (finCount_mass_pos Ω).ne.symm
+
+variable [MeasurableSingletonClass Ω]
+
+@[simp] lemma finCount_apply_eq_card (s : Set Ω) :
+    (finCount Ω : Measure Ω).real s = Finset.card (toFinite s).toFinset :=
+  congrArg ENNReal.toReal (Measure.count_apply_finite s (toFinite s))
+
+@[simp] lemma finUniformProba_apply_eq_inv_mul_card [Nonempty Ω] (s : Set Ω) :
+    (finUniformProba Ω : Measure Ω).real s
+      = (Fintype.card Ω : ℝ)⁻¹ * Finset.card (toFinite s).toFinset := by
+  simp [finUniformProba, FiniteMeasure.normalize, finCount_mass_nonzero Ω]
+  -- Why doesn't `ite_false` kick in? Also `rw [ite_false]` fails.
+  -- On the other hand `FiniteMeasure.mass` should probably be refactored, so the coercion
+  -- fight might not be worth it now.
+  sorry
+
+@[simp] lemma finUniformProba_apply_eq_inv_mul_card' [Nonempty Ω] (s : Set Ω) :
+    (finUniformProba Ω : Measure Ω) s
+      = (Fintype.card Ω : ℝ≥0∞)⁻¹ * Finset.card (toFinite s).toFinset := by
+  simp [finUniformProba, FiniteMeasure.normalize, finCount_mass_nonzero Ω]
+  -- Why doesn't `ite_false` kick in?
+  -- Also `rw [ite_false]` fails.
+  sorry
+
+lemma pmf_finUniformProba_eq_uniformOfFintype [Nonempty Ω] :
+    (finUniformProba Ω : Measure Ω).toPMF = PMF.uniformOfFintype Ω := by
+  ext ω
+  rw [Measure.toPMF]
+  simp only [finUniformProba_apply_eq_inv_mul_card', toFinite_toFinset,
+    toFinset_singleton, Finset.card_singleton, Nat.cast_one, mul_one, PMF.uniformOfFintype_apply]
+  rfl
+
+#check Measure.toPMF -- Mathlib: Why is `Countable` an assumption in `toPMF`?
+
+-- By this experiment, I'm not sure `(X.map μ).toPMF = PMF.uniformOfFinset _ _` would be a
+-- nice enough spelling for `IsUniform`.
+lemma pmf_finUniformProbaOn_eq_uniformOfFintype {X : Type*} [Countable X] -- why necessary?
+    [MeasurableSpace X] [MeasurableSingletonClass X] {s : Set X}
+    (s_nonemp : s.Nonempty) (s_finite : s.Finite) (s_mble : MeasurableSet s) :
+    (finUniformProbaOn s_nonemp s_finite s_mble : Measure X).toPMF
+      = PMF.uniformOfFinset s_finite.toFinset
+        ((Finite.toFinset_nonempty s_finite).mpr s_nonemp) := by
+  ext ω
+  rw [Measure.toPMF]
+  sorry
+
+-- Unnecessary, just for Kalle to practice with existing PMF API.
+lemma pmf_probabilityMeasure_apply_eq [MeasurableSingletonClass Ω] (μ : ProbabilityMeasure Ω) (ω : Ω) :
+    (μ : Measure Ω).toPMF ω = (μ : Measure Ω) {ω} := rfl
+
+-- Unnecessary, just for Kalle to practice with existing PMF API.
+lemma pmf_probabilityMeasure_apply_eq' [MeasurableSingletonClass Ω] (μ : ProbabilityMeasure Ω) (ω : Ω) :
+    (μ : Measure Ω).toPMF ω = ENNReal.ofReal ((μ : Measure Ω).real {ω}) := by
+  simp only [Measure.toPMF, Measure.real, ne_eq]
+  rw [ofReal_toReal]
+  · rfl
+  · exact measure_ne_top ↑μ {ω}
+
+-- For Kalle to practice the existing `pdf.IsUniform` and `PMF.uniformOfFinset` APIs.
+lemma isUniform_uniformOfFinset (s : Finset Ω) (hs : Finset.Nonempty s) :
+    pdf.IsUniform (id : Ω → Ω) s (PMF.uniformOfFinset s hs).toMeasure Measure.count := by
+  -- Apparently no results exist yet to connect densities w.r.t. counting measure to PMFs?
+  sorry
+
+end count -- section
+
+section density_count
+
+end density_count -- section

--- a/PFR/FiniteMeasureFintype.lean
+++ b/PFR/FiniteMeasureFintype.lean
@@ -46,7 +46,7 @@ has type
 finite measure. -/
 lemma continuous_pmf_apply [DiscreteTopology Ω] (ω : Ω) :
     Continuous (fun (μ : FiniteMeasure Ω) ↦ FiniteMeasure.pmf μ ω) :=
-  continuous_finiteMeasure_apply_of_isOpen_of_isClosed ⟨isOpen_discrete _, T1Space.t1 _⟩
+  continuous_finiteMeasure_apply_of_isClopen ⟨isOpen_discrete _, T1Space.t1 _⟩
 
 end pmf --section
 
@@ -64,7 +64,6 @@ lemma continuous_measureEntropy_probabilityMeasure [Fintype Ω] [DiscreteTopolog
   intro ω _
   apply continuous_negIdMulLog.comp
   simp only [measure_univ, inv_one, one_smul]
-  exact continuous_probabilityMeasure_apply_of_isOpen_of_isClosed
-    (s := {ω}) ⟨isOpen_discrete _, T1Space.t1 _⟩
+  exact continuous_probabilityMeasure_apply_of_isClopen (s := {ω}) ⟨isOpen_discrete _, T1Space.t1 _⟩
 
 end entropy -- section

--- a/PFR/FiniteMeasureFintype.lean
+++ b/PFR/FiniteMeasureFintype.lean
@@ -8,6 +8,21 @@ open MeasureTheory Topology Metric Filter Set ENNReal NNReal Real
 
 open scoped Topology ENNReal NNReal BoundedContinuousFunction
 
+section count
+/-! ### Counting measure as a finite measure and discrete uniform measure as a probability measure
+
+-/
+
+variable (Ω : Type*) [MeasurableSpace Ω] [Fintype Ω]
+
+noncomputable def finCount : FiniteMeasure Ω :=
+  ⟨Measure.count, Measure.count.isFiniteMeasure⟩
+
+noncomputable def finUniformProba [Nonempty Ω] : ProbabilityMeasure Ω :=
+  (finCount Ω).normalize
+
+end count -- section
+
 variable {ι : Type _} {Ω : Type _}
 variable [MeasurableSpace Ω] [TopologicalSpace Ω] [OpensMeasurableSpace Ω]
 

--- a/PFR/ForMathlib/CompactProb.lean
+++ b/PFR/ForMathlib/CompactProb.lean
@@ -1,6 +1,7 @@
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import PFR.MeasureReal
 import PFR.ForMathlib.Finiteness
+import PFR.ForMathlib.FiniteMeasureComponent
 
 /-!
 # Compactness of the space of probability measures
@@ -78,8 +79,19 @@ noncomputable def equiv_probabilityMeasure_stdSimplex [MeasurableSingletonClass 
 variable [TopologicalSpace X] [DiscreteTopology X] [BorelSpace X]
 
 variable {X}
+lemma continuous_pmf_apply' (i : X) :
+    Continuous (fun (μ : ProbabilityMeasure X) ↦ (μ : Measure X).real {i}) :=
+  continuous_probabilityMeasure_apply_of_isOpen_of_isClosed (s := {i})
+    ⟨isOpen_discrete _, T1Space.t1 _⟩
+
 lemma continuous_pmf_apply (i : X) :
-    Continuous (fun (μ : ProbabilityMeasure X) ↦ μ {i}) := sorry
+    Continuous (fun (μ : ProbabilityMeasure X) ↦ μ {i}) :=  by
+  -- KK: The coercion fight here is one reason why I now prefer ℝ-valued and not ℝ≥0-valued probas.
+  convert continuous_real_toNNReal.comp (continuous_pmf_apply' i)
+  ext
+  simp only [Measure.real, Function.comp_apply, Real.coe_toNNReal', ge_iff_le,
+             ENNReal.toReal_nonneg, max_eq_left]
+  rfl
 
 variable (X)
 

--- a/PFR/ForMathlib/CompactProb.lean
+++ b/PFR/ForMathlib/CompactProb.lean
@@ -79,9 +79,10 @@ noncomputable def equiv_probabilityMeasure_stdSimplex [MeasurableSingletonClass 
 variable [TopologicalSpace X] [DiscreteTopology X] [BorelSpace X]
 
 variable {X}
+
 lemma continuous_pmf_apply' (i : X) :
     Continuous (fun (μ : ProbabilityMeasure X) ↦ (μ : Measure X).real {i}) :=
-  continuous_probabilityMeasure_apply_of_isOpen_of_isClosed (s := {i})
+  continuous_probabilityMeasure_apply_of_isClopen (s := {i})
     ⟨isOpen_discrete _, T1Space.t1 _⟩
 
 lemma continuous_pmf_apply (i : X) :

--- a/PFR/ForMathlib/FiniteMeasureComponent.lean
+++ b/PFR/ForMathlib/FiniteMeasureComponent.lean
@@ -90,7 +90,7 @@ lemma integral_indicatorBCF {α : Type*} [TopologicalSpace α] [MeasurableSpace 
     ∫ x, (indicatorBCF s_clopen x) ∂μ = (μ s).toReal := integral_indicator_one s_mble
 
 /-- The measure of any connected component depends continuously on the `FiniteMeasure`. -/
-lemma continuous_finiteMeasure_apply_of_isOpen_of_isClosed
+lemma continuous_finiteMeasure_apply_of_isClopen
     {α : Type*} [TopologicalSpace α] [MeasurableSpace α] [OpensMeasurableSpace α]
     {s : Set α} (s_clopen : IsClopen s) :
     Continuous (fun (μ : FiniteMeasure α) ↦ (μ : Measure α).real s) := by
@@ -100,7 +100,7 @@ lemma continuous_finiteMeasure_apply_of_isOpen_of_isClosed
   rfl
 
 /-- The probability of any connected component depends continuously on the `ProbabilityMeasure`. -/
-lemma continuous_probabilityMeasure_apply_of_isOpen_of_isClosed
+lemma continuous_probabilityMeasure_apply_of_isClopen
     {α : Type*} [TopologicalSpace α] [MeasurableSpace α] [OpensMeasurableSpace α]
     {s : Set α} (s_clopen : IsClopen s) :
     Continuous (fun (μ : ProbabilityMeasure α) ↦ (μ : Measure α).real s) := by


### PR DESCRIPTION
This PR contains
 * small improvements to the previous PR on continuity of entropy and filling in the last sorry in `CompactProba.lean` which was morally done in the previous PR;
 * 1-line constructions of discrete uniform `ProbabilityMeasure`s and finite counting measures
 * unconclusive / unsuccessful attempts at a good spelling of `IsUniform` with `PDF.uniformOfFinset` (these should probably be discarded once a good spelling is agreed on).