### PR TITLE
remove measurable space condition earlier

### DIFF
--- a/PFR/main.lean
+++ b/PFR/main.lean
@@ -141,6 +141,8 @@ lemma PFR_conjecture_aux (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K * Nat
     Nat.card c ≤ K ^ (13/2) * (Nat.card A) ^ (1/2) * (Nat.card (H : Set G)) ^ (-1/2)
       ∧ Nat.card H ≤ K ^ 11 * Nat.card A ∧ Nat.card A ≤ K ^ 11 * Nat.card H ∧ A ⊆ c + H := by
   classical
+  let mG : MeasurableSpace G := ⊤
+  have : MeasurableSingletonClass G := ⟨λ _ ↦ trivial⟩
   obtain ⟨A_pos, -, K_pos⟩ : (0 : ℝ) < Nat.card A ∧ (0 : ℝ) < Nat.card (A + A) ∧ 0 < K :=
     PFR_conjecture_pos_aux h₀A hA
   rcases exists_isUniform_measureSpace A h₀A with ⟨Ω₀, mΩ₀, UA, hP₀, UAmeas, UAunif, -⟩
@@ -296,8 +298,6 @@ theorem PFR_conjecture' {G : Type*} [AddCommGroup G] [ElementaryAddCommGroup G 2
     (hA : Nat.card (A + A) ≤ K * Nat.card A) :
     ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
       Nat.card c < 2 * K ^ 12 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
-  let mG : MeasurableSpace G := ⊤
-  have : MeasurableSingletonClass G := ⟨λ _ ↦ trivial⟩
   let G' := AddSubgroup.closure A
   let G'fin : Fintype G' := by
     exact Finite.fintype (ElementaryAddCommGroup.finite_closure Afin)


### PR DESCRIPTION
This PR ensures that `PFR_conjecture` and `PFR_conjecture_aux` already don't have the `MeasurableSpace G` argument.