### PR TITLE
Lint some files

### DIFF
--- a/PFR/Entropy/Disintegration.lean
+++ b/PFR/Entropy/Disintegration.lean
@@ -151,7 +151,7 @@ lemma condKernel_prod_ae_eq (κ : kernel T S) [IsFiniteKernel κ]
     (η : kernel T U) [IsMarkovKernel η] [IsFiniteMeasure μ] :
     condKernel (κ ×ₖ η) =ᵐ[μ ⊗ₘ κ] prodMkRight η S := condKernel_compProd_ae_eq _ _
 
-instance (κ : kernel T (S × U)) [IsFiniteKernel κ] : IsFiniteKernel (condKernel κ) := by
+instance (κ : kernel T (S × U)) : IsFiniteKernel (condKernel κ) := by
   rw [condKernel]; infer_instance
 
 instance (κ : kernel T (S × U)) [IsMarkovKernel κ] : IsMarkovKernel (condKernel κ) := by
@@ -199,7 +199,7 @@ lemma disintegration (κ : kernel T (S × U)) [IsFiniteKernel κ] :
   · refine fun _ ↦ (measurable_fst (measurableSet_singleton _)).inter ?_
     exact measurable_prod_mk_left.comp measurable_snd hs
 
-lemma condKernel_map_prod_mk_left {V : Type*} [Fintype V] [Nonempty V] [MeasurableSpace V]
+lemma condKernel_map_prod_mk_left {V : Type*} [Nonempty V] [MeasurableSpace V]
     [MeasurableSingletonClass V]
     (κ : kernel T (S × U)) [IsMarkovKernel κ] (μ : Measure T) [IsFiniteMeasure μ]
     (f : (S × U) → V) :

--- a/PFR/Entropy/Measure.lean
+++ b/PFR/Entropy/Measure.lean
@@ -173,7 +173,7 @@ lemma measureEntropy_def' (μ : Measure S) :
   simp only [Measure.smul_toOuterMeasure, OuterMeasure.coe_smul, Pi.smul_apply, smul_eq_mul,
     ENNReal.toReal_mul, measureReal_def, ENNReal.toReal_inv]
 
-notation:100 "Hm[" μ "]" => measureEntropy μ
+@[inherit_doc measureEntropy] notation:100 "Hm[" μ "]" => measureEntropy μ
 
 @[simp]
 lemma measureEntropy_zero : Hm[(0 : Measure S)] = 0 := by

--- a/PFR/entropy_basic.lean
+++ b/PFR/entropy_basic.lean
@@ -39,6 +39,7 @@ open Real MeasureTheory
 open scoped ENNReal NNReal Topology ProbabilityTheory BigOperators
 
 /-- Give all finite types the discrete sigma-algebra by default. -/
+@[nolint unusedArguments]
 instance Fintype.instMeasurableSpace [Fintype S] : MeasurableSpace S := ⊤
 
 namespace ProbabilityTheory
@@ -57,10 +58,10 @@ section entropy
 noncomputable
 def entropy (X : Ω → S) (μ : Measure Ω := by volume_tac) := Hm[μ.map X]
 
