### PR TITLE
Products of probability measures.

### DIFF
--- a/PFR/ForMathlib/CompactProb.lean
+++ b/PFR/ForMathlib/CompactProb.lean
@@ -94,6 +94,16 @@ lemma continuous_pmf_apply (i : X) :
              ENNReal.toReal_nonneg, max_eq_left]
   rfl
 
+-- KK: I will reuse this, so could be used in `homeomorph_probabilityMeasure_stdSimplex`, too.
+open Filter in
+lemma tendsto_lintegral_of_forall_of_fintype {ι : Type*} {L : Filter ι}
+    (μs : ι → Measure X) [∀ i, IsFiniteMeasure (μs i)] (μ : Measure X) [IsFiniteMeasure μ]
+    (f : X →ᵇ ℝ≥0) (h : ∀ (x : X), Tendsto (fun i ↦ μs i {x}) L (𝓝 (μ {x}))) :
+    Tendsto (fun i ↦ ∫⁻ x, f x ∂(μs i)) L (𝓝 (∫⁻ x, f x ∂μ)) := by
+  simp only [lintegral_fintype]
+  refine tendsto_finset_sum Finset.univ ?_
+  exact fun x _ ↦ ENNReal.Tendsto.const_mul (h x) (Or.inr ENNReal.coe_ne_top)
+
 variable (X)
 
 noncomputable def homeomorph_probabilityMeasure_stdSimplex

--- a/PFR/ForMathlib/FiniteMeasureComponent.lean
+++ b/PFR/ForMathlib/FiniteMeasureComponent.lean
@@ -15,8 +15,6 @@ open scoped Topology ENNReal NNReal BoundedContinuousFunction
 
 section measure_of_component
 
-#check IsClopen
-
 lemma continuous_indicator_const {α β : Type*} [TopologicalSpace α]
     [Zero β] [TopologicalSpace β] {b : β} {s : Set α} (s_clopen : IsClopen s) :
     Continuous (indicator s (fun _ ↦ b)) := by
@@ -32,8 +30,6 @@ lemma continuous_indicator_const {α β : Type*} [TopologicalSpace α]
   · by_cases ht : 0 ∈ t
     · simp only [ht, ite_true, isOpen_compl_iff, s_clopen.isClosed]
     · simp only [ht, ite_false, isOpen_empty]
-
---#check IsolatedPoint -- Does not exist. What is the Mathlib-spelling?
 
 lemma continuous_indicator_singleton {α : Type*} [TopologicalSpace α] [T1Space α]
     {a : α} (ha : IsOpen {a}) :
@@ -74,7 +70,7 @@ noncomputable def indicatorBCF {α : Type*} [TopologicalSpace α]
                        dist_zero_left, norm_one, le_refl]
           · simp only [hx, hy, not_false_eq_true, indicator_of_not_mem, dist_self, zero_le_one]
 
-@[simp] lemma indicatorBCF_apply  {α : Type*} [TopologicalSpace α]
+@[simp] lemma indicatorBCF_apply {α : Type*} [TopologicalSpace α]
     {s : Set α} (s_clopen : IsClopen s) (x : α) :
     indicatorBCF s_clopen x = s.indicator (fun _ ↦ (1 : ℝ)) x := rfl
 

--- a/PFR/ForMathlib/FiniteMeasureComponent.lean
+++ b/PFR/ForMathlib/FiniteMeasureComponent.lean
@@ -45,16 +45,16 @@ lemma continuous_integral_finiteMeasure
     Continuous (fun (μ : FiniteMeasure α) ↦ ∫ x, f x ∂μ) := by
   apply continuous_iff_continuousAt.mpr
   intro μ
-  apply continuousAt_of_tendsto_nhds
-  exact FiniteMeasure.tendsto_iff_forall_integral_tendsto.mp tendsto_id f
+  exact continuousAt_of_tendsto_nhds
+    (FiniteMeasure.tendsto_iff_forall_integral_tendsto.mp tendsto_id f)
 
 lemma continuous_integral_probabilityMeasure
     {α : Type*} [TopologicalSpace α] [MeasurableSpace α] [OpensMeasurableSpace α] (f : α →ᵇ ℝ) :
     Continuous (fun (μ : ProbabilityMeasure α) ↦ ∫ x, f x ∂μ) := by
   apply continuous_iff_continuousAt.mpr
   intro μ
-  apply continuousAt_of_tendsto_nhds
-  exact ProbabilityMeasure.tendsto_iff_forall_integral_tendsto.mp tendsto_id f
+  exact  continuousAt_of_tendsto_nhds
+    (ProbabilityMeasure.tendsto_iff_forall_integral_tendsto.mp tendsto_id f)
 
 noncomputable def indicatorBCF {α : Type*} [TopologicalSpace α]
     {s : Set α} (s_clopen : IsClopen s) :

--- a/PFR/ForMathlib/FiniteMeasureProd.lean
+++ b/PFR/ForMathlib/FiniteMeasureProd.lean
@@ -18,14 +18,15 @@ namespace MeasureTheory
     (μ : FiniteMeasure α) (f : α → β) :
     (μ.map f).toMeasure = μ.toMeasure.map f := rfl
 
