### PR TITLE
prerequisites on entropy and uniform distributions for the final argument

### DIFF
--- a/PFR/Entropy/Measure.lean
+++ b/PFR/Entropy/Measure.lean
@@ -2,6 +2,7 @@ import Mathlib.Probability.ConditionalProbability
 import Mathlib.Probability.Independence.Basic
 import Mathlib.Probability.Notation
 import PFR.ForMathlib.Positivity
+import PFR.ForMathlib.Miscellaneous
 import PFR.neg_xlogx
 import PFR.MeasureReal
 
@@ -230,17 +231,6 @@ lemma measureEntropy_nonneg (μ : Measure S) : 0 ≤ Hm[μ] := by
   cases eq_zero_or_neZero μ with
   | inl hμ => simp [hμ]
   | inr hμ => exact prob_le_one
-
-
-variable [CommMonoid β]
-
-@[to_additive]
-theorem Finset.prod_finset_eq_prod [Fintype α] {s : Finset α} {f : α → β}
-    (h : ∀ i ∉ s, f i = 1) :
-    ∏ i in s, f i = ∏ i, f i := by
-  classical
-  have : ∏ i in sᶜ, f i = 1 := Finset.prod_eq_one (fun i hi ↦ h i (Finset.mem_compl.mp hi))
-  rw [← Finset.prod_mul_prod_compl s f, this, mul_one]
 
 lemma measureEntropy_le_card_aux {μ : Measure S} [IsProbabilityMeasure μ]
     (A : Finset S) (hμ : μ Aᶜ = 0) :

--- a/PFR/ForMathlib/Miscellaneous.lean
+++ b/PFR/ForMathlib/Miscellaneous.lean
@@ -1,0 +1,46 @@
+import Mathlib.Probability.IdentDistrib
+
+/- To move close to Set.Finite.measurableSet-/
+lemma Set.Finite.MeasurableSet
+    {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α] {s : Set α} (hs : s.Finite) :
+    MeasurableSet s :=
+  hs.countable.measurableSet
+
+/- To move close to Set.Finite.measurableSet-/
+lemma measurableSet_of_countable {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α]
+    [Countable α] (s : Set α) : MeasurableSet s :=
+  s.to_countable.measurableSet
+
+section
+
+open Set
+
+lemma Nat.card_eq_finset_card {α : Type*} {s : Finset α} : Nat.card s = s.card := by
+  simp only [Nat.card_eq_fintype_card, Fintype.card_coe]
+
+lemma Nat.card_eq_toFinset_card {α : Type*} {s : Set α} (hs : s.Finite) :
+    Nat.card s = hs.toFinset.card := by
+  simp only [← Nat.card_eq_finset_card, Finite.mem_toFinset]
+
+end
+
+section
+
+open Set MeasureTheory Measure
+
+lemma measure_preimage_eq_zero_iff_of_countable {Ω : Type*} {S : Type*} [MeasurableSpace Ω]
+    {H : Set S} {X : Ω → S} {μ : Measure Ω} (hs : H.Countable) :
+    μ (X ⁻¹' H) = 0 ↔ ∀ x ∈ H, μ (X ⁻¹' {x}) = 0 := by
+  have : Countable H := countable_coe_iff.mpr hs
+  refine ⟨fun h x hx ↦ ?_, fun h ↦ ?_⟩
+  · apply le_antisymm ((measure_mono _).trans h.le) (zero_le _)
+    apply preimage_mono
+    simp [hx]
+  · apply le_antisymm _ (zero_le _)
+    calc
+    μ (X ⁻¹' H) = μ (⋃ x : H, X ⁻¹' {(x : S)}) := by simp
+    _ ≤ ∑' x : H, μ (X ⁻¹' {(x : S)}) := measure_iUnion_le _
+    _ = ∑' x : H, 0 := by congr with x; exact h x x.2
+    _ = 0 := by simp
+
+end

