### PR TITLE
Remove the ad hoc lemma sub_eq_add_rv

### DIFF
--- a/PFR/f2_vec.lean
+++ b/PFR/f2_vec.lean
@@ -63,4 +63,80 @@ lemma sum_add_sum_eq_sum ( x y z : G ) : (x + y) + (y + z) = x + z := by
 lemma sum_add_sum_add_sum_eq_zero ( x y z : G ) : (x + y) + (y + z) + (z + x) = 0 := by
   rw [sum_add_sum_eq_sum, add_comm x z, add_self]
 
+open Function
+
+@[simp] lemma char_smul_eq_zero {Γ : Type*} [AddCommGroup Γ] [ElementaryAddCommGroup Γ p] (x : Γ) :
+    p • x = 0 := by
+  by_cases hx : x = 0
+  · simp only [hx, smul_zero]
+  · have obs := ElementaryAddCommGroup.orderOf_of_ne hx
+    rw [addOrderOf] at obs
+    simpa only [obs, add_left_iterate, add_zero] using
+      iterate_minimalPeriod (f := fun z ↦ x + z) (x := 0)
+
+lemma char_ne_one_of_nonzero {Γ : Type*} [AddCommGroup Γ] [ElementaryAddCommGroup Γ p] {x : Γ}
+    (x_ne_zero : x ≠ 0) : p ≠ 1 := by
+  have obs := ElementaryAddCommGroup.orderOf_of_ne x_ne_zero
+  rw [addOrderOf] at obs
+  by_contra maybe_one
+  apply x_ne_zero
+  simpa only [obs, maybe_one, iterate_succ, iterate_zero, comp_apply, add_zero, id_eq] using
+    iterate_minimalPeriod (f := fun z ↦ x + z) (x := 0)
+
+lemma two_le_char_of_nonzero {Γ : Type*} [NeZero p] [AddCommGroup Γ] [ElementaryAddCommGroup Γ p] {x : Γ}
+    (x_ne_zero : x ≠ 0) : 2 ≤ p := by
+  by_contra maybe_small
+  have p_le_one : p ≤ 1 := by linarith
+  rcases Nat.le_one_iff_eq_zero_or_eq_one.mp p_le_one with hp|hp
+  · simp_all only [neZero_zero_iff_false]
+  · exact char_ne_one_of_nonzero x_ne_zero hp
+
+lemma mem_periodicPts_of_nonzero {Γ : Type*} [NeZero p] [AddCommGroup Γ] [ElementaryAddCommGroup Γ p]
+    {x : Γ} (x_ne_zero : x ≠ 0) (y : Γ) :
+    y ∈ periodicPts (fun z ↦ x + z) := by
+  have obs := ElementaryAddCommGroup.orderOf_of_ne x_ne_zero
+  rw [addOrderOf] at obs
+  rw [periodicPts]
+  simp_rw [IsPeriodicPt]
+  simp only [gt_iff_lt, add_left_iterate, Set.mem_setOf_eq]
+  existsi p
+  refine ⟨Fin.size_pos', by simp [IsFixedPt]⟩
+
+open Nat in
+instance (Ω Γ : Type*) (p : ℕ) [NeZero p] [AddCommGroup Γ] [ElementaryAddCommGroup Γ p] :
+    ElementaryAddCommGroup (Ω → Γ) p where
+  orderOf_of_ne := by
+    intro f f_ne_zero
+    have iter_p : (fun x ↦ f + x)^[p] 0 = 0 := by
+      ext ω
+      simp
+    have no_less : ∀ n, 0 < n → n < p → (fun x ↦ f + x)^[n] 0 ≠ 0 := by
+      intro n n_pos n_lt_p
+      apply ne_iff.mpr
+      obtain ⟨ω, hfω⟩ := show ∃ ω, f ω ≠ 0 from ne_iff.mp f_ne_zero
+      existsi ω
+      have obs := ElementaryAddCommGroup.orderOf_of_ne hfω
+      rw [addOrderOf] at obs
+      by_contra con
+      apply not_isPeriodicPt_of_pos_of_lt_minimalPeriod (f := fun x ↦ f ω + x) (x := 0)
+              n_pos.ne.symm (by simpa only [obs] using n_lt_p)
+      simp_rw [IsPeriodicPt, IsFixedPt]
+      convert con
+      simp
+    rw [addOrderOf, minimalPeriod]
+    have mem_pPts : 0 ∈ periodicPts (fun g ↦ f + g) := by
+      rw [periodicPts]
+      existsi p
+      rw [IsPeriodicPt, IsFixedPt]
+      refine ⟨Fin.size_pos', ?_⟩
+      ext ω
+      simp
+    simp only [mem_pPts, gt_iff_lt, dite_true]
+    classical
+    rw [find_eq_iff]
+    refine ⟨⟨Fin.size_pos', iter_p⟩, ?_⟩
+    intro n n_lt_p
+    by_contra con
+    exact no_less n con.1 n_lt_p con.2
+
 end ElementaryAddCommGroup

