### PR TITLE
feat: finish part 1 of Lemma 3.23

### DIFF
--- a/PFR.lean
+++ b/PFR.lean
@@ -11,6 +11,7 @@ import PFR.fibring
 import PFR.first_estimate
 import PFR.ForMathlib.Finiteness
 import PFR.ForMathlib.Finiteness.Attr
+import PFR.ForMathlib.Independence
 import PFR.ForMathlib.Jensen
 import PFR.ForMathlib.Positivity
 import PFR.HundredPercent

--- a/PFR/ForMathlib/Independence.lean
+++ b/PFR/ForMathlib/Independence.lean
@@ -1,0 +1,92 @@
+import Mathlib.Probability.Independence.Basic
+import Mathlib.Probability.IdentDistrib
+
+open MeasureTheory ProbabilityTheory Function Set
+
+lemma Function.update_of_eq {β : Sort*} {a a' : α} (h : a = a') (v : β) (f : α → β) :
+  update f a v a' = v := by simp [h]
+
+namespace ProbabilityTheory
+
+section IdentDistrib
+variable {Ω Ω' α ι β β' : Type*} {mΩ : MeasurableSpace Ω} {mΩ' : MeasurableSpace Ω'}
+  {mβ : MeasurableSpace β}
+  {μ : Measure Ω} {ν : Measure Ω'}
+  {f g : Ω → β} {f' g' : Ω' → β}
+
+-- todo: weaken mathlib version of this lemma
+theorem indepFun_iff_map_prod_eq_prod_map_map' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
+    {f : Ω → β} {g : Ω → β'}
+    [IsFiniteMeasure μ] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
+    IndepFun f g μ ↔ μ.map (fun ω ↦ (f ω, g ω)) = (μ.map f).prod (μ.map g) := by
+  rw [indepFun_iff_measure_inter_preimage_eq_mul]
+  have h₀ {s : Set β} {t : Set β'} (hs : MeasurableSet s) (ht : MeasurableSet t) :
+      μ (f ⁻¹' s) * μ (g ⁻¹' t) = μ.map f s * μ.map g t ∧
+      μ (f ⁻¹' s ∩ g ⁻¹' t) = μ.map (fun ω ↦ (f ω, g ω)) (s ×ˢ t) :=
+    ⟨by rw [Measure.map_apply_of_aemeasurable hf hs, Measure.map_apply_of_aemeasurable hg ht],
+      (Measure.map_apply_of_aemeasurable (hf.prod_mk hg) (hs.prod ht)).symm⟩
+  constructor
+  · refine fun h ↦ (Measure.prod_eq fun s t hs ht ↦ ?_).symm
+    rw [← (h₀ hs ht).1, ← (h₀ hs ht).2, h s t hs ht]
+  · intro h s t hs ht
+    rw [(h₀ hs ht).1, (h₀ hs ht).2, h, Measure.prod_prod]
+
+
+variable [IsFiniteMeasure μ] [IsFiniteMeasure ν] in
+theorem IdentDistrib.prod_mk
+    (hff' : IdentDistrib f f' μ ν) (hgg' : IdentDistrib g g' μ ν)
+    (h : IndepFun f g μ) (h' : IndepFun f' g' ν) :
+    IdentDistrib (fun x ↦ (f x, g x)) (fun x ↦ (f' x, g' x)) μ ν where
+  aemeasurable_fst := hff'.aemeasurable_fst.prod_mk hgg'.aemeasurable_fst
+  aemeasurable_snd := hff'.aemeasurable_snd.prod_mk hgg'.aemeasurable_snd
+  map_eq := by
+    rw [indepFun_iff_map_prod_eq_prod_map_map' hff'.aemeasurable_fst hgg'.aemeasurable_fst] at h
+    rw [indepFun_iff_map_prod_eq_prod_map_map' hff'.aemeasurable_snd hgg'.aemeasurable_snd] at h'
+    rw [h, h', hff'.map_eq, hgg'.map_eq]
+
+variable [Mul β] [MeasurableMul₂ β] [IsFiniteMeasure μ] [IsFiniteMeasure ν] in
+@[to_additive]
+theorem IdentDistrib.mul
+    (hff' : IdentDistrib f f' μ ν) (hgg' : IdentDistrib g g' μ ν)
+    (h : IndepFun f g μ) (h' : IndepFun f' g' ν) :
+    IdentDistrib (f * g) (f' * g') μ ν :=
+  hff'.prod_mk hgg' h h' |>.comp_of_aemeasurable measurable_mul.aemeasurable
+
+end IdentDistrib
+
+section iIndepFun
+
+variable {Ω ι ι' : Type*} [MeasurableSpace Ω] {α β : ι → Type*}
+  {n : (i : ι) → MeasurableSpace (α i)}
+  {m : (i : ι) → MeasurableSpace (β i)} {f : (i : ι) → Ω → α i}
+  {μ : Measure Ω}
+
+variable (g : ι' ≃ ι)
+lemma iIndepFun.reindex (h : iIndepFun (n ∘' g) (f ∘' g) μ) :
+    iIndepFun n f μ := by
+  rw [iIndepFun_iff] at h ⊢
+  intro t s hs
+  have : ⋂ i, ⋂ (_ : g i ∈ t), s (g i) = ⋂ i ∈ t, s i
+  · ext x; simp [g.forall_congr_left']
+  specialize h (t.map g.symm.toEmbedding) (f' := s ∘ g)
+  simp [this, g.forall_congr_left'] at h
+  apply h
+  convert hs <;> simp
+
+lemma iIndepFun.comp (h : iIndepFun n f μ) (g : (i : ι) → α i → β i) (hg : ∀ i, Measurable (g i)) :
+    iIndepFun m (fun i ↦ g i ∘ f i) μ := by sorry
+
+variable (i : ι) [Neg (α i)] [MeasurableNeg (α i)] [DecidableEq ι] in
+lemma iIndepFun.neg (h : iIndepFun n f μ) : iIndepFun n (update f i (-f i)) μ := by
+  convert h.comp (update (fun _ ↦ id) i (-·)) _ with j
+  · by_cases hj : j = i
+    · subst hj; ext x; simp
+    · simp [hj]
+  intro j
+  by_cases hj : j = i
+  · subst hj; simp [measurable_neg]
+  · simp [hj, measurable_id]
+
+end iIndepFun
+
+end ProbabilityTheory

--- a/PFR/ForMathlib/Independence.lean
+++ b/PFR/ForMathlib/Independence.lean
@@ -14,7 +14,7 @@ variable {Ω Ω' α ι β β' : Type*} {mΩ : MeasurableSpace Ω} {mΩ' : Measur
   {μ : Measure Ω} {ν : Measure Ω'}
   {f g : Ω → β} {f' g' : Ω' → β}
 
--- todo: weaken mathlib version of this lemma
+-- todo: replace mathlib version with this lemma (this lemma uses `AEMeasurable`)
 theorem indepFun_iff_map_prod_eq_prod_map_map' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {f : Ω → β} {g : Ω → β'}
     [IsFiniteMeasure μ] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
@@ -74,7 +74,12 @@ lemma iIndepFun.reindex (h : iIndepFun (n ∘' g) (f ∘' g) μ) :
   convert hs <;> simp
 
 lemma iIndepFun.comp (h : iIndepFun n f μ) (g : (i : ι) → α i → β i) (hg : ∀ i, Measurable (g i)) :
-    iIndepFun m (fun i ↦ g i ∘ f i) μ := by sorry
+    iIndepFun m (fun i ↦ g i ∘ f i) μ := by
+  rw [iIndepFun_iff] at h ⊢
+  refine fun t s hs ↦ h t (fun i hi ↦ ?_)
+  simp_rw [measurable_iff_comap_le] at hg
+  simp_rw [← MeasurableSpace.comap_comp] at hs
+  exact MeasurableSpace.comap_mono (hg i) (s i) (hs i hi)
 
 variable (i : ι) [Neg (α i)] [MeasurableNeg (α i)] [DecidableEq ι] in
 lemma iIndepFun.neg (h : iIndepFun n f μ) : iIndepFun n (update f i (-f i)) μ := by

--- a/PFR/entropy_basic.lean
+++ b/PFR/entropy_basic.lean
@@ -683,7 +683,8 @@ def Triple_equiv_fin3 : Triple ≃ Fin 3 where
   left_inv x := by cases x <;> rfl
   right_inv i := by fin_cases i <;> rfl
 
-/-- A version with only 1 `S`. -/
+/-- A version with exactly 3 random variables that have the same codomain.
+It's unfortunately incredibly painful to prove this from the general case. -/
 lemma independent_copies3_nondep {S : Type u}
     [mS : MeasurableSpace S]
     {Ω₁ Ω₂ Ω₃ : Type v}

--- a/PFR/entropy_basic.lean
+++ b/PFR/entropy_basic.lean
@@ -669,9 +669,6 @@ lemma independent_copies' {I: Type*} [Fintype I] {S : I → Type u}
     (iIndepFun mS X' μA) ∧
     ∀ i : I, Measurable (X' i) ∧ IdentDistrib (X' i) (X i) μA (μ i) := by sorry
 
-/- This is neither `Fin.elim0` nor `Fin.elim0'` -/
-def Fin.rec0 {α : Fin 0 → Sort*} (i : Fin 0) : α i := absurd i.2 (Nat.not_lt_zero _)
-
 inductive Triple := | first | second | third deriving DecidableEq
 instance Triple.fintype : Fintype Triple where
   elems := {first, second, third}

--- a/PFR/entropy_basic.lean
+++ b/PFR/entropy_basic.lean
@@ -4,6 +4,7 @@ import Mathlib.Probability.Independence.Basic
 import Mathlib.Probability.Notation
 import Mathlib.Probability.IdentDistrib
 import PFR.Entropy.KernelMutualInformation
+import PFR.ForMathlib.Independence
 
 /-!
 # Entropy and conditional entropy
@@ -676,32 +677,11 @@ instance Triple.fintype : Fintype Triple where
   elems := {first, second, third}
   complete := by intro i; induction i <;> decide
 
-/-- A version with exactly 3 random variables. -/
-/- Note (Floris): Currently we assume that the `Ωᵢ` live in the same universe.
-If that is annoying, we can prove the general case with `ULift`.
-However, then even the statement will require ULifts, so it will not be nicer. -/
-lemma independent_copies3 {S₁ S₂ S₃ : Type u}
-    [mS₁ : MeasurableSpace S₁] [mS₂ : MeasurableSpace S₂] [mS₃ : MeasurableSpace S₃]
-    {Ω₁ Ω₂ Ω₃ : Type v}
-    [mΩ₁ : MeasurableSpace Ω₁] [mΩ₂ : MeasurableSpace Ω₂] [mΩ₃ : MeasurableSpace Ω₃]
-    {X₁ : Ω₁ → S₁} {X₂ : Ω₂ → S₂} {X₃ : Ω₃ → S₃}
-    (hX₁ : Measurable X₁) (hX₂ : Measurable X₂) (hX₃ : Measurable X₃)
-    (μ₁ : Measure Ω₁) (μ₂ : Measure Ω₂) (μ₃ : Measure Ω₃) :
-    ∃ (A : Type _) (mA : MeasurableSpace A) (μA : Measure A)
-      (X₁' : A → S₁) (X₂' : A → S₂) (X₃' : A → S₃),
-    IsProbabilityMeasure μA ∧
-    (iIndepFun (β := ![S₁, S₂, S₃])
-      (Fin.cons mS₁ (Fin.cons mS₂ (Fin.cons mS₃ Fin.rec0)))
-      (Fin.cons X₁' (Fin.cons X₂' (Fin.cons X₃' Fin.rec0))) μA) ∧
-      Measurable X₁ ∧ Measurable X₂ ∧ Measurable X₃ ∧
-      IdentDistrib X₁' X₁ μA μ₁ ∧ IdentDistrib X₂' X₂ μA μ₂ ∧ IdentDistrib X₃' X₃ μA μ₃ := by sorry
-  -- this is very painful!
-  -- let Ω : Fin 3 → Type v := ![Ω₁, Ω₂, Ω₃]
-  -- let mΩ : (i : Fin 3) → MeasurableSpace (Ω i) := by intro i; fin_cases i <;> dsimp
-  -- let S : Fin 3 → Type u := ![S₁, S₂, S₃]
-  -- let X : (i : Fin 3) → Ω i → S i := Fin.cons X₁ (Fin.cons X₂ (Fin.cons X₃ Fin.rec0))
-  -- have : ∀ (i : Fin 3), Measurable (X i) := by intro i; fin_cases i <;> simp [hX₁, hX₂, hX₃]
-  -- obtain ⟨A, mA, μA, X'⟩ := independent_copies'
+def Triple_equiv_fin3 : Triple ≃ Fin 3 where
+  toFun x := match x with | .first => 0 | .second => 1 | .third => 2
+  invFun := ![.first, .second, .third]
+  left_inv x := by cases x <;> rfl
+  right_inv i := by fin_cases i <;> rfl
 
 /-- A version with only 1 `S`. -/
 lemma independent_copies3_nondep {S : Type u}
@@ -727,8 +707,8 @@ lemma independent_copies3_nondep {S : Type u}
   refine ⟨A, mA, μA, X' .first, X' .second, X' .third, hμ, ?_,
     (hX' .first).1, (hX' .second).1, (hX' .third).1,
     (hX' .first).2, (hX' .second).2, (hX' .third).2⟩
-  sorry -- we need `iIndepFun.reindex`.
-
+  apply iIndepFun.reindex Triple_equiv_fin3 _
+  convert hi using 1; ext i; cases i <;> rfl
 
 /-- For $X,Y$ random variables, there is a canonical choice of conditionally independent trials $X_1,X_2,Y'$.-/
 lemma condIndependent_copies (X : Ω → S) (Y : Ω → T) (μ: Measure Ω): ∃ ν : Measure (S × S × T), ∃ X_1 X_2 : S × S × T → S, ∃ Y' : S × S × T → T, IsProbabilityMeasure ν ∧ Measurable X_1 ∧ Measurable X_2 ∧ Measurable Y' ∧ (condIndepFun X_1 X_2 Y' ν) ∧ IdentDistrib (⟨ X_1, Y' ⟩) (⟨ X, Y ⟩) ν μ ∧ IdentDistrib (⟨ X_2, Y' ⟩) (⟨ X, Y ⟩) ν μ := by sorry

--- a/PFR/f2_vec.lean
+++ b/PFR/f2_vec.lean
@@ -22,19 +22,24 @@ class ElementaryAddCommGroup (G : Type*) [AddCommGroup G] (p : outParam ℕ) whe
 
 variable [AddCommGroup G] [elem : ElementaryAddCommGroup G 2]
 
-lemma sum_eq_diff ( x y : G ) : x + y = x - y := by
-  rw [sub_eq_add_neg, add_right_inj, ← add_eq_zero_iff_eq_neg]
+@[simp]
+lemma sub_eq_add ( x y : G ) : x - y = x + y := by
+  rw [sub_eq_add_neg, add_right_inj, ← add_eq_zero_iff_neg_eq]
   by_cases h : y = 0
   · simp only [h, add_zero]
   · simpa only [elem.orderOf_of_ne h, two_nsmul] using (addOrderOf_nsmul_eq_zero y)
 
-lemma sum_eq_neg ( x : G ) : x + x = 0 := by
-  rw [sum_eq_diff x x]
-  simp only [sub_self]
+@[simp]
+lemma pi.sub_eq_add {ι} ( x y : ι → G ) : x - y = x + y := by ext; simp
+
+@[simp]
+lemma add_self ( x : G ) : x + x = 0 := by
+  rw [← sub_eq_add]
+  simp
 
 lemma sum_add_sum_eq_sum ( x y z : G ) : (x + y) + (y + z) = x + z := by
-  rw [sum_eq_diff x y]
+  rw [← sub_eq_add x y]
   abel
 
 lemma sum_add_sum_add_sum_eq_zero ( x y z : G ) : (x + y) + (y + z) + (z + x) = 0 := by
-  rw [sum_add_sum_eq_sum, add_comm x z, sum_eq_neg]
+  rw [sum_add_sum_eq_sum, add_comm x z, add_self]

--- a/PFR/ruzsa_distance.lean
+++ b/PFR/ruzsa_distance.lean
@@ -4,7 +4,6 @@ import Mathlib.Probability.IdentDistrib
 import PFR.Entropy.Group
 import PFR.entropy_basic
 import PFR.ForMathlib.FiniteMeasureComponent
-import PFR.ForMathlib.Independence
 import PFR.f2_vec
 
 

--- a/blueprint/src/chapter/distance.tex
+++ b/blueprint/src/chapter/distance.tex
@@ -292,7 +292,7 @@ Here, in the middle step we used Lemma \ref{cond-reduce}, and in the last step w
   \begin{proof}
     \uses{ruz-copy, ruz-lean, independent-exist, kv, ruz-indep, relabeled-entropy, cond-dist-fact}
   We first prove~\eqref{lem51-a}. We may assume (taking an independent copy, using Lemma \ref{independent-exist} and Lemma \ref{ruz-copy}, \ref{ruz-indep}) that $X$ is independent of $Y, Z$. Then we have
-  \begin{align*}  d[X;Y+Z] & - d[X;Y] \\ & = \bbH[X + Y + Z] - \bbH[X+Y] - \tfrac{1}{2}H[Y + Z] + \tfrac{1}{2} \bbH[Y].\end{align*}
+  \begin{align*}  d[X;Y+Z] & - d[X;Y] \\ & = \bbH[X + Y + Z] - \bbH[X+Y] - \tfrac{1}{2}\bbH[Y + Z] + \tfrac{1}{2} \bbH[Y].\end{align*}
   Combining this with Lemma \ref{kv} gives the required bound. The second form of the result is immediate Lemma \ref{ruz-indep}.
 
   Turning to~\eqref{ruzsa-3}, we have from Definition \ref{information-def} and Lemma \ref{relabeled-entropy}


### PR DESCRIPTION
* There are some preliminary lemmas about independent variables in `ForMathlib/Independence`. Maybe these lemmas already exist, but I couldn't find them
* It was incredibly painful to instantiate lemma `independent_copies'` to the case with 3 explicit random variables. I did this only if the variables have the same codomain, otherwise it would be even more painful.
* I only proved `condDist_diff_le` for `Ω` and `Ω'` in the same universe level. We could remove this constraint, but I don't think it will cause many problems (except that we maybe have to write some universe levels explicitly)
* For `condDist_diff_le'` I needed `H[Y + Z; μ'] = H[Y - Z; μ']`, so I assumed `ElementaryAddCommGroup G 2`. We should probably mention in the blueprint that this lemma only holds for elementary 2-groups? Maybe by choosing signs more carefully we get the result also without that condition.
* Also rename/reformulate some lemmas in `f2_vec`