### PR TITLE
some cleanup

### DIFF
--- a/PFR/endgame.lean
+++ b/PFR/endgame.lean
@@ -173,10 +173,7 @@ lemma sum_dist_diff_le :
 
 /-- $U+V+W=0$. -/
 lemma sum_uvw_eq_zero : U+V+W = 0 := by
-  funext ω
-  dsimp
-  rw [add_comm (X₁' ω) (X₂ ω)]
-  exact @ElementaryAddCommGroup.sum_add_sum_add_sum_eq_zero G addgroup elem _ _ _
+  rw [add_comm X₁' X₂, ElementaryAddCommGroup.sum_add_sum_add_sum_eq_zero]
 
 section construct_good
 variable {Ω' : Type u} [MeasureSpace Ω'] [IsProbabilityMeasure (ℙ : Measure Ω')]
@@ -210,10 +207,10 @@ lemma construct_good_prelim :
   have hη : 0 ≤ η := by norm_num [η]
   have hP : IsProbabilityMeasure (Measure.map T₃ ℙ) := isProbabilityMeasure_map hT₃.aemeasurable
   have h2T₃ : T₃ = T₁ + T₂
-  · calc T₃ = T₁ + T₂ + T₃ - T₃ := by rw [hT, zero_sub]; ext x; simp
+  · calc T₃ = T₁ + T₂ + T₃ - T₃ := by rw [hT, zero_sub]; simp
       _ = T₁ + T₂ := by rw [add_sub_cancel]
-  have h2T₁ : T₁ = T₂ + T₃ := by ext; simp [h2T₃, add_left_comm]
-  have h2T₂ : T₂ = T₃ + T₁ := by ext; simp [h2T₁, add_left_comm]
+  have h2T₁ : T₁ = T₂ + T₃ := by simp [h2T₃, add_left_comm]
+  have h2T₂ : T₂ = T₃ + T₁ := by simp [h2T₁, add_left_comm]
 
   have h1 : sum1 ≤ δ
   · have h1 : sum1 ≤ 3 * I[T₁ : T₂] + 2 * H[T₃] - H[T₁] - H[T₂] := ent_bsg hT₁ hT₂ h2T₃

--- a/PFR/f2_vec.lean
+++ b/PFR/f2_vec.lean
@@ -144,8 +144,6 @@ instance (Ω Γ : Type*) (p : ℕ) [NeZero p] [AddCommGroup Γ] [ElementaryAddCo
     by_contra con
     exact no_less n con.1 n_lt_p con.2
 
-lemma pi.sub_eq_add {ι} ( x y : ι → G ) : x - y = x + y := by simp
-
 lemma Int.mod_eq (n m : ℤ) : n % m = n - (n / m) * m := by
   rw [eq_sub_iff_add_eq, add_comm, Int.ediv_add_emod']
 

--- a/PFR/fibring.lean
+++ b/PFR/fibring.lean
@@ -186,6 +186,4 @@ lemma sum_of_rdist_eq_char_2
       = d[ (Y 0) + (Y 2); μ # (Y 1) + (Y 3); μ]
         + d[ Y 0 | (Y 0) + (Y 2); μ # Y 1 | (Y 1) + (Y 3); μ]
         + I[ (Y 0) + (Y 1) : (Y 1) + (Y 3) | (Y 0) + (Y 1) + (Y 2) + (Y 3); μ] := by
-  have h := sum_of_rdist_eq Y h_indep h_meas
-  simp only [ElementaryAddCommGroup.pi.sub_eq_add] at h
-  exact h
+  simpa using sum_of_rdist_eq Y h_indep h_meas

--- a/PFR/main.lean
+++ b/PFR/main.lean
@@ -292,11 +292,12 @@ theorem PFR_conjecture (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K * Nat.c
 /-- Corollary of `PFR_conjecture` in which the ambient group is not required to be finite (but) then
 $H$ and $c$ are finite. -/
 theorem PFR_conjecture' {G : Type*} [AddCommGroup G] [ElementaryAddCommGroup G 2]
-    [MeasurableSpace G] [MeasurableSingletonClass G]
     {A : Set G} {K : ℝ} (h₀A : A.Nonempty) (Afin : A.Finite)
     (hA : Nat.card (A + A) ≤ K * Nat.card A) :
     ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
       Nat.card c < 2 * K ^ 12 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  let mG : MeasurableSpace G := ⊤
+  have : MeasurableSingletonClass G := ⟨λ _ ↦ trivial⟩
   let G' := AddSubgroup.closure A
   let G'fin : Fintype G' := by
     exact Finite.fintype (ElementaryAddCommGroup.finite_closure Afin)

--- a/PFR/ruzsa_distance.lean
+++ b/PFR/ruzsa_distance.lean
@@ -174,7 +174,7 @@ lemma ent_of_indep_diff_lower  {X : Ω → G} {Y : Ω → G} (hX : Measurable X)
   have : IndepFun X (-Y) μ := h.comp measurable_id measurable_neg
   convert ent_of_indep_sum_lower hX hY.neg this using 2
   · exact (entropy_neg hY).symm
-  · ext x ; simp [sub_eq_add_neg]
+  · simp [sub_eq_add_neg]
 
 /-- The Ruzsa distance `rdist X Y` or $d[X;Y]$ between two random variables is defined as
 $H[X'-Y'] - H[X']/2 - H[Y']/2$, where $X', Y'$ are independent copies of $X, Y$. -/
@@ -857,7 +857,7 @@ lemma comparison_of_ruzsa_distances [IsProbabilityMeasure μ] [IsProbabilityMeas
   constructor
   · linarith [kaimanovich_vershik' hi hX' hY' hZ']
   · intro hG
-    rw [ElementaryAddCommGroup.pi.sub_eq_add Y' Z']
+    rw [ElementaryAddCommGroup.sub_eq_add Y' Z']
     ring
 
 variable (μ) in

--- a/PFR/ruzsa_distance.lean
+++ b/PFR/ruzsa_distance.lean
@@ -174,7 +174,7 @@ lemma ent_of_indep_diff_lower  {X : Ω → G} {Y : Ω → G} (hX : Measurable X)
   have : IndepFun X (-Y) μ := h.comp measurable_id measurable_neg
   convert ent_of_indep_sum_lower hX hY.neg this using 2
   · exact (entropy_neg hY).symm
-  · simp [sub_eq_add_neg]
+  · ext; simp [sub_eq_add_neg]
 
 /-- The Ruzsa distance `rdist X Y` or $d[X;Y]$ between two random variables is defined as
 $H[X'-Y'] - H[X']/2 - H[Y']/2$, where $X', Y'$ are independent copies of $X, Y$. -/

--- a/PFR/second_estimate.lean
+++ b/PFR/second_estimate.lean
@@ -15,7 +15,7 @@ Assumptions:
 
 ## Main results
 
-* `second_estimate` : $$ I_2 \leq 2 \eta k + \frac{2 \eta (2 \eta k - I_1)}{1 - \eta}.$$ 
+* `second_estimate` : $$ I_2 \leq 2 \eta k + \frac{2 \eta (2 \eta k - I_1)}{1 - \eta}.$$
 -/
 
 open MeasureTheory ProbabilityTheory ElementaryAddCommGroup
@@ -96,13 +96,13 @@ lemma second_estimate : I₂ ≤ 2 * η * k + (2 * η * (2 * η * k - I₁)) / (
   refine' h''.trans (mul_le_mul_of_nonneg_left _ (show 0 ≤ η by rw [η]; positivity))
   have h : d[X₁ + X₁' # X₂+ X₂'] ≤ (2 + η) * k - (d[X₁# X₁] + d[X₂ # X₂]) / 2 - I₁ := by
     have h := hX_indep.rdist_eq (hX₁.add hX₁') (hX₂.add hX₂')
-    rw [pi.sub_eq_add (X₁ + X₁') (X₂ + X₂'), ← pi.sub_eq_add X₁ X₁', ← pi.sub_eq_add X₂ X₂',
+    rw [sub_eq_add (X₁ + X₁') (X₂ + X₂'), ← sub_eq_add X₁ X₁', ← sub_eq_add X₂ X₂',
       sub_eq_iff_eq_add.mp (sub_eq_iff_eq_add.mp (hX₁_indep.rdist_eq hX₁ hX₁').symm),
       sub_eq_iff_eq_add.mp (sub_eq_iff_eq_add.mp (hX₂_indep.rdist_eq hX₂ hX₂').symm),
       ← h₁.entropy_eq, ← h₂.entropy_eq, add_assoc, add_assoc, add_halves', add_halves',
       ← (IdentDistrib.refl hX₁.aemeasurable).rdist_eq h₁,
       ← (IdentDistrib.refl hX₂.aemeasurable).rdist_eq h₂,
-      pi.sub_eq_add X₁ X₁', pi.sub_eq_add X₂ X₂', ← add_assoc, add_right_comm _ X₁'] at h
+      sub_eq_add X₁ X₁', sub_eq_add X₂ X₂', ← add_assoc, add_right_comm _ X₁'] at h
     have h_indep' : iIndepFun (fun _i => hG) ![X₁, X₂, X₂', X₁'] := by
       let σ : Fin 4 ≃ Fin 4 := { toFun := ![0, 1, 3, 2], invFun := ![0, 1, 3, 2], left_inv := by intro i; fin_cases i <;> rfl, right_inv := by intro i; fin_cases i <;> rfl }
       refine' iIndepFun.reindex σ.symm _; convert h_indep using 1; ext i; fin_cases i <;> rfl


### PR DESCRIPTION
* Use the `ElementaryAddCommGroup` instance on functions to simplify some proofs. In particular, `pi.sub_eq_add` is now just `sub_eq_add`.
* In the corollary `PFR_conjecture'`, remove the hypotheses that `G` must be equipped with a sigma-algebra, since that is not used in the statement of the theorem.