### PR TITLE
Prove entropic_PFR_conjecture

### DIFF
--- a/PFR/entropy_pfr.lean
+++ b/PFR/entropy_pfr.lean
@@ -2,6 +2,7 @@ import PFR.entropy_basic
 import PFR.f2_vec
 import PFR.ruzsa_distance
 import PFR.tau_functional
+import PFR.HundredPercent
 
 /-!
 # Entropic version of polynomial Freiman-Ruzsa conjecture
@@ -19,7 +20,7 @@ universe u
 
 variable (Ω₀₁ Ω₀₂ : Type*) [MeasureSpace Ω₀₁] [MeasureSpace Ω₀₂]
 
-variable {Ω Ω' : Type*} [mΩ : MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
+variable {Ω Ω' : Type*} [mΩ : MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)] [IsProbabilityMeasure (ℙ : Measure Ω₀₁)] [IsProbabilityMeasure (ℙ : Measure Ω₀₂)]
 
 variable {G : Type u} [AddCommGroup G] [ElementaryAddCommGroup G 2] [Fintype G]
 
@@ -32,9 +33,32 @@ theorem tau_strictly_decreases (h : tau_minimizes p X₁ X₂) : d[X₁ # X₂] 
 /-- `entropic_PFR_conjecture`: For two $G$-valued random variables $X^0_1, X^0_2$, there is some subgroup $H \leq G$ such that $d[X^0_1;U_H] + d[X^0_2;U_H] \le 11 d[X^0_1;X^0_2]$. -/
 theorem entropic_PFR_conjecture :
     ∃ H : AddSubgroup G, ∃ Ω : Type u, ∃ mΩ : MeasureSpace Ω, ∃ U : Ω → G,
-    isUniform H U ∧ d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 11 * d[p.X₀₁ # p.X₀₂] := by sorry
+    isUniform H U ∧ d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 11 * d[p.X₀₁ # p.X₀₂] := by
+  have : MeasurableSub₂ G := ⟨measurable_of_finite _⟩
+  have : MeasurableAdd₂ G := ⟨measurable_of_finite _⟩
+  obtain ⟨Ω', mΩ', X₁, X₂, hX₁, hX₂, _, htau_min⟩ := tau_minimizer_exists p
+  have hdist : d[X₁ # X₂] = 0 := tau_strictly_decreases _ _ p htau_min
+  obtain ⟨H, U, _, hH_unif, hdistX₁, hdistX₂⟩ := exists_isUniform_of_rdist_eq_zero hX₁ hX₂ hdist
+  refine ⟨H, Ω', inferInstance, U, hH_unif, ?_⟩
+  have h : τ[X₁ # X₂ | p] ≤ τ[p.X₀₂ # p.X₀₁ | p] := is_tau_min p htau_min p.hmeas2 p.hmeas1
+  rw [tau, tau, η] at h
+  norm_num at h
+  have : d[U # X₁] = d[X₁ # U] := rdist_symm ..
+  have : d[U # X₂] = d[X₂ # U] := rdist_symm ..
+  have : d[p.X₀₁ # p.X₀₂ ] = d[p.X₀₂ # p.X₀₁] := rdist_symm ..
+  have : d[p.X₀₁ # U] ≤ d[p.X₀₁ # X₁] + d[X₁ # U] := rdist_triangle ..
+  have : d[p.X₀₂ # U] ≤ d[p.X₀₂ # X₂] + d[X₂ # U] := rdist_triangle ..
+  linarith
 
 theorem entropic_PFR_conjecture' :
     ∃ H : AddSubgroup G, ∃ Ω : Type u, ∃ mΩ : MeasureSpace Ω, ∃ U : Ω → G,
     isUniform H U ∧ d[p.X₀₁ # U] ≤ 6 * d[p.X₀₁ # p.X₀₂] ∧
-      d[p.X₀₂ # U] ≤ 6 * d[p.X₀₁ # p.X₀₂] := by sorry
+      d[p.X₀₂ # U] ≤ 6 * d[p.X₀₁ # p.X₀₂] := by
+  have : MeasurableSub₂ G := ⟨measurable_of_finite _⟩
+  have : d[p.X₀₁ # p.X₀₂ ] = d[p.X₀₂ # p.X₀₁] := rdist_symm ..
+  peel entropic_PFR_conjecture Ω₀₁ Ω₀₂ p with hle H Ω mΩ U hU
+  have : d[p.X₀₁ # U] ≤ d[p.X₀₁ # p.X₀₂] + d[p.X₀₂ # U] := rdist_triangle ..
+  have : d[p.X₀₂ # U] ≤ d[p.X₀₂ # p.X₀₁] + d[p.X₀₁ # U] := rdist_triangle ..
+  constructor
+  · linarith
+  · linarith

--- a/blueprint/src/chapter/pfr-entropy.tex
+++ b/blueprint/src/chapter/pfr-entropy.tex
@@ -379,7 +379,7 @@ Moreover, for\footnote{In fact we can take any $\eta<\frac{1}{4 + \sqrt{17}} = \
   Furthermore, both $d[X^0_1;U_H]$ and $d[X^0_2;U_H]$ are at most $6 d[X^0_1;X^0_2]$.
 \end{theorem}
 
-\begin{proof} \uses{de-prop, tau-min, lem:100pc, ruzsa-triangle}  Let $X_1, X_2$ be the $\tau$-minimizer from Lemma \ref{tau-min}.  From Theorem \ref{de-prop}, $d[X_1;X_2]=0$.  From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau$-minimization we have $\tau[X_1;X_2] \leq \tau[X^0_1;X^0_2]$.  Using this and the Ruzsa triangle inequality we can conclude.
+\begin{proof} \uses{de-prop, tau-min, lem:100pc, ruzsa-triangle} \leanok  Let $X_1, X_2$ be the $\tau$-minimizer from Lemma \ref{tau-min}.  From Theorem \ref{de-prop}, $d[X_1;X_2]=0$.  From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau$-minimization we have $\tau[X_1;X_2] \leq \tau[X^0_1;X^0_2]$.  Using this and the Ruzsa triangle inequality we can conclude.
 \end{proof}
 
 Note: a ``stretch goal'' for this project would be to obtain a `decidable` analogue of this result (see the remark at the end of Section 2 for some related discussion).


### PR DESCRIPTION
As expected, the proof is just collecting a number of previously established inequalities.

It did uncover a minor typo in the paper: on page 5, in the proof of theorem 1.2, $|d[X_1; U_H ] − d[X_2; U_H ]| \le d[X_1; X_2]$ should read $|d[X^0_1; U_H ] − d[X^0_2; U_H ]| \le d[X^0_1; X^0_2]$.