--- a/PFR/first_estimate.lean
+++ b/PFR/first_estimate.lean
@@ -132,20 +132,6 @@ lemma first_estimate : I₁ ≤ 2 * η * k := by
   simp only [η, inv_eq_one_div] at *
   linarith [v1, v2, v3, v4, v5, v6, v7]
 
--- This is ad hoc. The better approach would be to fill in the instance below:
--- `ElementaryAddCommGroup (Ω → G) 2`
-lemma sub_eq_add_rv {Ω : Type*} (X Y : Ω → G) : X + Y = X - Y := by
-  ext ω
-  simp only [Pi.add_apply, Pi.sub_apply, ElementaryAddCommGroup.sub_eq_add]
-
-/-
-instance (Ω Γ : Type*) (p : ℕ) [NeZero p] [AddCommGroup Γ] [ElementaryAddCommGroup Γ p] :
-    ElementaryAddCommGroup (Ω → Γ) p where
-  orderOf_of_ne := by
-    intro f f_ne_zero
-    sorry
- -/
-
 /--
 $$H[X_1+X_2+\tilde X_1+\tilde X_2] \le \tfrac{1}{2} H[X_1]+\tfrac{1}{2} H[X_2] + (2 + \eta) k - I_1.$$
 -/
@@ -190,7 +176,7 @@ lemma ent_ofsum_le : H[X₁ + X₂ + X₁' + X₂'] ≤ H[X₁]/2 + H[X₂]/2 + 
           IdentDistrib.rdist_eq (IdentDistrib.refl hX₁.aemeasurable) h₂
         rw [k_eq_aux]
         exact IndepFun.rdist_eq (h_indep.indepFun (show (0 : Fin 4) ≠ 2 by decide)) hX₁ hX₂'
-      rw [k_eq, ←sub_eq_add_rv, ←HX₂_eq]
+      rw [k_eq, ←ElementaryAddCommGroup.sub_eq_add, ←HX₂_eq]
       ring
     have rw₃ : H[X₂ + X₁'] = k + H[X₁]/2 + H[X₂]/2 := by
       have HX₁_eq : H[X₁] = H[X₁'] :=
@@ -200,7 +186,7 @@ lemma ent_ofsum_le : H[X₁ + X₂ + X₁' + X₂'] ≤ H[X₁]/2 + H[X₂]/2 + 
           IdentDistrib.rdist_eq h₁ (IdentDistrib.refl hX₂.aemeasurable)
         rw [k_eq_aux]
         exact IndepFun.rdist_eq (h_indep.indepFun (show (3 : Fin 4) ≠ 1 by decide)) hX₁' hX₂
-      rw [add_comm X₂ X₁', k_eq', ←sub_eq_add_rv, ←HX₁_eq]
+      rw [add_comm X₂ X₁', k_eq', ←ElementaryAddCommGroup.sub_eq_add, ←HX₁_eq]
       ring
     rw [rw₂, rw₃, add_halves]
     apply le_of_eq


### PR DESCRIPTION
Remove the ad hoc lemma `sub_eq_add_rv` by providing an instance of `ElementaryAddCommGroup` for random variables with values in one.

This approach is longer, but it seems more principled, and probably more generally useful. (I also added a couple of first lemmas about general characteristic `ElementaryAddCommGroup`s along the way, although the proofs are not very pretty.)