+@[simp] lemma ProbabilityMeasure.toMeasure_map {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    (μ : ProbabilityMeasure α) {f : α → β} (hf : AEMeasurable f μ) :
+    (μ.map hf).toMeasure = μ.toMeasure.map f := rfl
+
 section FiniteMeasure_product
 
 namespace FiniteMeasure
 
-variable {α : Type*} [MeasurableSpace α]
--- [TopologicalSpace α] [OpensMeasurableSpace α]
-variable {β : Type*} [MeasurableSpace β]
--- [TopologicalSpace β] [OpensMeasurableSpace β]
+variable {α : Type*} [MeasurableSpace α] {β : Type*} [MeasurableSpace β]
 
 /-- The binary product of finite measures. -/
 noncomputable def prod (μ : FiniteMeasure α) (ν : FiniteMeasure β) : FiniteMeasure (α × β) :=
@@ -177,6 +178,102 @@ end FiniteMeasure -- namespace
 end FiniteMeasure_product -- section
 
 section ProbabilityMeasure_product
+
+namespace ProbabilityMeasure
+
+variable {α : Type*} [MeasurableSpace α] {β : Type*} [MeasurableSpace β]
+
+/-- The binary product of probability measures. -/
+noncomputable def prod (μ : ProbabilityMeasure α) (ν : ProbabilityMeasure β) :
+    ProbabilityMeasure (α × β) :=
+  ⟨μ.toMeasure.prod ν.toMeasure, Measure.prod.instIsProbabilityMeasure μ.toMeasure ν.toMeasure⟩
+
+variable (μ : ProbabilityMeasure α) (ν : ProbabilityMeasure β)
+
+@[simp] lemma toMeasure_prod : (μ.prod ν).toMeasure = μ.toMeasure.prod ν.toMeasure := rfl
+
+lemma prod_apply (s : Set (α × β)) (s_mble : MeasurableSet s) :
+    μ.prod ν s = ENNReal.toNNReal (∫⁻ x, ν.toMeasure (Prod.mk x ⁻¹' s) ∂μ) := by
+  simp [@Measure.prod_apply α β _ _ μ ν _ s s_mble]
+
+lemma prod_apply_symm (s : Set (α × β)) (s_mble : MeasurableSet s) :
+    μ.prod ν s = ENNReal.toNNReal (∫⁻ y, μ.toMeasure ((fun x ↦ ⟨x, y⟩) ⁻¹' s) ∂ν) := by
+  simp [@Measure.prod_apply_symm α β _ _ μ ν _ _ s s_mble]
+
+lemma prod_prod (s : Set α) (t : Set β) : μ.prod ν (s ×ˢ t) = μ s * ν t := by simp
+
+example : Measurable (Prod.fst : α × β → α) := by
+  exact measurable_fst
+
+@[simp] lemma map_fst_prod : (μ.prod ν).map measurable_fst.aemeasurable = μ := by
+  apply Subtype.ext
+  simp only [val_eq_to_measure, toMeasure_map, toMeasure_prod, Measure.map_fst_prod,
+             measure_univ, one_smul]
+
+@[simp] lemma map_snd_prod : (μ.prod ν).map measurable_snd.aemeasurable = ν := by
+  apply Subtype.ext
+  simp only [val_eq_to_measure, toMeasure_map, toMeasure_prod, Measure.map_snd_prod,
+             measure_univ, one_smul]
+
+example  {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
+    {f : α → α'} {g : β → β'} (f_mble : Measurable f) (g_mble : Measurable g) :
+    Measurable (Prod.map f g) := by
+  exact Measurable.prod_map f_mble g_mble
+
+example  {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
+    {f : α → α'} {g : β → β'} (f_mble : AEMeasurable f μ) (g_mble : AEMeasurable g ν) :
+    AEMeasurable (Prod.map f g) (μ.toMeasure.prod ν.toMeasure) := by
+  --exact?
+  sorry
+
+lemma map_prod_map {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
+    {f : α → α'} {g : β → β'} (f_mble : Measurable f) (g_mble : Measurable g) :
+    (μ.map f_mble.aemeasurable).prod (ν.map g_mble.aemeasurable)
+      = (μ.prod ν).map (f_mble.prod_map g_mble).aemeasurable := by
+  apply Subtype.ext
+  simp only [val_eq_to_measure, toMeasure_prod, toMeasure_map]
+  rw [Measure.map_prod_map _ _ f_mble g_mble] <;>
+    exact IsFiniteMeasure.toSigmaFinite (Measure.map _ _)
+
+lemma prod_apply_null {s : Set (α × β)} (hs : MeasurableSet s) :
+    μ.prod ν s = 0 ↔ (fun x ↦ ν (Prod.mk x ⁻¹' s)) =ᵐ[μ] 0 := by
+  convert Measure.measure_prod_null (μ := μ.toMeasure) (ν := ν.toMeasure) hs
+  · simp only [toMeasure_prod, toNNReal_eq_zero_iff, or_iff_left_iff_imp]
+    intro con
+    by_contra
+    exact measure_ne_top _ _ con
+  · constructor <;> intro h <;> filter_upwards [h] with p hp
+    · simp only [Pi.zero_apply] at *
+      rcases (ENNReal.toNNReal_eq_zero_iff _).mp hp with (h'|con)
+      · exact h'
+      · by_contra
+        exact measure_ne_top _ _ con
+    · simp only [Pi.zero_apply] at *
+      exact (ENNReal.toNNReal_eq_zero_iff _).mpr (Or.inl hp)
+
+lemma measure_ae_null_of_prod_null {s : Set (α × β)} (h : μ.prod ν s = 0) :
+    (fun x ↦ ν (Prod.mk x ⁻¹' s)) =ᵐ[μ] 0 := by
+  convert Measure.measure_ae_null_of_prod_null (μ := μ.toMeasure) (ν := ν.toMeasure) (s := s) ?_
+  · constructor <;> intro h <;> filter_upwards [h] with p hp
+    · simp only [Pi.zero_apply] at *
+      rcases (ENNReal.toNNReal_eq_zero_iff _).mp hp with (h'|con)
+      · exact h'
+      · by_contra
+        exact measure_ne_top _ _ con
+    · simp only [Pi.zero_apply] at *
+      exact (ENNReal.toNNReal_eq_zero_iff _).mpr (Or.inl hp)
+  · simp [toNNReal_eq_zero_iff] at h
+    rcases h with (h'|con)
+    · exact h'
+    · by_contra
+      exact measure_ne_top _ _ con
+
+lemma prod_swap : (μ.prod ν).map measurable_swap.aemeasurable = ν.prod μ := by
+  apply Subtype.ext
+  simp [Measure.prod_swap]
+
+end ProbabilityMeasure -- namespace
+
 end ProbabilityMeasure_product -- section
 
 end MeasureTheory -- namespace

--- a/PFR/ForMathlib/FiniteMeasureProd.lean
+++ b/PFR/ForMathlib/FiniteMeasureProd.lean
@@ -1,6 +1,5 @@
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.Constructions.Prod.Basic
-import Mathlib.MeasureTheory.Measure.Portmanteau
 
 /-!
 # Products of finite measures and probability measures

--- a/PFR/ForMathlib/FiniteMeasureProd.lean
+++ b/PFR/ForMathlib/FiniteMeasureProd.lean
@@ -27,7 +27,6 @@ variable {α : Type*} [MeasurableSpace α]
 variable {β : Type*} [MeasurableSpace β]
 -- [TopologicalSpace β] [OpensMeasurableSpace β]
 
-
 /-- The binary product of finite measures. -/
 noncomputable def prod (μ : FiniteMeasure α) (ν : FiniteMeasure β) : FiniteMeasure (α × β) :=
   ⟨μ.toMeasure.prod ν.toMeasure, Measure.prod.instIsFiniteMeasure μ.toMeasure ν.toMeasure⟩
@@ -60,12 +59,19 @@ lemma prod_zero : μ.prod (0 : FiniteMeasure β) = 0 := by
 @[simp] lemma map_fst_prod : (μ.prod ν).map Prod.fst = (ν univ) • μ := by
   apply Subtype.ext
   simp only [val_eq_toMeasure, toMeasure_map, toMeasure_prod, Measure.map_fst_prod]
-  ext s s_mble
+  ext s _
   simp only [Measure.smul_toOuterMeasure, OuterMeasure.coe_smul, Pi.smul_apply, smul_eq_mul]
-  sorry
+  have aux := @coeFn_smul_apply α _ ℝ≥0 _ _ _ _ _ (ν univ) μ s
+  simpa using congr_arg ENNReal.ofNNReal aux.symm
 
 @[simp] lemma map_snd_prod : (μ.prod ν).map Prod.snd = (μ univ) • ν := by
-  sorry
+  apply Subtype.ext
+  simp only [val_eq_toMeasure, toMeasure_map, toMeasure_prod, Measure.map_fst_prod]
+  ext s _
+  simp only [Measure.map_snd_prod, Measure.smul_toOuterMeasure, OuterMeasure.coe_smul,
+    Pi.smul_apply, smul_eq_mul]
+  have aux := @coeFn_smul_apply β _ ℝ≥0 _ _ _ _ _ (μ univ) ν s
+  simpa using congr_arg ENNReal.ofNNReal aux.symm
 
 lemma map_prod_map {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
     {f : α → α'} {g : β → β'}  (f_mble : Measurable f) (g_mble : Measurable g):
@@ -121,6 +127,7 @@ lemma sum_prod {ι : Type*} [Fintype ι] (μs : ι → FiniteMeasure β) :
   sorry
  -/
 
+/-
 variable [TopologicalSpace α] [OpensMeasurableSpace α] [TopologicalSpace β] [OpensMeasurableSpace β]
 
 lemma tendsto_prod [SecondCountableTopology α] {ι : Type*} {L : Filter ι}
@@ -164,7 +171,7 @@ lemma continuous_prod [SecondCountableTopology α] :
 lemma continuous_prod' [SecondCountableTopology β] :
     Continuous (fun (μν : FiniteMeasure α × FiniteMeasure β) ↦ μν.1.prod μν.2) := by
   sorry
-
+ -/
 end FiniteMeasure -- namespace
 
 end FiniteMeasure_product -- section

--- a/PFR/ForMathlib/FiniteMeasureProd.lean
+++ b/PFR/ForMathlib/FiniteMeasureProd.lean
@@ -1,0 +1,140 @@
+import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
+import Mathlib.MeasureTheory.Constructions.Prod.Basic
+--import Mathlib
+
+/-!
+# Products of finite measures and probability measures
+
+-/
+
+open MeasureTheory Topology Metric Filter Set ENNReal NNReal
+
+open scoped Topology ENNReal NNReal BoundedContinuousFunction BigOperators
+
+namespace MeasureTheory
+
+@[simp] lemma FiniteMeasure.toMeasure_map {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    (μ : FiniteMeasure α) (f : α → β) :
+    (μ.map f).toMeasure = μ.toMeasure.map f := rfl
+
+section FiniteMeasure_product
+
+namespace FiniteMeasure
+
+variable {α : Type*} [MeasurableSpace α]
+-- [TopologicalSpace α] [OpensMeasurableSpace α]
+variable {β : Type*} [MeasurableSpace β]
+-- [TopologicalSpace β] [OpensMeasurableSpace β]
+
+
+/-- The binary product of finite measures. -/
+noncomputable def prod (μ : FiniteMeasure α) (ν : FiniteMeasure β) : FiniteMeasure (α × β) :=
+  ⟨μ.toMeasure.prod ν.toMeasure, Measure.prod.instIsFiniteMeasure μ.toMeasure ν.toMeasure⟩
+
+variable (μ : FiniteMeasure α) (ν : FiniteMeasure β)
+
+@[simp] lemma toMeasure_prod : (μ.prod ν).toMeasure = μ.toMeasure.prod ν.toMeasure := rfl
+
+lemma prod_apply (s : Set (α × β)) (s_mble : MeasurableSet s) :
+    μ.prod ν s = ENNReal.toNNReal (∫⁻ x, ν.toMeasure (Prod.mk x ⁻¹' s) ∂μ) := by
+  simp [@Measure.prod_apply α β _ _ μ ν _ s s_mble]
+
+lemma prod_apply_symm (s : Set (α × β)) (s_mble : MeasurableSet s) :
+    μ.prod ν s = ENNReal.toNNReal (∫⁻ y, μ.toMeasure ((fun x ↦ ⟨x, y⟩) ⁻¹' s) ∂ν) := by
+  simp [@Measure.prod_apply_symm α β _ _ μ ν _ _ s s_mble]
+
+lemma prod_prod (s : Set α) (t : Set β) : μ.prod ν (s ×ˢ t) = μ s * ν t := by simp
+
+lemma mass_prod : (μ.prod ν).mass = μ.mass * ν.mass := by
+  simp only [mass, univ_prod_univ.symm, toMeasure_prod]
+  rw [← ENNReal.toNNReal_mul]
+  exact congr_arg ENNReal.toNNReal (Measure.prod_prod univ univ)
+
+lemma zero_prod : (0 : FiniteMeasure α).prod ν = 0 := by
+  rw [← mass_zero_iff, mass_prod, zero_mass, zero_mul]
+
+lemma prod_zero : μ.prod (0 : FiniteMeasure β) = 0 := by
+  rw [← mass_zero_iff, mass_prod, zero_mass, mul_zero]
+
+@[simp] lemma map_fst_prod : (μ.prod ν).map Prod.fst = (ν univ) • μ := by
+  apply Subtype.ext
+  simp only [val_eq_toMeasure, toMeasure_map, toMeasure_prod, Measure.map_fst_prod]
+  ext s s_mble
+  simp only [Measure.smul_toOuterMeasure, OuterMeasure.coe_smul, Pi.smul_apply, smul_eq_mul]
+  sorry
+
+@[simp] lemma map_snd_prod : (μ.prod ν).map Prod.snd = (μ univ) • ν := by
+  sorry
+
+lemma map_prod_map {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
+    {f : α → α'} {g : β → β'}  (f_mble : Measurable f) (g_mble : Measurable g):
+    (μ.map f).prod (ν.map g) = (μ.prod ν).map (Prod.map f g) := by
+  apply Subtype.ext
+  simp only [val_eq_toMeasure, toMeasure_prod, toMeasure_map]
+  rw [Measure.map_prod_map _ _ f_mble g_mble] <;> exact IsFiniteMeasure.toSigmaFinite _
+
+lemma prod_apply_null {s : Set (α × β)} (hs : MeasurableSet s) :
+    μ.prod ν s = 0 ↔ (fun x ↦ ν (Prod.mk x ⁻¹' s)) =ᵐ[μ] 0 := by
+  convert Measure.measure_prod_null (μ := μ.toMeasure) (ν := ν.toMeasure) hs
+  · simp only [toMeasure_prod, toNNReal_eq_zero_iff, or_iff_left_iff_imp]
+    intro con
+    by_contra
+    exact measure_ne_top _ _ con
+  · constructor <;> intro h <;> filter_upwards [h] with p hp
+    · simp only [Pi.zero_apply] at *
+      rcases (ENNReal.toNNReal_eq_zero_iff _).mp hp with (h'|con)
+      · exact h'
+      · by_contra
+        exact measure_ne_top _ _ con
+    · simp only [Pi.zero_apply] at *
+      exact (ENNReal.toNNReal_eq_zero_iff _).mpr (Or.inl hp)
+
+lemma measure_ae_null_of_prod_null {s : Set (α × β)} (h : μ.prod ν s = 0) :
+    (fun x ↦ ν (Prod.mk x ⁻¹' s)) =ᵐ[μ] 0 := by
+  convert Measure.measure_ae_null_of_prod_null (μ := μ.toMeasure) (ν := ν.toMeasure) (s := s) ?_
+  · constructor <;> intro h <;> filter_upwards [h] with p hp
+    · simp only [Pi.zero_apply] at *
+      rcases (ENNReal.toNNReal_eq_zero_iff _).mp hp with (h'|con)
+      · exact h'
+      · by_contra
+        exact measure_ne_top _ _ con
+    · simp only [Pi.zero_apply] at *
+      exact (ENNReal.toNNReal_eq_zero_iff _).mpr (Or.inl hp)
+  · simp [toNNReal_eq_zero_iff] at h
+    rcases h with (h'|con)
+    · exact h'
+    · by_contra
+      exact measure_ne_top _ _ con
+
+lemma prod_swap : (μ.prod ν).map Prod.swap = ν.prod μ := by
+  apply Subtype.ext
+  simp [Measure.prod_swap]
+
+/-
+lemma prod_sum {ι : Type*} [Fintype ι] (νs : ι → FiniteMeasure β) :
+    μ.prod (∑ i, νs i) = ∑ i, μ.prod (νs i) := by
+  sorry
+
+lemma sum_prod {ι : Type*} [Fintype ι] (μs : ι → FiniteMeasure β) :
+    (∑ i, μs i).prod ν = ∑ i, (μs i).prod ν := by
+  sorry
+ -/
+
+variable [TopologicalSpace α] [OpensMeasurableSpace α] [TopologicalSpace β] [OpensMeasurableSpace β]
+
+lemma continuous_prod [SecondCountableTopology α] :
+    Continuous (fun (μν : FiniteMeasure α × FiniteMeasure β) ↦ μν.1.prod μν.2) := by
+  sorry
+
+lemma continuous_prod' [SecondCountableTopology β] :
+    Continuous (fun (μν : FiniteMeasure α × FiniteMeasure β) ↦ μν.1.prod μν.2) := by
+  sorry
+
+end FiniteMeasure -- namespace
+
+end FiniteMeasure_product -- section
+
+section ProbabilityMeasure_product
+end ProbabilityMeasure_product -- section
+
+end MeasureTheory -- namespace

--- a/PFR/ForMathlib/FiniteMeasureProd.lean
+++ b/PFR/ForMathlib/FiniteMeasureProd.lean
@@ -1,5 +1,6 @@
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.Constructions.Prod.Basic
+import Mathlib.MeasureTheory.Measure.Portmanteau
 --import Mathlib
 
 /-!
@@ -122,9 +123,43 @@ lemma sum_prod {ι : Type*} [Fintype ι] (μs : ι → FiniteMeasure β) :
 
 variable [TopologicalSpace α] [OpensMeasurableSpace α] [TopologicalSpace β] [OpensMeasurableSpace β]
 
+lemma tendsto_prod [SecondCountableTopology α] {ι : Type*} {L : Filter ι}
+    {μνs : ι → FiniteMeasure α × FiniteMeasure β} {μν : FiniteMeasure α × FiniteMeasure β}
+    (h_lim : L.Tendsto μνs (𝓝 μν)) :
+    L.Tendsto (fun i ↦ (μνs i).1.prod (μνs i).2) (𝓝 (μν.1.prod μν.2)) := by
+  rw [nhds_prod_eq] at h_lim
+  --simp [tendsto_prod_iff] at h_lim
+  --rw [Tendsto.prod_mk_nhds] at h_lim
+  --rw [tendsto_nhds_prod] at h_lim
+  rw [tendsto_iff_forall_integral_tendsto]
+  sorry
+
 lemma continuous_prod [SecondCountableTopology α] :
     Continuous (fun (μν : FiniteMeasure α × FiniteMeasure β) ↦ μν.1.prod μν.2) := by
-  sorry
+  haveI : T1Space (FiniteMeasure (α × β)) := sorry -- Under some reasonable hypotheses?
+  --haveI : T1Space (FiniteMeasure α × FiniteMeasure β) := sorry
+  apply continuous_iff_continuousAt.mpr
+  intro ⟨μ, ν⟩
+  let μν : FiniteMeasure α × FiniteMeasure β := ⟨μ, ν⟩
+  apply continuousAt_of_tendsto_nhds (y := μ.prod ν)
+  -- Assume also second countability!
+  haveI : Nonempty (α × β) := sorry -- ...otherwise trivial
+  apply (@tendsto_normalize_iff_tendsto (α × β) _ _ (μ.prod ν) _ _ _
+          (𝓝 μν) (fun κ ↦ κ.1.prod κ.2) ?_).mp
+  · refine ⟨?_, ?_⟩
+    · -- **This is the main sorry!**
+      -- Oh $#!, there is a universe misprint in the statement of `tendsto_of_forall_isOpen_le_liminf`
+      have := @tendsto_of_forall_isOpen_le_liminf
+      sorry
+    · sorry  -- The easy case.
+  · sorry -- ...otherwise trivial
+  --apply tendsto_of_forall_isOpen_le_liminf
+  --have := tendsto_of_liminf
+  --have := @tendsto_iff_forall_integral_tendsto (α × β) _ _ _ ?_ ?_  -- (μ.prod ν)
+  --sorry
+
+#check continuousAt_of_tendsto_nhds
+#check T1Space
 
 lemma continuous_prod' [SecondCountableTopology β] :
     Continuous (fun (μν : FiniteMeasure α × FiniteMeasure β) ↦ μν.1.prod μν.2) := by

--- a/PFR/ForMathlib/FiniteMeasureProd.lean
+++ b/PFR/ForMathlib/FiniteMeasureProd.lean
@@ -1,7 +1,6 @@
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.Constructions.Prod.Basic
 import Mathlib.MeasureTheory.Measure.Portmanteau
---import Mathlib
 
 /-!
 # Products of finite measures and probability measures
@@ -118,61 +117,6 @@ lemma prod_swap : (μ.prod ν).map Prod.swap = ν.prod μ := by
   apply Subtype.ext
   simp [Measure.prod_swap]
 
-/-
-lemma prod_sum {ι : Type*} [Fintype ι] (νs : ι → FiniteMeasure β) :
-    μ.prod (∑ i, νs i) = ∑ i, μ.prod (νs i) := by
-  sorry
-
-lemma sum_prod {ι : Type*} [Fintype ι] (μs : ι → FiniteMeasure β) :
-    (∑ i, μs i).prod ν = ∑ i, (μs i).prod ν := by
-  sorry
- -/
-
-/-
-variable [TopologicalSpace α] [OpensMeasurableSpace α] [TopologicalSpace β] [OpensMeasurableSpace β]
-
-lemma tendsto_prod [SecondCountableTopology α] {ι : Type*} {L : Filter ι}
-    {μνs : ι → FiniteMeasure α × FiniteMeasure β} {μν : FiniteMeasure α × FiniteMeasure β}
-    (h_lim : L.Tendsto μνs (𝓝 μν)) :
-    L.Tendsto (fun i ↦ (μνs i).1.prod (μνs i).2) (𝓝 (μν.1.prod μν.2)) := by
-  rw [nhds_prod_eq] at h_lim
-  --simp [tendsto_prod_iff] at h_lim
-  --rw [Tendsto.prod_mk_nhds] at h_lim
-  --rw [tendsto_nhds_prod] at h_lim
-  rw [tendsto_iff_forall_integral_tendsto]
-  sorry
-
-lemma continuous_prod [SecondCountableTopology α] :
-    Continuous (fun (μν : FiniteMeasure α × FiniteMeasure β) ↦ μν.1.prod μν.2) := by
-  haveI : T1Space (FiniteMeasure (α × β)) := sorry -- Under some reasonable hypotheses?
-  --haveI : T1Space (FiniteMeasure α × FiniteMeasure β) := sorry
-  apply continuous_iff_continuousAt.mpr
-  intro ⟨μ, ν⟩
-  let μν : FiniteMeasure α × FiniteMeasure β := ⟨μ, ν⟩
-  apply continuousAt_of_tendsto_nhds (y := μ.prod ν)
-  -- Assume also second countability!
-  haveI : Nonempty (α × β) := sorry -- ...otherwise trivial
-  apply (@tendsto_normalize_iff_tendsto (α × β) _ _ (μ.prod ν) _ _ _
-          (𝓝 μν) (fun κ ↦ κ.1.prod κ.2) ?_).mp
-  · refine ⟨?_, ?_⟩
-    · -- **This is the main sorry!**
-      -- Oh $#!, there is a universe misprint in the statement of `tendsto_of_forall_isOpen_le_liminf`
-      have := @tendsto_of_forall_isOpen_le_liminf
-      sorry
-    · sorry  -- The easy case.
-  · sorry -- ...otherwise trivial
-  --apply tendsto_of_forall_isOpen_le_liminf
-  --have := tendsto_of_liminf
-  --have := @tendsto_iff_forall_integral_tendsto (α × β) _ _ _ ?_ ?_  -- (μ.prod ν)
-  --sorry
-
-#check continuousAt_of_tendsto_nhds
-#check T1Space
-
-lemma continuous_prod' [SecondCountableTopology β] :
-    Continuous (fun (μν : FiniteMeasure α × FiniteMeasure β) ↦ μν.1.prod μν.2) := by
-  sorry
- -/
 end FiniteMeasure -- namespace
 
 end FiniteMeasure_product -- section
@@ -214,17 +158,6 @@ example : Measurable (Prod.fst : α × β → α) := by
   apply Subtype.ext
   simp only [val_eq_to_measure, toMeasure_map, toMeasure_prod, Measure.map_snd_prod,
              measure_univ, one_smul]
-
-example  {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
-    {f : α → α'} {g : β → β'} (f_mble : Measurable f) (g_mble : Measurable g) :
-    Measurable (Prod.map f g) := by
-  exact Measurable.prod_map f_mble g_mble
-
-example  {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
-    {f : α → α'} {g : β → β'} (f_mble : AEMeasurable f μ) (g_mble : AEMeasurable g ν) :
-    AEMeasurable (Prod.map f g) (μ.toMeasure.prod ν.toMeasure) := by
-  --exact?
-  sorry
 
 lemma map_prod_map {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
     {f : α → α'} {g : β → β'} (f_mble : Measurable f) (g_mble : Measurable g) :

--- a/PFR/ForMathlib/ProbabilityMeasureProdCont.lean
+++ b/PFR/ForMathlib/ProbabilityMeasureProdCont.lean
@@ -1,0 +1,47 @@
+import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
+import Mathlib.MeasureTheory.Constructions.Prod.Basic
+import Mathlib.MeasureTheory.Measure.Portmanteau
+import PFR.ForMathlib.FiniteMeasureProd
+import PFR.ForMathlib.CompactProb
+--import Mathlib
+
+/-!
+# Continuity of products of probability measures on finite types
+
+-/
+
+open MeasureTheory Topology Metric Filter Set ENNReal NNReal
+
+open scoped Topology ENNReal NNReal BoundedContinuousFunction BigOperators
+
+namespace MeasureTheory
+
+/-- Finite measures on a finite space tend to a limit if and only if the probability masses
+of all points tend to the corresponding limits. -/
+lemma FiniteMeasure.tendsto_iff_forall_apply_tendsto
+    {ι : Type*} {L : Filter ι} [NeBot L]
+    {α : Type*} [Fintype α] [TopologicalSpace α] [DiscreteTopology α] [MeasurableSpace α]
+    [BorelSpace α] (μs : ι → FiniteMeasure α) (μ : FiniteMeasure α) :
+    Tendsto μs L (𝓝 μ) ↔ ∀ (a : α), Tendsto (fun i ↦ μs i {a}) L (𝓝 (μ {a})) := by
+  sorry
+
+/-- Probability measures on a finite space tend to a limit if and only if the probability masses
+of all points tend to the corresponding limits. -/
+lemma ProbabilityMeasure.tendsto_iff_forall_apply_tendsto
+    {ι : Type*} {L : Filter ι} [NeBot L]
+    {α : Type*} [Fintype α] [TopologicalSpace α] [DiscreteTopology α] [MeasurableSpace α]
+    [BorelSpace α] (μs : ι → ProbabilityMeasure α) (μ : ProbabilityMeasure α) :
+    Tendsto μs L (𝓝 μ) ↔ ∀ (a : α), Tendsto (fun i ↦ μs i {a}) L (𝓝 (μ {a})) := by
+  constructor <;> intro h
+  · exact fun a ↦ ((continuous_pmf_apply a).continuousAt (x := μ)).tendsto.comp h
+  · apply ProbabilityMeasure.tendsto_iff_forall_lintegral_tendsto.mpr
+    intro f
+    apply tendsto_lintegral_of_forall_of_fintype
+    intro a
+    simp at h ⊢
+    -- TODO: rename `ENNReal.continuous_coe` to `ENNReal.continuous_ofNNReal`
+    convert ENNReal.continuous_coe.continuousAt.tendsto.comp (h a)
+    simp only [Function.comp_apply, ne_eq, ennreal_coeFn_eq_coeFn_toMeasure, coe_toNNReal]
+    simp only [ne_eq, ennreal_coeFn_eq_coeFn_toMeasure]
+
+end MeasureTheory -- namespace

--- a/PFR/ProbabilityMeasureProdCont.lean
+++ b/PFR/ProbabilityMeasureProdCont.lean
@@ -38,8 +38,9 @@ instance {α : Type*} [Fintype α] [TopologicalSpace α] : SecondCountableTopolo
     use {U | IsOpen U}
     exact ⟨to_countable {U | IsOpen U}, TopologicalSpace.isTopologicalBasis_opens.eq_generateFrom⟩
 
-/-- Probability measures on a finite space tend to a limit if and only if the probability masses
-of all points tend to the corresponding limits. -/
+/-- If probability measures on two finite spaces tend to limits, then the products of them
+on the product space tend to the product of the limits.
+TODO: In Mathlib, this should be done on all separable metrizable spaces. -/
 lemma ProbabilityMeasure.tendsto_prod_of_tendsto_of_tendsto
     {ι : Type*} {L : Filter ι} [NeBot L] {α β : Type*}
     [Fintype α] [TopologicalSpace α] [DiscreteTopology α] [MeasurableSpace α] [BorelSpace α]

--- a/PFR/ProbabilityMeasureProdCont.lean
+++ b/PFR/ProbabilityMeasureProdCont.lean
@@ -1,9 +1,7 @@
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.Constructions.Prod.Basic
-import Mathlib.MeasureTheory.Measure.Portmanteau
 import PFR.ForMathlib.FiniteMeasureProd
 import PFR.ForMathlib.CompactProb
---import Mathlib
 
 /-!
 # Continuity of products of probability measures on finite types
@@ -15,15 +13,6 @@ open MeasureTheory Topology Metric Filter Set ENNReal NNReal
 open scoped Topology ENNReal NNReal BoundedContinuousFunction BigOperators
 
 namespace MeasureTheory
-
-/-- Finite measures on a finite space tend to a limit if and only if the probability masses
-of all points tend to the corresponding limits. -/
-lemma FiniteMeasure.tendsto_iff_forall_apply_tendsto
-    {ι : Type*} {L : Filter ι} [NeBot L]
-    {α : Type*} [Fintype α] [TopologicalSpace α] [DiscreteTopology α] [MeasurableSpace α]
-    [BorelSpace α] (μs : ι → FiniteMeasure α) (μ : FiniteMeasure α) :
-    Tendsto μs L (𝓝 μ) ↔ ∀ (a : α), Tendsto (fun i ↦ μs i {a}) L (𝓝 (μ {a})) := by
-  sorry -- Almost the same as below (some earlier lemmas need restating, too).
 
 /-- Probability measures on a finite space tend to a limit if and only if the probability masses
 of all points tend to the corresponding limits. -/

--- a/PFR/ProbabilityMeasureProdCont.lean
+++ b/PFR/ProbabilityMeasureProdCont.lean
@@ -23,7 +23,7 @@ lemma FiniteMeasure.tendsto_iff_forall_apply_tendsto
     {α : Type*} [Fintype α] [TopologicalSpace α] [DiscreteTopology α] [MeasurableSpace α]
     [BorelSpace α] (μs : ι → FiniteMeasure α) (μ : FiniteMeasure α) :
     Tendsto μs L (𝓝 μ) ↔ ∀ (a : α), Tendsto (fun i ↦ μs i {a}) L (𝓝 (μ {a})) := by
-  sorry
+  sorry -- Almost the same as below (some earlier lemmas need restating, too).
 
 /-- Probability measures on a finite space tend to a limit if and only if the probability masses
 of all points tend to the corresponding limits. -/
@@ -38,10 +38,32 @@ lemma ProbabilityMeasure.tendsto_iff_forall_apply_tendsto
     intro f
     apply tendsto_lintegral_of_forall_of_fintype
     intro a
-    simp at h ⊢
-    -- TODO: rename `ENNReal.continuous_coe` to `ENNReal.continuous_ofNNReal`
+    -- TODO: rename `ENNReal.continuous_coe` to `ENNReal.continuous_ofNNReal`?
     convert ENNReal.continuous_coe.continuousAt.tendsto.comp (h a)
     simp only [Function.comp_apply, ne_eq, ennreal_coeFn_eq_coeFn_toMeasure, coe_toNNReal]
     simp only [ne_eq, ennreal_coeFn_eq_coeFn_toMeasure]
+
+-- To Mathlib
+instance {α : Type*} [Fintype α] [TopologicalSpace α] : SecondCountableTopology α where
+  is_open_generated_countable := by
+    use {U | IsOpen U}
+    exact ⟨to_countable {U | IsOpen U}, TopologicalSpace.isTopologicalBasis_opens.eq_generateFrom⟩
+
+/-- Probability measures on a finite space tend to a limit if and only if the probability masses
+of all points tend to the corresponding limits. -/
+lemma ProbabilityMeasure.tendsto_prod_of_tendsto_of_tendsto
+    {ι : Type*} {L : Filter ι} [NeBot L] {α β : Type*}
+    [Fintype α] [TopologicalSpace α] [DiscreteTopology α] [MeasurableSpace α] [BorelSpace α]
+    [Fintype β] [TopologicalSpace β] [DiscreteTopology β] [MeasurableSpace β] [BorelSpace β]
+    (μs : ι → ProbabilityMeasure α) (μ : ProbabilityMeasure α) (μs_lim : Tendsto μs L (𝓝 μ))
+    (νs : ι → ProbabilityMeasure β) (ν : ProbabilityMeasure β) (νs_lim : Tendsto νs L (𝓝 ν)) :
+    Tendsto (fun i ↦ (μs i).prod (νs i)) L (𝓝 (μ.prod ν)) := by
+  apply (ProbabilityMeasure.tendsto_iff_forall_apply_tendsto _ _).mpr
+  intro ab
+  have aux : {ab} = {ab.1} ×ˢ {ab.2} := toFinset_inj.mp rfl
+  simp_rw [aux, prod_prod]
+  have obs_μs := ((continuous_pmf_apply ab.1).continuousAt (x := μ)).tendsto.comp μs_lim
+  have obs_νs := ((continuous_pmf_apply ab.2).continuousAt (x := ν)).tendsto.comp νs_lim
+  exact tendsto_mul.comp (Tendsto.prod_mk_nhds obs_μs obs_νs)
 
 end MeasureTheory -- namespace

--- a/PFR/ruzsa_distance.lean
+++ b/PFR/ruzsa_distance.lean
@@ -214,6 +214,7 @@ lemma continuous_rdist_restrict_probabilityMeasure
       H[fun x ↦ x.1 - x.2 ; μ.1.toMeasure.prod μ.2.toMeasure]) := by
     -- Requires:
     -- (1) Some API about (continuity of) products of probability measures.
+    --     (`ProbabilityMeasure.tendsto_prod_of_tendsto_of_tendsto` is enough here.)
     -- (2) Continuity of mapping probability measures: `ProbabilityMeasure.continuous_map`.
     sorry
   have obs₁ : Continuous


### PR DESCRIPTION
I added a version of the continuity of products of probability measures on finite spaces, which should be sufficient for the remaining continuity proofs. (In Mathlib the continuity of products of probability measures should be proven for all separable metrizable spaces, but this requires a bit more.)