### PR TITLE
Fix Mathlib search

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,9 +51,10 @@ jobs:
             .lake/build/doc/Lean
             .lake/build/doc/Std
             .lake/build/doc/Mathlib
-          key: DocGen4-${{ hashFiles('lake-manifest.json') }}
+            .lake/build/doc/declarations
+          key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
-            DocGen4-
+            MathlibDoc-
 
       - name: Build documentation
         run: ~/.elan/bin/lake -Kenv=dev build PFR:docs


### PR DESCRIPTION
As reported by @YaelDillies, searching Mathlib defs/lemmas is not working on the PFR docs:

![image](https://github.com/teorth/pfr/assets/64258/ab7ca9a4-2b80-4958-927c-1c3f20da51b5)

while the doc actually exists: https://teorth.github.io/pfr/docs/Mathlib/Algebra/Group/Basic.html#sub_add_comm 

The cause:

Mathlib doc is included in the generated docs (from cache), but the cache stops doc-gen4 from regenerating the Mathlib docs and declarations (which are not cached at all due to me), causing all Mathlib declarations to not be included in the final website, so people can only search PFR defs/lemmas.

This PR fixes the issue by:

- Adding `.lake/build/doc/declarations` to cache, which should include all declaration for the search function to work
- Invalidating the current incomplete cache, by changing the cache prefix

The expected result:

1. Merging this PR into master would be a longer CI (because it would rebuild Mathlib doc), and the search of Mathlib should be working
2. The next commit to master should be a shorter CI (because it benefits from the cache), and the search if Mathlib would still be working 

Can you help making 2 happen after 1 finishes, to verify 2? @YaelDillies 