### PR TITLE
Mostly reduced continuity proof of tau to that of d.

### DIFF
--- a/PFR/ruzsa_distance.lean
+++ b/PFR/ruzsa_distance.lean
@@ -3,6 +3,7 @@ import Mathlib.Probability.ConditionalProbability
 import Mathlib.Probability.IdentDistrib
 import PFR.Entropy.Group
 import PFR.entropy_basic
+import PFR.ForMathlib.CompactProb
 
 /-!
 # Ruzsa distance
@@ -178,6 +179,34 @@ def rdist (X : Ω → G) (Y : Ω' → G) (μ : Measure Ω := by volume_tac)
 notation3:max "d[" X " ; " μ " # " Y " ; " μ' "]" => rdist X Y μ μ'
 
 notation3:max "d[" X " # " Y "]" => rdist X Y MeasureTheory.MeasureSpace.volume MeasureTheory.MeasureSpace.volume
+
+lemma continuous_rdist_restrict_probabilityMeasure
+    [TopologicalSpace G] [DiscreteTopology G] [BorelSpace G] :
+    Continuous
+      (fun (μ : ProbabilityMeasure G × ProbabilityMeasure G) ↦
+        d[ id ; μ.1.toMeasure # id ; μ.2.toMeasure ]) :=
+  sorry
+
+lemma continuous_rdist_restrict_probabilityMeasure₁
+    [TopologicalSpace G] [DiscreteTopology G] [BorelSpace G]
+    (X : Ω → G) (P : Measure Ω := by volume_tac) [IsProbabilityMeasure P] :
+    Continuous
+      (fun (μ : ProbabilityMeasure G) ↦ d[ id ; P.map X # id ; μ.toMeasure ]) := by
+  have obs : IsProbabilityMeasure (P.map X) := by
+    sorry -- Requires measurability assumptions on X ?
+  let ι : ProbabilityMeasure G → ProbabilityMeasure G × ProbabilityMeasure G :=
+      fun ν ↦ ⟨⟨P.map X, obs⟩, ν⟩
+  have ι_cont : Continuous ι := by exact Continuous.Prod.mk _
+  convert continuous_rdist_restrict_probabilityMeasure.comp ι_cont
+
+lemma continuous_rdist_restrict_probabilityMeasure₁'
+    [TopologicalSpace G] [DiscreteTopology G] [BorelSpace G]
+    (X : Ω → G) (P : Measure Ω := by volume_tac) [IsProbabilityMeasure P] :
+    Continuous
+      (fun (μ : ProbabilityMeasure G) ↦ d[ X ; P # id ; μ.toMeasure ]) := by
+  convert @continuous_rdist_restrict_probabilityMeasure₁ Ω G _ _ _ _ _ _ _ X P _
+  -- Kalle: I hope this is true (by definition)...
+  sorry
 
 lemma rdist_def (X : Ω → G) (Y : Ω' → G) (μ : Measure Ω) (μ' : Measure Ω') :
     d[ X ; μ # Y ; μ' ]

--- a/PFR/tau_functional.lean
+++ b/PFR/tau_functional.lean
@@ -64,9 +64,16 @@ lemma continuous_tau_restrict_probabilityMeasure
     [TopologicalSpace G] [DiscreteTopology G] [BorelSpace G] :
     Continuous
       (fun (μ : ProbabilityMeasure G × ProbabilityMeasure G) ↦ τ[id ; μ.1 # id ; μ.2 | p]) := by
-  -- Need phrasing of Ruzsa distance in terms of measures, so the defining terms make sense,
-  -- and continuity (in the topology of `ProbabilityMeasure`) of each makes sense.
-  sorry
+  have obs₁ : Continuous
+      (fun (μ : ProbabilityMeasure G × ProbabilityMeasure G) ↦ d[p.X₀₂ ; ℙ # id ; μ.2]) :=
+    Continuous.comp (continuous_rdist_restrict_probabilityMeasure₁' _ _) continuous_snd
+  have obs₂ : Continuous
+      (fun (μ : ProbabilityMeasure G × ProbabilityMeasure G) ↦ d[id ; μ.1.toMeasure # id ; μ.2]) :=
+    continuous_rdist_restrict_probabilityMeasure
+  have obs₃ : Continuous
+      (fun (μ : ProbabilityMeasure G × ProbabilityMeasure G) ↦ d[p.X₀₁ ; ℙ # id ; μ.1]) :=
+    Continuous.comp (continuous_rdist_restrict_probabilityMeasure₁' _ _) continuous_fst
+  continuity
 
 /-- If $X'_1, X'_2$ are copies of $X_1,X_2$, then $\tau[X'_1;X'_2] = \tau[X_1;X_2]$. --/
 lemma ProbabilityTheory.IdentDistrib.tau_eq [MeasurableSpace Ω₁] [MeasurableSpace Ω₂]


### PR DESCRIPTION
The remaining thing for existence of tau minimizer is continuity statements, which should be gradually reduced to the continuity of entropy. Here a reduction of continuity of tau to the continuity of Rusza distance is added (maybe some measurability assumptions need to be added later, but I hope I did not otherwise reduce it to something unprovable).