### PR TITLE
Check for broken references in blueprint to Lean declarations

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -3,11 +3,14 @@ import shutil
 import subprocess
 from pathlib import Path
 from invoke import run, task
+import json
+import re
 
 from blueprint.tasks import web, bp, print_bp, serve
 
 ROOT = Path(__file__).parent
 BP_DIR = ROOT/'blueprint'
+PROJ = 'PFR'
 
 @task(bp, web)
 def all(ctx):
@@ -48,3 +51,41 @@ def dev(ctx):
                 '.*\.synctex.*$',
             )
         ))
+
+@task
+def check(ctx):
+    """
+    Check for broken references in blueprint to Lean declarations
+    """
+
+    broken_decls = []
+
+    DECLS_FILE = ROOT/'.lake/build/doc/declarations/declaration-data.bmp'
+    if not DECLS_FILE.exists():
+        print('[ERROR] Declarations file not found. Please run `lake -Kenv=dev build %s:docs` first.' % PROJ)
+        exit(1)
+
+    DEP_GRAPH_FILE = BP_DIR/'web/dep_graph_document.html'
+    if not DEP_GRAPH_FILE.exists():
+        print('[ERROR] Dependency graph file not found. Please run `inv all` (or only `inv web`) first.')
+        exit(1)
+
+    with open(DECLS_FILE) as f:
+        lean_decls = json.load(f)['declarations']
+
+    with open(DEP_GRAPH_FILE) as f:
+        lean_decl_regex = re.compile(r'lean_decl.*href=".*/find/#doc/([^"]+)"')
+        for line in f:
+            match = lean_decl_regex.search(line)
+            if match and match.lastindex == 1:
+                blueprint_decl = match[1]
+                if blueprint_decl not in lean_decls:
+                    broken_decls.append(blueprint_decl)
+
+    if broken_decls:
+        print('[WARN] The following Lean declarations are referenced in the blueprint but not in Lean:\n')
+        for decl in broken_decls:
+            print(decl)
+        exit(1)
+    else:
+        print('[OK] All Lean declarations referenced in the blueprint exist.')


### PR DESCRIPTION
This PR implements a new task `inv check` which can be run in CI or locally to check for broken references in blueprint to Lean declarations as discussed on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/412902-Polynomial-Freiman-Ruzsa-conjecture/topic/blueprint.20docs.20404).

Non-ideal side of this `inv check`:

1. It's not an ideal design, as it's implemented on the user side in formalization projects but not in `leanblueprint` itself. But this is a common issue of the blueprint ecosystem, namely every project is using a slightly different setup with a few loosely coupled building blocks, in Python, in Github Actions workflows, in LaTeX etc. Moving them into `leanblueprint` is something up to discussion but at least for me, keeping multiple projects running OK and fixing usability issues separately has become quite some overhead (which eats my spare time for writing actual Lean code).
2. It assumes `lake -Kenv=dev build PFR:docs` and `inv all`(at least `inv web`) are run. This is satisfied in CI but takes a while for local testing.
3. For simpler implementation, it makes use of the fact that `dep_graph_document.html` is generated with fixed format and in a line-based manner thus much simpler to handle. This is a simple trick so that the core of the implementation is even shorter than the paragraphs here but of course it should reuse what's available to `leanblueprint` before generating the dot graph and the html, but it takes more time to land this feature in `leanblueprint` than the time PFR finishes formalization.

That said, this `inv check` works as expected and has some safeguards in it, so it's useful and robust enough.

`inv check` currently reports the following issues that need to be fixed in blueprint:

```lean
[WARN] The following Lean declarations are referenced in the blueprint but not in Lean:

ent_of_cond_indep -- incomplete, should be a full `ProbabilityTheory.ent_of_cond_indep`
construct_good-prelim -- dash issue, should be `construct_good_prelim`
IdentDistrib.entropy_eq -- incomplete, should be a full `ProbabilityTheory.IdentDistrib.entropy_eq`
eta -- incorrect, should be `η`
tau_min_exists -- spell issue, seems to be `tau_minimizer_exists`
IsUniform.entropy_eq -- incomplete, should be `ProbabilityTheory.IsUniform.entropy_eq`
ProbabilityTheory.entropy_of_uniform -- missing
```

Before fixing them, merging this PR and adding this to CI will fail the CI.