### PR TITLE
Misc improvements on blueprint

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,7 +45,12 @@ jobs:
       - name: Cache mathlib docs
         uses: actions/cache@v3
         with:
-          path: .lake/build/doc/Mathlib
+          path: |
+            .lake/build/doc/Init
+            .lake/build/doc/Lake
+            .lake/build/doc/Lean
+            .lake/build/doc/Std
+            .lake/build/doc/Mathlib
           key: DocGen4-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
             DocGen4-
@@ -95,3 +100,7 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+
+      - name: Make sure the cache works
+        run: |
+          mv docs/docs .lake/build/doc

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ inv all
 To view the web-version of the blueprint locally, run `inv serve` and navigate to
 `http://localhost:8000/` in your favorite browser.
 
+Or you can just run `inv dev` instead of `inv all` and `inv serve`, after each edit to the LaTeX,
+it will automatically rebuild the blueprint, you just need to refresh the web page to see the rendered result.
+
+Note: If you have something wrong in your LaTeX file, and the LaTeX compilation fails,
+LaTeX will stuck and ask for commands, you'll need to type `X` then return to exit LaTeX,
+then fix the LaTeX error, and run `inv dev` again.
+
 ## Source reference
 
 `[GGMT]`: <https://arxiv.org/abs/2311.05762>

--- a/README.md
+++ b/README.md
@@ -21,15 +21,11 @@ To build the project, run `lake exe cache get` and then `lake build`.
 
 To build the web version of the blueprint, you need a working LaTeX installation.
 Furthermore, you need some packages:
+
 ```
 sudo apt install graphviz libgraphviz-dev
-pip3 install invoke pandoc
-cd .. # go to folder where you are happy clone git repos
-git clone git@github.com:plastex/plastex
-pip3 install ./plastex
-git clone git@github.com:PatrickMassot/leanblueprint
-pip3 install ./leanblueprint
-cd pfr # go back to the PFR repository
+pip uninstall -y leanblueprint
+pip install -r blueprint/requirements.txt
 ```
 
 To actually build the blueprint, run

--- a/blueprint/requirements.txt
+++ b/blueprint/requirements.txt
@@ -1,4 +1,5 @@
 invoke==1.7.1
 plasTeX @ git+https://github.com/plastex/plastex.git
-leanblueprint @ git+https://github.com/utensil/leanblueprint.git@lean4-only
+leanblueprint @ git+https://github.com/PatrickMassot/leanblueprint.git
 watchfiles==0.16.1
+pandoc==2.3

--- a/blueprint/tasks.py
+++ b/blueprint/tasks.py
@@ -52,9 +52,15 @@ def serve(ctx, random_port=False):
     Handler = http.server.SimpleHTTPRequestHandler
     if random_port:
         port = random.randint(8000, 8100)
-        print("Serving on port " + str(port))
     else:
         port = 8000
+
     httpd = socketserver.TCPServer(("", port), Handler)
-    httpd.serve_forever()
-    os.chdir(cwd)
+    try:
+        (ip, port) = httpd.server_address
+        ip = ip or 'localhost'
+        print(f'Serving http://{ip}:{port}/ ...')
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()

--- a/tasks.py
+++ b/tasks.py
@@ -7,6 +7,7 @@ from invoke import run, task
 from blueprint.tasks import web, bp, print_bp, serve
 
 ROOT = Path(__file__).parent
+BP_DIR = ROOT/'blueprint'
 
 @task(bp, web)
 def all(ctx):
@@ -18,3 +19,32 @@ def all(ctx):
 def html(ctx):
     shutil.rmtree(ROOT/'docs'/'blueprint', ignore_errors=True)
     shutil.copytree(ROOT/'blueprint'/'web', ROOT/'docs'/'blueprint')
+
+@task(all)
+def dev(ctx):
+    """
+    Serve the blueprint website, rebuild PDF and the website on file changes
+    """
+
+    from watchfiles import run_process, DefaultFilter
+
+    def callback(changes):
+        print('Changes detected:', changes)
+        bp(ctx)
+        web(ctx)
+
+    run_process(BP_DIR/'src', target='inv serve', callback=callback,
+        watch_filter=DefaultFilter(
+            ignore_entity_patterns=(
+                '.*\.aux$',
+                '.*\.log$',
+                '.*\.fls$',
+                '.*\.fdb_latexmk$',
+                '.*\.bbl$',
+                '.*\.paux$',
+                '.*\.pdf$',
+                '.*\.out$',
+                '.*\.blg$',
+                '.*\.synctex.*$',
+            )
+        ))


### PR DESCRIPTION
Per discussions with @kbuzzard and @YaelDillies , this PR includes some improvements on blueprint, namely:

1. Currently, the Mathlib doc caching is not effective, this is because the doc is moved during CI for publishing to Pages.

Fixing this should make CI faster. More deps of Mathlib are also cached.

2. `inv serve` is silent about which port it's serving, unlike `inv serve` in other repos, which would show a link to click on for convenience and less confusion.

3. Currently, after each edit to LaTeX, one must rerun both `inv all` and `inv serve`, unlike `inv dev` available in other repos, which will rebuild the blueprint on file changes, making local testing more convenient.

4. The CI uses `requirements.txt` but instructions for local testing is not using it, and it's more complicated than it could be, this PR simplifies the instructions, and introduces the `inv dev` improvement. Also, consistently pointing the leanblueprint to Patrick's master branch of leanblueprint.