### PR TITLE
Fibring identity for first estimate

### DIFF
--- a/PFR/first_estimate.lean
+++ b/PFR/first_estimate.lean
@@ -1,6 +1,7 @@
 import PFR.Entropy.Basic
 import PFR.tau_functional
 import PFR.f2_vec
+import PFR.fibring
 
 /-!
 # First estimate
@@ -37,7 +38,7 @@ variable (X₁ X₂ X₁' X₂' : Ω → G)
 
 variable (h₁ : IdentDistrib X₁ X₁') (h₂ : IdentDistrib X₂ X₂')
 
-variable (h_indep : iIndepFun ![hG, hG, hG, hG] ![X₁, X₂, X₁', X₂'])
+variable (h_indep : iIndepFun (fun _i => hG) ![X₁, X₂, X₂', X₁'])
 
 variable (h_min: tau_minimizes p X₁ X₂)
 
@@ -50,7 +51,21 @@ $$ d[X_1+\tilde X_2;X_2+\tilde X_1] + d[X_1|X_1+\tilde X_2; X_2|X_2+\tilde X_1] 
 and
 $$ I[ X_1+ X_2 : \tilde X_1 + X_2 \,|\, X_1 + X_2 + \tilde X_1 + \tilde X_2 ] $$
 is equal to $2k$. -/
