### PR TITLE
Entropy additive iff independent

### DIFF
--- a/PFR/MeasureReal.lean
+++ b/PFR/MeasureReal.lean
@@ -1,3 +1,4 @@
+import Mathlib.MeasureTheory.Constructions.Prod.Basic
 import PFR.ForMathlib.Finiteness
 
 /-!
@@ -440,6 +441,35 @@ theorem nonempty_inter_of_measureReal_lt_add' {m : MeasurableSpace α} (μ : Mea
   rw [add_comm] at h
   rw [inter_comm]
   exact nonempty_inter_of_measureReal_lt_add μ hs h't h's h hu
+
+theorem measureReal_prod_prod {μ : Measure α} {ν : Measure β} [SigmaFinite ν] (s : Set α)
+    (t : Set β) :
+    (μ.prod ν).real (s ×ˢ t) = μ.real s * ν.real t := by
+  simp only [measureReal_def, prod_prod, ENNReal.toReal_mul]
+
+-- find this in library?  generalize?
+theorem Measure.ext_iff_singleton [Fintype S] [MeasurableSpace S] [MeasurableSingletonClass S]
+    {μ1 μ2 : Measure S} :
+    μ1 = μ2 ↔ ∀ x, μ1 {x} = μ2 {x} := by
+  classical
+  constructor
+  · rintro rfl
+    simp
+  · intro h
+    ext s
+    have hs : Set.Finite s := Set.toFinite s
+    rw [← hs.coe_toFinset, ← Finset.sum_measure_singleton μ1, ← Finset.sum_measure_singleton μ2]
+    simp_rw [h]
+
+theorem ext_iff_measureReal_singleton [Fintype S] [MeasurableSpace S] [MeasurableSingletonClass S]
+    {μ1 μ2 : Measure S} [IsFiniteMeasure μ1] [IsFiniteMeasure μ2] :
+    μ1 = μ2 ↔ ∀ x, μ1.real {x} = μ2.real {x} := by
+  rw [Measure.ext_iff_singleton]
+  congr! with x
+  have h1 : μ1 {x} ≠ ⊤ := by finiteness
+  have h2 : μ2 {x} ≠ ⊤ := by finiteness
+  rw [measureReal_def, measureReal_def, ENNReal.toReal_eq_toReal_iff]
+  simp [h1, h2]
 
 end MeasureTheory
 