--- a/PFR/ForMathlib/Miscellaneous.lean
+++ b/PFR/ForMathlib/Miscellaneous.lean
@@ -44,3 +44,19 @@ lemma measure_preimage_eq_zero_iff_of_countable {Ω : Type*} {S : Type*} [Measur
     _ = 0 := by simp
 
 end
+
+section
+
+open scoped BigOperators
+
+variable [CommMonoid β]
+
+@[to_additive]
+theorem Finset.prod_finset_eq_prod [Fintype α] {s : Finset α} {f : α → β}
+    (h : ∀ i ∉ s, f i = 1) :
+    ∏ i in s, f i = ∏ i, f i := by
+  classical
+  have : ∏ i in sᶜ, f i = 1 := Finset.prod_eq_one (fun i hi ↦ h i (Finset.mem_compl.mp hi))
+  rw [← Finset.prod_mul_prod_compl s f, this, mul_one]
+
+end

--- a/PFR/HundredPercent.lean
+++ b/PFR/HundredPercent.lean
@@ -107,7 +107,7 @@ lemma sub_mem_symmGroup (hX : Measurable X) (hdist : d[X # X] = 0) {x y : G}
 /-- If `d[X # X] = 0`, then `X - x₀` is the uniform distribution on the subgroup of `G`
 stabilizing the distribution of `X`, for any `x₀` of positive probability. -/
 lemma isUniform_sub_const_of_rdist_eq_zero (hX : Measurable X) (hdist : d[X # X] = 0) {x₀ : G}
-    (hx₀ : ℙ (X⁻¹' {x₀}) ≠ 0) : isUniform (symmGroup X hX) (fun ω ↦ X ω - x₀) where
+    (hx₀ : ℙ (X⁻¹' {x₀}) ≠ 0) : IsUniform (symmGroup X hX) (fun ω ↦ X ω - x₀) where
   eq_of_mem := by
     have B c z : (fun ω ↦ X ω - c) ⁻¹' {z} = X ⁻¹' {c + z} := by
       ext w; simp [sub_eq_iff_eq_add']
@@ -122,7 +122,8 @@ lemma isUniform_sub_const_of_rdist_eq_zero (hX : Measurable X) (hdist : d[X # X]
     intro x y hx hy
     have : - x ∈ symmGroup X hX := AddSubgroup.neg_mem (symmGroup X hX) hx
     rw [A x hx, A y hy]
-  zero_of_not_mem := by
+  measure_preimage_compl := by
+    apply (measure_preimage_eq_zero_iff_of_countable (Set.to_countable _)).2
     intro x hx
     contrapose! hx
     have B : (fun ω ↦ X ω - x₀) ⁻¹' {x} = X ⁻¹' {x₀ + x} := by
@@ -132,7 +133,7 @@ lemma isUniform_sub_const_of_rdist_eq_zero (hX : Measurable X) (hdist : d[X # X]
 
 /-- If $d[X;X]=0$, then there exists a subgroup $H \leq G$ such that $d[X;U_H] = 0$. -/
 theorem exists_isUniform_of_rdist_self_eq_zero (hX : Measurable X) (hdist : d[X # X] = 0) :
-    ∃ H : AddSubgroup G, ∃ U : Ω → G, Measurable U ∧ isUniform H U ∧ d[X # U] = 0 := by
+    ∃ H : AddSubgroup G, ∃ U : Ω → G, Measurable U ∧ IsUniform H U ∧ d[X # U] = 0 := by
   -- use for `U` a translate of `X` to make sure that `0` is in its support.
   obtain ⟨x₀, h₀⟩ : ∃ x₀, ℙ (X⁻¹' {x₀}) ≠ 0 := by
     by_contra' h
@@ -157,7 +158,7 @@ theorem exists_isUniform_of_rdist_eq_zero
     {Ω' : Type*} [MeasureSpace Ω'] [IsProbabilityMeasure (ℙ : Measure Ω')] {X' : Ω' → G}
     (hX : Measurable X)(hX' : Measurable X') (hdist : d[X # X'] = 0) :
     ∃ H : AddSubgroup G, ∃ U : Ω → G,
-      Measurable U ∧ isUniform H U ∧ d[X # U] = 0 ∧ d[X' # U] = 0 := by
+      Measurable U ∧ IsUniform H U ∧ d[X # U] = 0 ∧ d[X' # U] = 0 := by
   have h' : d[X # X] = 0 := by
     apply le_antisymm _ (rdist_nonneg hX hX)
     calc

--- a/PFR/entropy_basic.lean
+++ b/PFR/entropy_basic.lean
@@ -5,6 +5,7 @@ import Mathlib.Probability.Notation
 import Mathlib.Probability.IdentDistrib
 import PFR.Entropy.KernelMutualInformation
 import PFR.ForMathlib.Independence
+import PFR.ForMathlib.Miscellaneous
 
 /-!
 # Entropy and conditional entropy
@@ -51,7 +52,9 @@ instance Fintype.instMeasurableSingletonClass [Fintype S] : MeasurableSingletonC
 
 namespace ProbabilityTheory
 
-variable {Ω S T U: Type*} [mΩ : MeasurableSpace Ω]
+universe uΩ uS uT uU
+
+variable {Ω : Type uΩ} {S : Type uS} {T : Type uT} {U : Type uU} [mΩ : MeasurableSpace Ω]
   [Fintype S] [Fintype T] [Fintype U]
   [Nonempty S] [Nonempty T] [Nonempty U]
   [MeasurableSpace S] [MeasurableSpace T] [MeasurableSpace U]
@@ -94,13 +97,19 @@ lemma entropy_nonneg (X : Ω → S) (μ : Measure Ω) : 0 ≤ entropy X μ := me
 
 /-- Two variables that have the same distribution, have the same entropy. -/
 lemma IdentDistrib.entropy_eq {Ω' : Type*} [MeasurableSpace Ω'] {μ' : Measure Ω'} {X' : Ω' → S}
-    (h : IdentDistrib X X' μ μ') : entropy X μ = entropy X' μ' := by
+    (h : IdentDistrib X X' μ μ') : H[X ; μ] = H[X' ; μ'] := by
   simp [entropy_def, h.map_eq]
 
 /-- Entropy is at most the logarithm of the cardinality of the range. -/
 lemma entropy_le_log_card
-    (X : Ω → S) (μ : Measure Ω) : entropy X μ ≤ log (Fintype.card S) :=
+    (X : Ω → S) (μ : Measure Ω) : H[X ; μ] ≤ log (Fintype.card S) :=
   measureEntropy_le_log_card _
+
+lemma entropy_le_log_card_of_mem {A : Set S} {μ : Measure Ω} {X : Ω → S}
+    (hX : Measurable X) (h : ∀ᵐ ω ∂μ, X ω ∈ A) :
+    H[X ; μ] ≤ log (Nat.card A) := by
+  apply measureEntropy_le_log_card_of_mem
+  rwa [Measure.map_apply hX (measurableSet_of_countable _)]
 
 /-- $H[X] = \sum_s P[X=s] \log \frac{1}{P[X=s]}$. -/
 lemma entropy_eq_sum (hX : Measurable X) (μ : Measure Ω) [IsProbabilityMeasure μ] :
@@ -138,29 +147,89 @@ attribute [-instance] Fintype.instMeasurableSpace in
 While in applications $H$ will be non-empty finite set, $X$ measurable, and and $μ$ a probability
 measure, it could be technically convenient to have a definition that works even without these
 hypotheses.  (For instance, `isUniform` would be well-defined, but false, for infinite `H`)   -/
-structure isUniform (H : Set S) (X : Ω → S) (μ : Measure Ω := by volume_tac) : Prop :=
+structure IsUniform (H : Set S) (X : Ω → S) (μ : Measure Ω := by volume_tac) : Prop :=
   eq_of_mem : ∀ x y, x ∈ H → y ∈ H → μ (X ⁻¹' {x}) = μ (X ⁻¹' {y})
-  zero_of_not_mem : ∀ x, x ∉ H → μ (X ⁻¹' {x}) = 0
+  measure_preimage_compl : μ (X ⁻¹' Hᶜ) = 0
+
+open Set
 
 /-- Uniform distributions exist.   -/
-lemma exists_uniform (H : Finset S) [h: Nonempty H] : ∃ Ω : Type*, ∃ mΩ : MeasurableSpace Ω, ∃ X : Ω → S, ∃ μ: Measure Ω, IsProbabilityMeasure μ ∧ Measurable X ∧ isUniform H X μ ∧ ∀ ω : Ω, X ω ∈ H := by sorry
+lemma exists_isUniform (H : Finset S) (h: H.Nonempty) :
+  ∃ (Ω : Type uS) (mΩ : MeasurableSpace Ω) (X : Ω → S) (μ : Measure Ω),
+  IsProbabilityMeasure μ ∧ Measurable X ∧ IsUniform H X μ ∧ ∀ ω : Ω, X ω ∈ H := by sorry
+
+/-- Uniform distributions exist, version within a fintype and giving a measure space  -/
+lemma exists_isUniform_measureSpace
+    {S : Type u} [Fintype S] (H : Set S) (h: H.Nonempty) :
+    ∃ (Ω : Type u) (mΩ : MeasureSpace Ω) (U : Ω → S),
+    IsProbabilityMeasure (ℙ : Measure Ω) ∧ Measurable U ∧ IsUniform H U ∧ ∀ ω : Ω, U ω ∈ H := by
+  sorry
+
+lemma IsUniform.ae_mem {H : Set S} {X : Ω → S} {μ : Measure Ω} (h : IsUniform H X μ) :
+    ∀ᵐ ω ∂μ, X ω ∈ H := h.measure_preimage_compl
 
 /-- A "unit test" for the definition of uniform distribution. -/
-lemma prob_of_uniform_of_in (H: Finset S) (X : Ω → S) (μ : Measure Ω) (hX : isUniform H X μ) (s : S) (hs: s ∈ H): μ.map X {s} = (μ Set.univ) / (Fintype.card H) := sorry
+lemma IsUniform.measure_preimage_of_mem
+    {H : Set S} {X : Ω → S} {μ : Measure Ω} (h : IsUniform H X μ) (hX : Measurable X)
+    {s : S} (hs : s ∈ H) :
+    μ (X ⁻¹' {s}) = (μ Set.univ) / (Nat.card H) := by
+  let H' := H.toFinite.toFinset
+  have B : μ univ = (Nat.card H) * μ (X ⁻¹' {s}) := calc
+    μ univ = μ (X ⁻¹' Hᶜ) + μ (X ⁻¹' H) := by
+      rw [← measure_union (disjoint_compl_left.preimage _) (hX (measurableSet_of_countable _))]
+      simp
+    _ = μ (X ⁻¹' H) := by rw [h.measure_preimage_compl, zero_add]
+    _ = ∑ x in H', μ (X ⁻¹' {x}) := by
+      have : X ⁻¹' H = ⋃ x ∈ H', X ⁻¹' ({x} : Set S) := by simp
+      rw [this, measure_biUnion_finset]
+      · intro y _hy z _hz hyz
+        apply Disjoint.preimage
+        simp [hyz]
+      · intro y _hy
+        exact hX (measurableSet_of_countable _)
+    _ = ∑ _x in H', μ (X ⁻¹' {s}) :=
+      Finset.sum_congr rfl (fun x hx ↦ h.eq_of_mem x s (by simpa using hx) hs)
+    _ = H'.card * μ (X ⁻¹' {s}) := by simp
+    _ = (Nat.card H) * μ (X ⁻¹' {s}) := by
+      congr; exact (Nat.card_eq_toFinset_card (toFinite H)).symm
+  rcases Nat.eq_zero_or_pos (Nat.card H) with hH|hH
+  · simp only [hH, CharP.cast_eq_zero, zero_mul, Measure.measure_univ_eq_zero] at B
+    simp [B]
+  · rwa [eq_comm, ← ENNReal.eq_div_iff] at B
+    · simpa using Nat.pos_iff_ne_zero.mp hH
+    · simp
 
 /-- Another "unit test" for the definition of uniform distribution. -/
-lemma prob_of_uniform_of_not_in (H: Finset S) (X : Ω → S) (μ : Measure Ω) (hX : isUniform H X μ) (s : S) (hs: ¬ s ∈ H): μ.map X {s} = 0 := sorry
+lemma IsUniform.measure_preimage_of_nmem
+    {H : Set S} {X : Ω → S} {μ : Measure Ω} (h : IsUniform H X μ) {s : S} (hs : s ∉ H) :
+    μ (X ⁻¹' {s}) = 0 := by
+  apply le_antisymm ((measure_mono _).trans h.measure_preimage_compl.le) (zero_le _)
+  apply preimage_mono
+  simpa using hs
 
+lemma IsUniform.of_identDistrib {Ω' : Type*} [MeasurableSpace Ω']
+    {H : Set S} {X : Ω → S} {μ : Measure Ω} (h : IsUniform H X μ)
+    {X' : Ω' → S} {μ' : Measure Ω'} (h' : IdentDistrib X X' μ μ') (hH : MeasurableSet H) :
+    IsUniform H X' μ' := by
+  constructor
+  · intro x y hx hy
+    rw [← h'.measure_mem_eq (MeasurableSet.singleton x),
+      ← h'.measure_mem_eq (MeasurableSet.singleton y)]
+    apply h.eq_of_mem x y hx hy
+  · rw [← h'.measure_mem_eq hH.compl]
+    exact h.measure_preimage_compl
 
-
-
-/-- If $X$ is uniformly distributed on $H$, then $H[X] = \log |H|$.  May need some non-degeneracy and measurability conditions. -/
-lemma entropy_of_uniform (H: Finset S) (X : Ω → S) (μ : Measure Ω) (hX : isUniform H X μ) :
-    H[X ; μ] = log (Fintype.card H) := sorry
+/-- If $X$ is uniformly distributed on $H$, then $H[X] = \log |H|$.
+May need some non-degeneracy and measurability conditions. -/
+lemma IsUniform.entropy_eq (H : Set S) (X : Ω → S) {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (hX : IsUniform H X μ) : H[X ; μ] = log (Nat.card H) := sorry
 
 /-- If $X$ is $S$-valued random variable, then $H[X] = \log |S|$ if and only if $X$ is uniformly
 distributed. -/
-lemma entropy_eq_log_card {X : Ω → S} (hX : Measurable X) (μ : Measure Ω) (hμ: NeZero μ) (hμ' : IsFiniteMeasure μ): (entropy X μ = log (Fintype.card S)) ↔ (∀ s : S, μ.map X {s} = (μ Set.univ) / (Fintype.card S)) := by
+lemma entropy_eq_log_card {X : Ω → S} (hX : Measurable X) (μ : Measure Ω) (hμ : NeZero μ)
+    (hμ' : IsFiniteMeasure μ) :
+    (entropy X μ = log (Fintype.card S)) ↔
+      (∀ s : S, μ.map X {s} = (μ Set.univ) / (Fintype.card S)) := by
   rcases eq_zero_or_neZero (μ.map X) with h | h
   . have := Measure.le_map_apply  (@Measurable.aemeasurable Ω S _ _ X μ hX) Set.univ
     simp [h] at this; simp [this] at hμ
@@ -171,7 +240,8 @@ lemma entropy_eq_log_card {X : Ω → S} (hX : Measurable X) (μ : Measure Ω) (
 
 /-- If $X$ is an $S$-valued random variable, then there exists $s \in S$ such that
 $P[X=s] \geq \exp(-H[X])$. -/
-lemma prob_ge_exp_neg_entropy (X : Ω → S) (μ : Measure Ω) : ∃ s : S, μ.map X {s} ≥ (μ Set.univ) * (rexp (- entropy X μ )).toNNReal := by sorry
+lemma prob_ge_exp_neg_entropy (X : Ω → S) (μ : Measure Ω) :
+  ∃ s : S, μ.map X {s} ≥ (μ Set.univ) * (rexp (- entropy X μ)).toNNReal := by sorry
 
 /-- The pair of two random variables -/
 abbrev prod {Ω S T : Type*} ( X : Ω → S ) ( Y : Ω → T ) (ω : Ω) : S × T := (X ω, Y ω)

--- a/PFR/entropy_pfr.lean
+++ b/PFR/entropy_pfr.lean
@@ -33,7 +33,7 @@ theorem tau_strictly_decreases (h : tau_minimizes p X₁ X₂) : d[X₁ # X₂] 
 /-- `entropic_PFR_conjecture`: For two $G$-valued random variables $X^0_1, X^0_2$, there is some subgroup $H \leq G$ such that $d[X^0_1;U_H] + d[X^0_2;U_H] \le 11 d[X^0_1;X^0_2]$. -/
 theorem entropic_PFR_conjecture :
     ∃ H : AddSubgroup G, ∃ Ω : Type u, ∃ mΩ : MeasureSpace Ω, ∃ U : Ω → G,
-    isUniform H U ∧ d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 11 * d[p.X₀₁ # p.X₀₂] := by
+    IsUniform H U ∧ d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 11 * d[p.X₀₁ # p.X₀₂] := by
   have : MeasurableSub₂ G := ⟨measurable_of_finite _⟩
   have : MeasurableAdd₂ G := ⟨measurable_of_finite _⟩
   obtain ⟨Ω', mΩ', X₁, X₂, hX₁, hX₂, _, htau_min⟩ := tau_minimizer_exists p
@@ -52,7 +52,7 @@ theorem entropic_PFR_conjecture :
 
 theorem entropic_PFR_conjecture' :
     ∃ H : AddSubgroup G, ∃ Ω : Type u, ∃ mΩ : MeasureSpace Ω, ∃ U : Ω → G,
-    isUniform H U ∧ d[p.X₀₁ # U] ≤ 6 * d[p.X₀₁ # p.X₀₂] ∧
+    IsUniform H U ∧ d[p.X₀₁ # U] ≤ 6 * d[p.X₀₁ # p.X₀₂] ∧
       d[p.X₀₂ # U] ≤ 6 * d[p.X₀₁ # p.X₀₂] := by
   have : MeasurableSub₂ G := ⟨measurable_of_finite _⟩
   have : d[p.X₀₁ # p.X₀₂ ] = d[p.X₀₂ # p.X₀₁] := rdist_symm ..

--- a/PFR/main.lean
+++ b/PFR/main.lean
@@ -12,11 +12,40 @@ Here we prove the polynomial Freiman-Ruzsa conjecture.
 
 -/
 
-open Pointwise Nat
+open Pointwise ProbabilityTheory MeasureTheory Real
+universe u
 
-/-- The polynomial Freiman-Ruzsa (PFR) conjecture: if $A$ is a subset of an elementary abelian 2-group of doubling constant at most $K$, then $A$ can be covered by at most $2K^{12}$ cosets of a subgroup of cardinality at most $|A|$. -/
+namespace ProbabilityTheory
+
+/-- The polynomial Freiman-Ruzsa (PFR) conjecture: if $A$ is a subset of an elementary abelian
+2-group of doubling constant at most $K$, then $A$ can be covered by at most $2K^{12}$ cosets of
+a subgroup of cardinality at most $|A|$. -/
 theorem PFR_conjecture {G : Type*} [AddCommGroup G] [ElementaryAddCommGroup G 2] [Fintype G]
-    [DecidableEq G] {A : Set G} {K : ℝ} (h₀A : A.Nonempty)
+    {A : Set G} {K : ℝ} (h₀A : A.Nonempty)
     (hA : Nat.card (A + A) ≤ K * Nat.card A) : ∃ (H : AddSubgroup G) (c : Set G),
     Nat.card c ≤ 2 * K ^ 12 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  have card_AA_pos : (0 : ℝ) < Nat.card (A + A) := by
+    have : Nonempty (A + A) := Set.nonempty_coe_sort.mpr (Set.Nonempty.add h₀A h₀A)
+    have : Finite (A + A) := by exact Subtype.finite
+    simp [Nat.cast_pos, Nat.card_pos_iff]
+  have KA_pos : 0 < K ∧ (0 : ℝ) < Nat.card A := by
+    have I : ¬ ((Nat.card A : ℝ) < 0) := by simp
+    simpa [Nat.cast_pos, I, and_false, or_false] using mul_pos_iff.1 (card_AA_pos.trans_le hA)
+  have : MeasurableAdd₂ G := ⟨measurable_of_finite _⟩
+  have : MeasurableSub₂ G := ⟨measurable_of_finite _⟩
+  rcases exists_isUniform_measureSpace A h₀A with ⟨Ω₀, mΩ₀, U₀, hP₀, U₀meas, U₀unif, U₀mem⟩
+  rcases independent_copies_two U₀meas U₀meas with ⟨Ω, mΩ, U, U', hP, hU, hU', UU'_indep, idU, idU'⟩
+  have Uunif : IsUniform A U := U₀unif.of_identDistrib idU.symm trivial
+  have U'unif : IsUniform A U' := U₀unif.of_identDistrib idU'.symm trivial
+  have : d[U # U'] ≤ log K := by
+    have I : H[U + U'] ≤ log (Nat.card (A + A)) := by
+      apply entropy_le_log_card_of_mem (hU.add hU')
+      filter_upwards [Uunif.ae_mem, U'unif.ae_mem] with ω h1 h2
+      exact Set.add_mem_add h1 h2
+    have J : log (Nat.card (A + A)) ≤ log K + log (Nat.card A) := by
+      apply (log_le_log' card_AA_pos hA).trans (le_of_eq _)
+      rw [log_mul KA_pos.1.ne' KA_pos.2.ne']
+    have : H[U + U'] = H[U - U'] := by congr; simp
+    rw [UU'_indep.rdist_eq hU hU', Uunif.entropy_eq, U'unif.entropy_eq, ← this]
+    linarith
   sorry

--- a/PFR/neg_xlogx.lean
+++ b/PFR/neg_xlogx.lean
@@ -145,12 +145,15 @@ lemma strictConcaveOn_negIdMulLog : StrictConcaveOn ℝ (Set.Ici (0 : ℝ)) negI
   rw [negIdMulLog_eq_neg]
   exact strictConvexOn_id_mul_log.neg
 
+lemma sum_negIdMulLog_finset_le {S : Type*} {A : Finset S} {w : S → ℝ} {p : S → ℝ}
+    (h0 : ∀ s ∈ A, 0 ≤ w s) (h1 : ∑ s in A, w s = 1) (hmem : ∀ s ∈ A, 0 ≤ p s) :
+    ∑ s in A, (w s) * negIdMulLog (p s) ≤ negIdMulLog (∑ s in A, (w s) * (p s)) :=
+  ConcaveOn.le_map_sum concaveOn_negIdMulLog h0 h1 hmem
+
 lemma sum_negIdMulLog_le {S : Type*} [Fintype S] {w : S → ℝ} {p : S → ℝ} (h0 : ∀ s, 0 ≤ w s)
     (h1 : ∑ s, w s = 1) (hmem : ∀ s, 0 ≤ p s) :
-    ∑ s, (w s) * negIdMulLog (p s) ≤ negIdMulLog (∑ s, (w s) * (p s)) := by
-  refine ConcaveOn.le_map_sum concaveOn_negIdMulLog ?_ h1 ?_
-  · simp [h0]
-  · simp [hmem]
+    ∑ s, (w s) * negIdMulLog (p s) ≤ negIdMulLog (∑ s, (w s) * (p s)) :=
+  sum_negIdMulLog_finset_le (fun s _hs ↦ h0 s) h1 (fun s _hs ↦ hmem s)
 
 -- a form of equality case of Jensen
 lemma sum_negIdMulLog_eq_aux {w : S → ℝ} {p : S → ℝ} {U : Finset S}

--- a/Test/entropy_basic_old.lean
+++ b/Test/entropy_basic_old.lean
@@ -72,7 +72,7 @@ lemma entropy_le_log (hX : Measurable X): H[X] ≤ log (Fintype.card S) := by
 
 /-- Equality in Jensen is attained when X is uniform.  TODO: also establish converse.  One could
 also remove hΩ but this seems of little use.  -/
-lemma entropy_of_uniform (hΩ : ProbabilitySpace.isNondeg Ω) (hX : ProbabilitySpace.isUniform X) :
+lemma entropy_of_uniform (hΩ : ProbabilitySpace.isNondeg Ω) (hX : IsUniform X) :
     H[X] = log (Fintype.card S) := by
   rcases hX with ⟨ hX1, hX2 ⟩
   unfold entropy


### PR DESCRIPTION
We add more facts on uniform distributions, and the fact that the entropy of a random variable supported on a set `A` is at most `log A`. 

Also rename `isUniform` to `IsUniform` to match mathlib naming conventions.