-lemma rdist_add_rdist_add_condMutual_eq : d[X₁ + X₂' # X₂ + X₁'] + d[X₁ | X₁ + X₂' # X₂ | X₂ + X₁' ] + I[X₁ + X₂ : X₁' + X₂ | X₁ + X₂ + X₁' + X₂'] = 2 * k := by sorry
+lemma rdist_add_rdist_add_condMutual_eq : d[X₁ + X₂' # X₂ + X₁'] + d[X₁ | X₁ + X₂' # X₂ | X₂ + X₁']
+    + I[X₁ + X₂ : X₁' + X₂ | X₁ + X₂ + X₁' + X₂'] = 2 * k := by
+  have h0 : ![X₁, X₂, X₂', X₁'] 0 = X₁ := rfl
+  have h1 : ![X₁, X₂, X₂', X₁'] 1 = X₂ := rfl
+  have h2 : ![X₁, X₂, X₂', X₁'] 2 = X₂' := rfl
+  have h3 : ![X₁, X₂, X₂', X₁'] 3 = X₁' := rfl
+  have h := sum_of_rdist_eq_char_2 ![X₁, X₂, X₂', X₁'] h_indep (fun i => by fin_cases i <;> assumption)
+  rw [h0, h1, h2, h3] at h
+  have heq : d[X₂' # X₁'] = k
+  · rw [rdist_symm]
+    apply ProbabilityTheory.IdentDistrib.rdist_eq h₁.symm h₂.symm
+  rw[heq] at h
+  convert h.symm using 1
+  · congr 2 <;> abel
+  · ring
 
 /-- The distance $d[X_1+\tilde X_2; X_2+\tilde X_1]$ is at least
 $$ k - \eta (d[X^0_1; X_1+\tilde X_2] - d[X^0_1; X_1]) \\& \qquad- \eta (d[X^0_2; X_2+\tilde X_1] - d[X^0_2; X_2]).$$ -/
@@ -72,7 +87,7 @@ lemma cond_rdist_of_sums_ge :
 /-- $$d[X^0_1; X_1+\tilde X_2] - d[X^0_1; X_1] \leq \tfrac{1}{2} k + \tfrac{1}{4} \bbH[X_2] - \tfrac{1}{4} \bbH[X_1].$$ -/
 lemma diff_rdist_le_1 : d[p.X₀₁ # X₁ + X₂'] - d[p.X₀₁ # X₁] ≤ k/2 + H[X₂]/4 - H[X₁]/4 := by
   have h : IndepFun X₁ X₂'
-  · simpa using h_indep.indepFun (show (0:Fin 4) ≠ 3 by decide)
+  · simpa using h_indep.indepFun (show (0:Fin 4) ≠ 2 by decide)
   convert condDist_diff_le' ℙ p.hmeas1 hX₁ hX₂' h using 4
   · exact ProbabilityTheory.IdentDistrib.rdist_eq (IdentDistrib.refl hX₁.aemeasurable) h₂
   · exact h₂.entropy_eq
@@ -80,7 +95,7 @@ lemma diff_rdist_le_1 : d[p.X₀₁ # X₁ + X₂'] - d[p.X₀₁ # X₁] ≤ k/
 /-- $$ d[X^0_2;X_2+\tilde X_1] - d[X^0_2; X_2] \leq \tfrac{1}{2} k + \tfrac{1}{4} \bbH[X_1] - \tfrac{1}{4} \bbH[X_2].$$ -/
 lemma diff_rdist_le_2 : d[p.X₀₂ # X₂ + X₁'] - d[p.X₀₂ # X₂] ≤ k/2 + H[X₁]/4 - H[X₂]/4 := by
   have h : IndepFun X₂ X₁'
-  · simpa using h_indep.indepFun (show (1:Fin 4) ≠ 2 by decide)
+  · simpa using h_indep.indepFun (show (1:Fin 4) ≠ 3 by decide)
   convert condDist_diff_le' ℙ p.hmeas2 hX₂ hX₁' h using 4
   · rw [rdist_symm]
     exact ProbabilityTheory.IdentDistrib.rdist_eq (IdentDistrib.refl hX₂.aemeasurable) h₁
@@ -89,7 +104,7 @@ lemma diff_rdist_le_2 : d[p.X₀₂ # X₂ + X₁'] - d[p.X₀₂ # X₂] ≤ k/
 /-- $$ d[X_1^0;X_1|X_1+\tilde X_2] - d[X_1^0;X_1] \leq \tfrac{1}{2} k + \tfrac{1}{4} \bbH[X_1] - \tfrac{1}{4} \bbH[X_2].$$ -/
 lemma diff_rdist_le_3 : d[p.X₀₁ # X₁ | X₁ + X₂'] - d[p.X₀₁ # X₁] ≤ k/2 + H[X₁]/4 - H[X₂]/4 := by
   have h : IndepFun X₁ X₂'
-  · simpa using h_indep.indepFun (show (0:Fin 4) ≠ 3 by decide)
+  · simpa using h_indep.indepFun (show (0:Fin 4) ≠ 2 by decide)
   convert condDist_diff_le''' ℙ p.hmeas1 hX₁ hX₂' h using 3
   · rw[ProbabilityTheory.IdentDistrib.rdist_eq (IdentDistrib.refl hX₁.aemeasurable) h₂]
   · apply h₂.entropy_eq
@@ -97,14 +112,14 @@ lemma diff_rdist_le_3 : d[p.X₀₁ # X₁ | X₁ + X₂'] - d[p.X₀₁ # X₁]
 /-- $$ d[X_2^0; X_2|X_2+\tilde X_1] - d[X_2^0; X_2] &\leq \tfrac{1}{2}k + \tfrac{1}{4} \bbH[X_2] - \tfrac{1}{4} \bbH[X_1].$$ -/
 lemma diff_rdist_le_4 : d[p.X₀₂ # X₂ | X₂ + X₁'] - d[p.X₀₂ # X₂] ≤ k/2 + H[X₂]/4 - H[X₁]/4 := by
   have h : IndepFun X₂ X₁'
-  · simpa using h_indep.indepFun (show (1:Fin 4) ≠ 2 by decide)
+  · simpa using h_indep.indepFun (show (1:Fin 4) ≠ 3 by decide)
   convert condDist_diff_le''' ℙ p.hmeas2 hX₂ hX₁' h using 3
   · rw[rdist_symm, ProbabilityTheory.IdentDistrib.rdist_eq (IdentDistrib.refl hX₂.aemeasurable) h₁]
   · apply h₁.entropy_eq
 
 /--  We have $I_1 \leq 2 \eta k$ -/
 lemma first_estimate : I₁ ≤ 2 * η * k := by
-  have v1 := rdist_add_rdist_add_condMutual_eq X₁ X₂ X₁' X₂'
+  have v1 := rdist_add_rdist_add_condMutual_eq X₁ X₂ X₁' X₂' ‹_› ‹_› ‹_› ‹_› ‹_› ‹_› ‹_›
   have v2 := rdist_of_sums_ge p X₁ X₂ X₁' X₂' ‹_› ‹_› ‹_› ‹_› ‹_›
   have v3 := cond_rdist_of_sums_ge p X₁ X₂ X₁' X₂' ‹_› ‹_› ‹_›
   have v4 := diff_rdist_le_1 p X₁ X₂ X₁' X₂' ‹_› ‹_› ‹_› ‹_›

--- a/blueprint/src/chapter/pfr-entropy.tex
+++ b/blueprint/src/chapter/pfr-entropy.tex
@@ -85,7 +85,7 @@ $$ I_1 :=  I [ X_1+X_2 : \tilde X_1 + X_2 | X_1+X_2+\tilde X_1+\tilde X_2 ].$$
   \end{align*}
 \end{lemma}
 
-\begin{proof}\uses{cor-fibre}  Immediate from Corollary \ref{cor-fibre}.
+\begin{proof}\uses{cor-fibre} \leanok  Immediate from Corollary \ref{cor-fibre}.
 \end{proof}
 
 \begin{lemma}[Lower bound on distances]\label{first-dist-sum}


### PR DESCRIPTION
Another easy one.

I did change `h_indep` to match `sum_of_rdist_eq_char_2`. I hope this doesn't come back to bite, but for now it saves having to permute a vector.