-notation3:max "H[" X "; " μ "]" => entropy X μ
-notation3:max "H[" X "]" => entropy X volume
-notation3:max "H[" X "|" Y "←" y "; " μ "]" => entropy X (μ[|Y ⁻¹' {y}])
-notation3:max "H[" X "|" Y "←" y "]" => entropy X (ℙ[|Y ⁻¹' {y}])
+@[inherit_doc entropy] notation3:max "H[" X "; " μ "]" => entropy X μ
+@[inherit_doc entropy] notation3:max "H[" X "]" => entropy X volume
+@[inherit_doc entropy] notation3:max "H[" X "|" Y "←" y "; " μ "]" => entropy X (μ[|Y ⁻¹' {y}])
+@[inherit_doc entropy] notation3:max "H[" X "|" Y "←" y "]" => entropy X (ℙ[|Y ⁻¹' {y}])
 
 /-- Entropy of a random variable agrees with entropy of its distribution. -/
 lemma entropy_def (X : Ω → S) (μ : Measure Ω) : entropy X μ = Hm[μ.map X] := rfl
@@ -152,9 +153,10 @@ lemma entropy_eq_log_card {X : Ω → S} (hX : Measurable X) (μ : Measure Ω) (
 $P[X=s] \geq \exp(-H[X])$. -/
 lemma prob_ge_exp_neg_entropy (X : Ω → S) (μ : Measure Ω) : ∃ s : S, μ.map X {s} ≥ (μ Set.univ) * (rexp (- entropy X μ )).toNNReal := by sorry
 
+/-- The pair of two random variables -/
 abbrev prod {Ω S T : Type*} ( X : Ω → S ) ( Y : Ω → T ) (ω : Ω) : S × T := (X ω, Y ω)
 
-notation3:100 "⟨" X ", " Y "⟩" => prod X Y
+@[inherit_doc prod] notation3:100 "⟨" X ", " Y "⟩" => prod X Y
 
 /-- $H[X,Y] = H[Y,X]$. -/
 lemma entropy_comm
@@ -187,8 +189,8 @@ def condEntropy (X : Ω → S) (Y : Ω → T) (μ : Measure Ω := by volume_tac)
 lemma condEntropy_def (X : Ω → S) (Y : Ω → T) (μ : Measure Ω) :
     condEntropy X Y μ = (μ.map Y)[fun y ↦ H[X | Y ← y ; μ]] := rfl
 
-notation3:max "H[" X "|" Y "; " μ "]" => condEntropy X Y μ
-notation3:max "H[" X "|" Y "]" => condEntropy X Y volume
+@[inherit_doc condEntropy] notation3:max "H[" X "|" Y "; " μ "]" => condEntropy X Y μ
+@[inherit_doc condEntropy] notation3:max "H[" X "|" Y "]" => condEntropy X Y volume
 
 /-- Conditional entropy of a random variable is equal to the entropy of its conditional kernel. -/
 lemma condEntropy_eq_kernel_entropy
@@ -223,7 +225,6 @@ lemma condEntropy_two_eq_kernel_entropy
     H[X | ⟨ Y, Z ⟩ ; μ] =
       Hk[kernel.condKernel (condEntropyKernel (fun a ↦ (Y a, X a)) Z μ) ,
         Measure.map Z μ ⊗ₘ kernel.fst (condEntropyKernel (fun a ↦ (Y a, X a)) Z μ)] := by
-  have : IsProbabilityMeasure (μ.map Z) := isProbabilityMeasure_map hZ.aemeasurable
   have := isMarkovKernel_condEntropyKernel (hY.prod_mk hX) hZ μ
   have := isMarkovKernel_condEntropyKernel hY hZ μ
   rw [Measure.compProd_congr (condEntropyKernel_fst_ae_eq hY hX hZ μ),
@@ -419,8 +420,8 @@ def mutualInformation (X : Ω → S) (Y : Ω → T) (μ : Measure Ω := by volum
 lemma mutualInformation_def (X : Ω → S) (Y : Ω → T) (μ : Measure Ω) :
   mutualInformation X Y μ = H[X ; μ] + H[Y ; μ] - H[⟨ X, Y ⟩ ; μ] := rfl
 
-notation3:max "I[" X ":" Y ";" μ "]" => mutualInformation X Y μ
-notation3:max "I[" X ":" Y "]" => mutualInformation X Y volume
+@[inherit_doc mutualInformation] notation3:max "I[" X ":" Y ";" μ "]" => mutualInformation X Y μ
+@[inherit_doc mutualInformation] notation3:max "I[" X ":" Y "]" => mutualInformation X Y volume
 
 /-- $I[X:Y] = H[X] - H[X|Y]$. -/
 lemma mutualInformation_eq_entropy_sub_condEntropy [MeasurableSingletonClass S]
@@ -509,8 +510,10 @@ lemma condMutualInformation_def (X : Ω → S) (Y : Ω → T) (Z : Ω → U) (μ
     condMutualInformation X Y Z μ = (μ.map Z)[fun z ↦
       H[X | Z ← z ; μ] + H[Y | Z ← z ; μ] - H[⟨ X, Y ⟩ | Z ← z ; μ]] := rfl
 
+@[inherit_doc condMutualInformation]
 notation3:max "I[" X ":" Y "|" Z ";" μ "]" => condMutualInformation X Y Z μ
-notation3:max "I[" X ":" Y "|" Z "]" => condMutualInformation X Y Z MeasureTheory.MeasureSpace.volume
+@[inherit_doc condMutualInformation]
+notation3:max "I[" X ":" Y "|" Z "]" => condMutualInformation X Y Z volume
 
 /-- The conditional mutual information agrees with the information of the conditional kernel.
 -/

--- a/PFR/ruzsa_distance.lean
+++ b/PFR/ruzsa_distance.lean
@@ -175,10 +175,10 @@ def rdist (X : Ω → G) (Y : Ω' → G) (μ : Measure Ω := by volume_tac)
     (μ' : Measure Ω' := by volume_tac) : ℝ :=
   H[fun x ↦ x.1 - x.2 ; (μ.map X).prod (μ'.map Y)] - H[X ; μ]/2 - H[Y ; μ']/2
 
-/-- Needed a new separator here, chose `#` arbitrarily, but am open to other suggestions -/
-notation3:max "d[" X " ; " μ " # " Y " ; " μ' "]" => rdist X Y μ μ'
+/- Needed a new separator here, chose `#` arbitrarily, but am open to other suggestions -/
+@[inherit_doc rdist] notation3:max "d[" X " ; " μ " # " Y " ; " μ' "]" => rdist X Y μ μ'
 
-notation3:max "d[" X " # " Y "]" => rdist X Y MeasureTheory.MeasureSpace.volume MeasureTheory.MeasureSpace.volume
+@[inherit_doc rdist] notation3:max "d[" X " # " Y "]" => rdist X Y volume volume
 
 lemma rdist_def (X : Ω → G) (Y : Ω' → G) (μ : Measure Ω) (μ' : Measure Ω') :
     d[ X ; μ # Y ; μ' ]
@@ -347,14 +347,17 @@ lemma rdist_triangle (X : Ω → G) (Y : Ω' → G) (Z : Ω'' → G) :
 /-- The conditional Ruzsa distance `d[X|Z ; Y|W]`. -/
 def cond_rdist [MeasurableSpace S] [MeasurableSpace T] (X : Ω → G) (Z : Ω → S) (Y : Ω' → G) (W : Ω' → T) (μ : Measure Ω := by volume_tac) (μ' : Measure Ω' := by volume_tac) : ℝ := sorry
 
+@[inherit_doc cond_rdist]
 notation3:max "d[" X " | " Z " ; " μ " # " Y " | " W " ; " μ'"]" => cond_rdist X Z Y W μ μ'
 
 /-- The conditional Ruzsa distance `d[X ; Y|W]`. -/
 def cond_rdist' [MeasurableSpace T] (X : Ω → G) (Y : Ω' → G) (W : Ω' → T)
     (μ : Measure Ω := by volume_tac) (μ' : Measure Ω' := by volume_tac) : ℝ := sorry
 
+@[inherit_doc cond_rdist']
 notation3:max "d[" X " ; " μ " # " Y " | " W " ; " μ' "]" => cond_rdist' X Y W μ μ'
-notation3:max "d[" X " # " Y " | " W "]" => cond_rdist' X Y W MeasureTheory.MeasureSpace.volume MeasureTheory.MeasureSpace.volume
+@[inherit_doc cond_rdist']
+notation3:max "d[" X " # " Y " | " W "]" => cond_rdist' X Y W volume volume
 
 /-- If $(X,Z)$ and $(Y,W)$ are independent, then
 $$  d[X  | Z ; Y | W] = H[X'-Y'|Z', W'] - H[X'|Z']/2 - H[Y'|W']/2$$


### PR DESCRIPTION
* Remove a few unused assumptions in already proven lemmas
* Give notation the documentation of what it's defining (i.e. mousing over `H[` will now show the documentation for `entropy`)