### PR TITLE
feat: `prob_ge_exp_neg_entropy`

### DIFF
--- a/PFR/Entropy/Basic.lean
+++ b/PFR/Entropy/Basic.lean
@@ -306,16 +306,135 @@ lemma entropy_eq_log_card {X : Ω → S} (hX : Measurable X) (μ : Measure Ω) (
   rw [entropy_def, measureEntropy_eq_card_iff_measure_eq, Measure.map_apply hX MeasurableSet.univ]
   simp
 
+/-- $\sum_s g(f(s)) = \sum_{f(s) \neq 0} g(f(s))$ if $g(0) = 0$ -/
+lemma Fintype.sum_eq_sum_nonzero_comp {S α β : Type*} [Zero α] [DecidableEq α] [AddCommMonoid β]
+    [Fintype S] {f : S → α} {g : α → β} (h : g 0 = 0) :
+    Finset.sum Finset.univ (g ∘ f) =
+    Finset.sum (Finset.univ.filter (fun s ↦ f s ≠ 0)) (g ∘ f) := by
+  let S_nonzero := Finset.univ.filter (fun s ↦ f s ≠ 0)
+  let h_nonzero_subset := Finset.filter_subset (fun s ↦ f s ≠ 0) Finset.univ
+  have h_zero_terms : ∀ s ∈ Finset.univ, s ∉ S_nonzero → (g ∘ f) s = 0 := by
+    intros s h_s h_s_notin
+    rw [Finset.mem_filter, not_and_not_right] at h_s_notin
+    rw [show (g ∘ f) s = g (f s) by rfl, h_s_notin h_s, h]
+  rw [Finset.sum_subset h_nonzero_subset h_zero_terms]
+
 /-- If $X$ is an $S$-valued random variable, then there exists $s \in S$ such that
 $P[X=s] \geq \exp(-H[X])$. -/
-lemma prob_ge_exp_neg_entropy (X : Ω → S) (μ : Measure Ω) :
-  ∃ s : S, μ.map X {s} ≥ (μ Set.univ) * (rexp (- H[X ; μ])).toNNReal := by sorry
+lemma prob_ge_exp_neg_entropy (X : Ω → S) (μ : Measure Ω) (hX : Measurable X) :
+    ∃ s : S, μ.map X {s} ≥ (μ Set.univ) * (rexp (- H[X ; μ])).toNNReal := by
+  let μS := μ.map X
+  let μs s := μS {s}
+  let S_nonzero := Finset.univ.filter (fun s ↦ μs s ≠ 0)
+
+  let norm := μS Set.univ
+  have h_norm: norm = μ Set.univ := by
+    rw [← preimage_univ]
+    have h := MeasureTheory.Measure.map_apply (μ := μ) hX (Finset.measurableSet Finset.univ)
+    rw [Finset.coe_univ] at h
+    exact h
+
+  let pdf_nn s := norm⁻¹ * μs s
+  let pdf s := (pdf_nn s).toReal
+  let neg_log_pdf s := -log (pdf s)
+
+  rcases Finset.eq_empty_or_nonempty S_nonzero with h_empty | h_nonempty
+  . have h_norm_zero : μ Set.univ = 0 := by
+      rw [← h_norm, show norm = μS Set.univ from rfl, ← sum_measure_singleton]
+      show ∑ s, (id ∘ μs) s = 0
+      rw [Fintype.sum_eq_sum_nonzero_comp (f := μs) (g := id) rfl]
+      show Finset.sum S_nonzero μs = 0
+      rw [h_empty, show Finset.sum ∅ μs = 0 from rfl]
+    let s := Classical.arbitrary (α := S)
+    have h_ineq : μs s ≥ (μ Set.univ) * (rexp (- H[X ; μ])).toNNReal := by
+      rw [h_norm_zero, zero_mul]
+      exact le_of_not_gt ENNReal.not_lt_zero
+    exact ⟨ s, h_ineq ⟩
+
+  rcases exists_or_forall_not (fun s ↦ μs s = ∞) with h_infty | h_finite
+  . let ⟨ s, h_s ⟩ := h_infty
+    have h_ineq : μs s ≥ (μ Set.univ) * (rexp (- H[X ; μ])).toNNReal := by
+      rw [h_s]
+      exact le_top
+    exact ⟨ s, h_ineq ⟩
+
+  rcases eq_zero_or_neZero μ with h_zero | h_nonzero
+  . let s := Classical.arbitrary (α := S)
+    have h_ineq : μs s ≥ (μ Set.univ) * (rexp (- H[X ; μ])).toNNReal := by
+      rw [h_zero, show (0 : Measure Ω) Set.univ = 0 from rfl, zero_mul]
+      exact zero_le _
+    exact ⟨ s, h_ineq ⟩
+
+  have h_norm_pos : 0 < norm := by
+    rw [h_norm, MeasureTheory.Measure.measure_univ_pos]
+    exact NeZero.ne μ
+  have h_norm_ne_zero : norm ≠ 0 := ne_zero_of_lt h_norm_pos
+  have h_norm_nonneg : 0 ≤ norm := le_of_lt h_norm_pos
+  have h_norm_finite : norm < ∞ := by
+    rw [show norm = μS Set.univ from rfl, ← sum_measure_singleton μS]
+    exact ENNReal.sum_lt_top (fun s _ ↦ h_finite s)
+  have h_invinvnorm_finite : norm⁻¹⁻¹ ≠ ∞ := by
+    rw [inv_inv]
+    exact LT.lt.ne_top h_norm_finite
+  have h_invnorm_ne_zero : norm⁻¹ ≠ 0 := ENNReal.inv_ne_top.mp h_invinvnorm_finite
+  have h_invnorm_finite : norm⁻¹ ≠ ∞ := by
+    rw [← ENNReal.inv_ne_zero, inv_inv]
+    exact h_norm_ne_zero
+  have h_pdf_nonneg : ∀ s, 0 ≤ pdf s := fun s ↦ ENNReal.toReal_nonneg
+  have h_pdf_finite : ∀ s ∈ Finset.univ, pdf_nn s ≠ ⊤ :=
+    fun s _ ↦ ENNReal.mul_ne_top h_invnorm_finite (h_finite s)
+
+  have h_norm_cancel : norm * norm⁻¹ = 1 :=
+    ENNReal.mul_inv_cancel h_norm_ne_zero (LT.lt.ne_top h_norm_finite)
+  have h_pdf1 : (∑ s, pdf s) = 1 := by
+    rw [← ENNReal.toReal_sum h_pdf_finite, ← Finset.mul_sum,
+      sum_measure_singleton μS, mul_comm, h_norm_cancel]
+    exact ENNReal.one_toReal
+
+  let ⟨ s_max, hs, h_min ⟩ := Finset.exists_min_image S_nonzero neg_log_pdf h_nonempty
+  have h_pdf_s_max_pos : 0 < pdf s_max := by
+    rw [Finset.mem_filter] at hs
+    have h_nonzero : pdf s_max ≠ 0 := by
+      exact ENNReal.toReal_ne_zero.mpr ⟨ mul_ne_zero h_invnorm_ne_zero hs.2,
+        ENNReal.mul_ne_top h_invnorm_finite (h_finite s_max) ⟩
+    exact LE.le.lt_of_ne (h_pdf_nonneg s_max) (Ne.symm h_nonzero)
+
+  have h_ineq : μs s_max ≥ (μ Set.univ) * (rexp (-H[X ; μ])).toNNReal := by
+    rw [← h_norm, ← one_mul (μs s_max), ← h_norm_cancel, mul_assoc]
+    apply mul_le_mul_of_nonneg_left _ h_norm_nonneg
+    suffices pdf s_max ≥ rexp (-H[X ; μ]) by
+      show ENNReal.ofReal (rexp (-H[X ; μ])) ≤ pdf_nn s_max
+      rw [ENNReal.ofReal_le_iff_le_toReal (h_pdf_finite s_max (Fintype.complete s_max))]
+      exact this
+    rw [← Real.exp_log h_pdf_s_max_pos]
+    apply exp_monotone
+    rw [neg_le, show -log (pdf s_max) = neg_log_pdf s_max from rfl,
+      ← one_mul (neg_log_pdf s_max), ← h_pdf1, Finset.sum_mul]
+    let g_lhs x := (norm⁻¹ * x).toReal * neg_log_pdf s_max
+    have h_lhs : g_lhs 0 = 0 := by simp
+    let g_rhs x := -(norm⁻¹ * x).toReal * log (norm⁻¹ * x).toReal
+    have h_rhs : g_rhs 0 = 0 := by simp
+    show ∑ s, (g_lhs ∘ μs) s ≤ ∑ s, (g_rhs ∘ μs) s
+    rw [Fintype.sum_eq_sum_nonzero_comp h_lhs, Fintype.sum_eq_sum_nonzero_comp h_rhs]
+    apply Finset.sum_le_sum
+    intros s h_s
+    show pdf s * neg_log_pdf s_max ≤ (-pdf s) * log (pdf s)
+    rw [neg_mul_comm, show -log (pdf s) = neg_log_pdf s from rfl]
+    exact mul_le_mul_of_nonneg_left (h_min s h_s) (h_pdf_nonneg s)
+  exact ⟨ s_max, h_ineq ⟩
 
 /-- If $X$ is an $S$-valued random variable, then there exists $s \in S$ such that
 $P[X=s] \geq \exp(-H[X])$. -/
 lemma prob_ge_exp_neg_entropy' {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
-    [IsProbabilityMeasure μ] [Fintype S] (X : Ω → S) :
-    ∃ s : S, rexp (- H[X ; μ]) ≤ μ.real (X ⁻¹' {s}) := by sorry
+    [IsProbabilityMeasure μ] [Fintype S] (X : Ω → S) (hX : Measurable X) :
+    ∃ s : S, rexp (- H[X ; μ]) ≤ μ.real (X ⁻¹' {s}) := by
+  obtain ⟨s, hs⟩ := prob_ge_exp_neg_entropy X μ hX
+  use s
+  haveI : IsProbabilityMeasure (μ.map X) := isProbabilityMeasure_map hX.aemeasurable
+  rwa [IsProbabilityMeasure.measure_univ, one_mul, ge_iff_le,
+    (show ENNReal.ofNNReal (toNNReal (rexp (-H[X; μ]))) = ENNReal.ofReal (rexp (-H[X; μ])) from rfl),
+    ENNReal.ofReal_le_iff_le_toReal (measure_ne_top _ _), ←MeasureTheory.Measure.real,
+    map_measureReal_apply hX (MeasurableSet.singleton s)] at hs
 
 /-- The pair of two random variables -/
 abbrev prod {Ω S T : Type*} ( X : Ω → S ) ( Y : Ω → T ) (ω : Ω) : S × T := (X ω, Y ω)

--- a/PFR/main.lean
+++ b/PFR/main.lean
@@ -179,7 +179,7 @@ theorem PFR_conjecture_aux {G : Type*} [AddCommGroup G] [ElementaryAddCommGroup 
     linarith
   -- therefore, there exists a point `x₀` which is attained by `VA - VH` with a large probability
   obtain ⟨x₀, h₀⟩ : ∃ x₀ : G, rexp (- H[VA - VH]) ≤ (ℙ : Measure Ω).real ((VA - VH) ⁻¹' {x₀}) :=
-    prob_ge_exp_neg_entropy' _
+    prob_ge_exp_neg_entropy' _ ((VAmeas.sub VHmeas).comp measurable_id')
   -- massage the previous inequality to get that `A ∩ (H + {x₀})` is large
   have J : K ^ (-11/2) * (Nat.card A) ^ (1/2) * (Nat.card (H : Set G)) ^ (1/2) ≤
       Nat.card (A ∩ (H + {x₀}) : Set G) := by

--- a/blueprint/src/chapter/entropy.tex
+++ b/blueprint/src/chapter/entropy.tex
@@ -71,6 +71,7 @@ Random variables in this paper are measurable maps $X : \Omega \to S$ from a pro
 \end{lemma}
 
 \begin{proof}
+  \leanok
   We have
   $$ \bbH[X] = \sum_{s \in S} \bbP[X=s] \log \frac{1}{\bbP[X=s]} \geq \min_{s \in S} \log \frac{1}{\bbP[X=s]}$$
   and the claim follows.


### PR DESCRIPTION
Joint work with @Paul-Lez and Jonas Bayer. In particular, `prob_ge_exp_neg_entropy'` is due to @Paul-Lez.

Co-authored-by: Paul Lezeau <paul.lezeau@gmail.com>
Co-authored-by: Jonas Bayer <jonas.bayer@fu-berlin.de>