--- a/PFR/entropy_basic.lean
+++ b/PFR/entropy_basic.lean
@@ -407,6 +407,39 @@ lemma entropy_pair_le_add [MeasurableSingletonClass S] [MeasurableSingletonClass
     H[⟨ X, Y ⟩ ; μ] ≤ H[X ; μ] + H[Y ; μ] :=
   sub_nonneg.1 $ mutualInformation_nonneg hX hY _
 
+/-- $I[X:Y]=0$ iff $X,Y$ are independent. -/
+lemma mutualInformation_eq_zero (hX : Measurable X) (hY : Measurable Y) {μ : Measure Ω}
+    [IsProbabilityMeasure μ] :
+    I[X : Y ; μ] = 0 ↔ IndepFun X Y μ := by
+  have : IsProbabilityMeasure (μ.map (⟨ X, Y ⟩)) :=
+    isProbabilityMeasure_map (hX.prod_mk hY).aemeasurable
+  simp_rw [mutualInformation_def, entropy_def]
+  have h_fst : μ.map X = (μ.map (⟨ X, Y ⟩)).map Prod.fst := by
+    rw [Measure.map_map measurable_fst (hX.prod_mk hY)]
+    congr
+  have h_snd : μ.map Y = (μ.map (⟨ X, Y ⟩)).map Prod.snd := by
+    rw [Measure.map_map measurable_snd (hX.prod_mk hY)]
+    congr
+  rw [h_fst, h_snd]
+  convert measureMutualInfo_eq_zero_iff (μ.map (⟨ X, Y ⟩))
+  rw [indepFun_iff_map_prod_eq_prod_map_map hX hY, ext_iff_measureReal_singleton]
+  congr! with p
+  convert measureReal_prod_prod (μ:=  μ.map X) (ν := μ.map Y) {p.1} {p.2}
+  · simp
+  · exact Measure.map_map measurable_fst (hX.prod_mk hY)
+  · exact Measure.map_map measurable_snd (hX.prod_mk hY)
+
+lemma entropy_pair_eq_add (hX : Measurable X) (hY : Measurable Y) {μ : Measure Ω}
+    [IsProbabilityMeasure μ] :
+    H[⟨ X, Y ⟩ ; μ] = H[X ; μ] + H[Y ; μ] ↔ IndepFun X Y μ := by
+  rw [eq_comm, ←sub_eq_zero]
+  exact mutualInformation_eq_zero hX hY
+
+lemma entropy_pair_eq_add' (hX : Measurable X) (hY : Measurable Y) {μ : Measure Ω}
+    [IsProbabilityMeasure μ] (h: IndepFun X Y μ) :
+    H[⟨ X, Y ⟩ ; μ] = H[X ; μ] + H[Y ; μ] :=
+  (entropy_pair_eq_add hX hY).2 h
+
 noncomputable
 def condMutualInformation (X : Ω → S) (Y : Ω → T) (Z : Ω → U) (μ : Measure Ω := by volume_tac) :
     ℝ := (μ.map Z)[fun z ↦ H[X | Z ← z ; μ] + H[Y | Z ← z ; μ] - H[⟨ X, Y ⟩ | Z ← z ; μ]]
@@ -502,16 +535,6 @@ lemma entropy_triple_add_entropy_le
   exact add_le_add le_rfl (entropy_submodular _ hX hY hZ)
 
 variable {μ : Measure Ω}
-
-lemma entropy_pair_eq_add' (h: IndepFun X Y μ) :
-H[⟨ X, Y ⟩ ; μ] = H[X ; μ] + H[Y ; μ] := by sorry
-
-lemma entropy_pair_eq_add : H[⟨ X, Y ⟩ ; μ] = H[X ; μ] + H[Y ; μ] ↔ IndepFun X Y μ :=
-  sorry -- the lemma `measureMutualInfo_eq_zero_iff` should be most of the way there
-
-/-- $I[X:Y]=0$ iff $X,Y$ are independent. -/
-lemma mutualInformation_eq_zero : I[X : Y ; μ] = 0 ↔ IndepFun X Y μ :=
-  sub_eq_zero.trans $ eq_comm.trans entropy_pair_eq_add
 
 /-- The assertion that X and Y are conditionally independent relative to Z.  -/
 def condIndepFun (X : Ω → S) (Y : Ω → T) (Z : Ω → U) (μ : Measure Ω) : Prop := sorry

--- a/PFR/ruzsa_distance.lean
+++ b/PFR/ruzsa_distance.lean
@@ -246,10 +246,10 @@ lemma Kaimonovich_Vershik {X Y Z : Ω → G} (h: iIndepFun ![hG, hG, hG] ![X,Y,Z
   convert entropy_triple_add_entropy_le _ hX hZ (Measurable.add' hX (Measurable.add' hY hZ)) using 2
   . sorry
   . rw [add_assoc]
-  . rw [<-entropy_pair_eq_add']
+  . refine entropy_pair_eq_add' hX (hY.add hZ) ?_ |>.symm.trans ?_
     . sorry
     sorry
-  rw [<-entropy_pair_eq_add']
+  refine entropy_pair_eq_add' hZ (hX.add hY) ?_ |>.symm.trans ?_
   . sorry
   sorry
 

--- a/blueprint/src/chapter/entropy.tex
+++ b/blueprint/src/chapter/entropy.tex
@@ -229,26 +229,27 @@ $$ \bbH[X, Y | Z ] = \bbH[Y | Z] + \bbH[X|Y, Z].$$
   Two random variables $X: \Omega \to S$ and $Y: \Omega \to T$ are independent if the law of $(X,Y)$ is the product of the law of $X$ and the law of $Y$.  Similarly for more than two variables.
 \end{definition}
 
-\begin{lemma}[Additivity of entropy]\label{add-entropy}
-  \uses{independent-def}
+\begin{lemma}[Vanishing of mutual information]
+  \label{vanish-entropy}
+  \uses{information-def, independent-def}
+  \lean{ProbabilityTheory.mutualInformation_eq_zero}
+  \leanok
+  If $X,Y$ are random variables, then $\bbI[X:Y] = 0$ if and only if $X,Y$ are independent.
+  \end{lemma}
+
+  \begin{proof} \uses{converse-jensen}\leanok
+    An application of the equality case of Jensen's inequality, Lemma \ref{converse-jensen}.
+  \end{proof}
+
+\begin{corollary}[Additivity of entropy]\label{add-entropy}
+  \uses{entropy-def}
   \lean{ProbabilityTheory.entropy_pair_eq_add}
   \leanok
   If $X,Y$ are random variables, then $\bbH[X,Y] = \bbH[X] + \bbH[Y]$ if and only if $X,Y$ are independent.
-\end{lemma}
-
-\begin{proof} \uses{chain-rule,conditional-entropy} Simplest proof for the ``if'' is to use Lemma \ref{chain-rule} and show that $\bbH[X|Y] = \bbH[X]$ by first showing that $\bbH[X|Y=y] = \bbH[X]$ whenever $P[Y=y]$ is non-zero.  ``only if'' direction will require some converse Jensen.
-\end{proof}
-
-
-\begin{corollary}[Vanishing of mutual information]
-\label{vanish-entropy}
-\uses{information-def}
-\lean{ProbabilityTheory.mutualInformation_eq_zero}
-\leanok
-If $X,Y$ are random variables, then $\bbI[X:Y] = 0$ if and only if $X,Y$ are independent.
 \end{corollary}
 
-\begin{proof} \uses{add-entropy}\leanok Immediate from Lemma \ref{add-entropy} and Definition \ref{information-def}.
+\begin{proof} \uses{vanish-entropy}\leanok
+  Direct from Lemma \ref{vanish-entropy}.
 \end{proof}
 
 \begin{definition}[Conditional mutual information]


### PR DESCRIPTION
I include an adjustment of the blueprint to account for a reversed dependence:  I prove this from the characterization of when mutual information is zero, rather than vice versa.  Might be worth double-checking my blueprint additions since I didn't have a way of checking the build locally.

I added assumptions `(hX : Measurable X) (hY : Measurable Y) [IsProbabilityMeasure μ]`.  Expected?