### PR TITLE
refactor(homomorphism): upstream logic to LinearAlgebra

### DIFF
--- a/PFR/Homomorphism.lean
+++ b/PFR/Homomorphism.lean
@@ -1,24 +1,20 @@
 import PFR.ForMathlib.Graph
 import PFR.Main
 import Mathlib.Data.Set.Card
+import PFR.Mathlib.LinearAlgebra.Basis.VectorSpace
 
 open Pointwise
 
-variable {G G' : Type*} [AddCommGroup G] [ElementaryAddCommGroup G 2] [Fintype G] [AddCommGroup G'] [ElementaryAddCommGroup G' 2] [Fintype G']
+variable {G G' : Type*} [AddCommGroup G] [Fintype G] [AddCommGroup G'] [Fintype G']
+  [ElementaryAddCommGroup G 2] [ElementaryAddCommGroup G' 2]
 
 /-- Let $H_0$ be a subgroup of $G$.  Then every homomorphism $\phi: H_0 \to G'$ can be extended to a homomorphism $\tilde \phi: G \to G'$. -/
 lemma hahn_banach (H₀ : AddSubgroup G) (φ : H₀ →+ G') : ∃ (φ' : G →+ G'), ∀ x : H₀, φ x = φ' x := by
-  haveI : ElementaryAddCommGroup H₀ 2 := ElementaryAddCommGroup.subgroup _
-  let ι := ElementaryAddCommGroup.linearMap H₀.subtype
-  have hι : Function.Injective ι :=
-    show Function.Injective H₀.subtype from AddSubgroup.subtype_injective H₀
-  have : LinearMap.ker ι = ⊥ := by exact LinearMap.ker_eq_bot.mpr hι
-  obtain ⟨g,hg⟩ := LinearMap.exists_leftInverse_of_injective ι this
-  use φ.comp g.toAddMonoidHom
-  intro x
-  show φ x = φ ((g.comp ι) x)
-  rw [hg]
-  rfl
+  let H₀ : Submodule (ZMod 2) G := H₀
+  let φ : H₀ →+ G' := φ
+  let φ : H₀ →ₗ[ZMod 2] G' := φ
+  obtain ⟨ φ', hφ' ⟩ := φ.exists_extend
+  use φ'; intro x; show φ x = φ'.comp H₀.subtype x; rw [hφ']
 
 /-- Let $H$ be a subgroup of $G \times G'$.  Then there exists a subgroup $H_0$ of $G$, a subgroup $H_1$ of $G'$, and a homomorphism $\phi: G \to G'$ such that
 $$ H := \{ (x, \phi(x) + y): x \in H_0, y \in H_1 \}.$$
@@ -26,76 +22,16 @@ In particular, $|H| = |H_0| |H_1|$. -/
 lemma goursat (H : AddSubgroup (G × G')): ∃ (H₀ : AddSubgroup G) (H₁ : AddSubgroup G') (φ : G →+ G'),
     (∀ x : G × G', x ∈ H ↔ (x.1 ∈ H₀ ∧ x.2 - φ x.1 ∈ H₁)) ∧
     (Nat.card H) = (Nat.card H₀) * (Nat.card H₁) := by
-  let π₁ := AddMonoidHom.fst G G'
-  let π₂ := AddMonoidHom.snd G G'
-  let p₁ := AddMonoidHom.addSubgroupMap π₁ H
-  let p₂ := AddMonoidHom.addSubgroupMap π₂ (H ⊓ π₁.ker)
-  let H₀ := AddSubgroup.map π₁ H
-  let H₁ := AddSubgroup.map π₂ (H ⊓ π₁.ker)
-  have : ElementaryAddCommGroup H 2 := ElementaryAddCommGroup.subgroup H
-  have : ElementaryAddCommGroup H₀ 2 := ElementaryAddCommGroup.subgroup H₀
-  let p₁' := ElementaryAddCommGroup.linearMap p₁
-  obtain ⟨ φ', hφ' ⟩ := LinearMap.exists_rightInverse_of_surjective p₁'
-    (LinearMap.range_eq_top.mpr (AddMonoidHom.addSubgroupMap_surjective π₁ H))
-  obtain ⟨ φ, hφ ⟩ := hahn_banach H₀ ((π₂.restrict H).comp φ'.toAddMonoidHom)
-
-  let bij (x : H) : G × G' := (x.val.1, x.val.2 - φ x.val.1)
-  let bij_inv (x : H₀ × H₁) : G × G' := (x.1.val, φ x.1.val + x.2.val)
-  have h_bij' : ∀ x : G × G', x ∈ H ↔ (x.1 ∈ H₀ ∧ x.2 - φ x.1 ∈ H₁) := by
-    intro x
-    constructor
-
-    intro hx
-    let x₁ : H₀ := ⟨ x.1, AddSubgroup.mem_map_of_mem π₁ hx ⟩
-    let x₂ : H := { val := x, property := hx } - (φ' x₁)
-    have h_ker : x₂.val ∈ π₁.ker := by
-      show π₁ x - p₁'.comp φ' x₁ = 0
-      rw [sub_eq_zero, hφ', show LinearMap.id x₁ = π₁ x from rfl]
-    constructor
-    exact AddSubgroup.mem_map_of_mem (K := H) π₁ hx
-    rw [← hφ x₁]
-    exact AddSubgroup.mem_map_of_mem (K := H ⊓ π₁.ker) π₂ (Set.mem_inter x₂.property h_ker)
-
-    intro hx
-    let x₁ : H₀ := ⟨ x.1, hx.left ⟩
-    let x₂ : H₁ := ⟨ x.2 - φ x₁, hx.right ⟩
-    let xₗ : H := φ' x₁
-    let xᵣ : G × G' := (0, x₂.val)
-    have hxₗ : xₗ.val = (x.1, φ x₁) := by
-      have hx₁ : xₗ.val.1 = x.1 := by
-        rw [show xₗ.val.1 = p₁'.comp φ' x₁ from rfl, hφ', show LinearMap.id x₁ = x.1 from rfl]
-      exact Prod.ext hx₁ (hφ x₁)
-    have hxᵣ : xᵣ ∈ H := by
-      obtain ⟨ g, hg ⟩ := Set.Nonempty.preimage (Set.singleton_nonempty x₂)
-        (AddMonoidHom.addSubgroupMap_surjective π₂ (H ⊓ π₁.ker))
-      have h_ker : g.val ∈ H ∧ g.val ∈ π₁.ker := AddSubgroup.mem_inf.mp g.property
-      have hg₁ : g.val.1 = xᵣ.1 := (AddMonoidHom.mem_ker π₁).mp h_ker.right
-      have hg₂ : g.val.2 = xᵣ.2 := by { show (p₂ g).val = x₂.val ; rw [← hg] }
-      rw [← Prod.ext hg₁ hg₂]
-      exact h_ker.left
-    let xᵣ : H := ⟨ xᵣ, hxᵣ ⟩
-    have hx : x = xₗ.val + xᵣ.val := by
-      rw [hxₗ, show xᵣ = _ from rfl, Prod.mk_add_mk, add_zero, ← add_comm_sub, sub_self, zero_add]
-    rw [hx]
-    exact (xₗ + xᵣ).property
-
-  have h_bij_prop (x : H) : (bij x).1 ∈ H₀ ∧ (bij x).2 ∈ H₁ := (h_bij' x.val).mp x.property
-  let bij (x : H) : H₀ × H₁ := (⟨ (bij x).1, (h_bij_prop x).1 ⟩, ⟨ (bij x).2, (h_bij_prop x).2 ⟩)
-  have h_bij_inv_prop (x : H₀ × H₁) : bij_inv x ∈ H := (h_bij' (bij_inv x)).mpr
-    ⟨ x.1.property, by simp only [x.2.property, add_comm, add_sub_assoc, sub_self, add_zero] ⟩
-  let bij_inv (x : H₀ × H₁) : H := ⟨ bij_inv x, h_bij_inv_prop x ⟩
-  have h_leftinv : Function.LeftInverse bij_inv bij := fun _ ↦ by
-    simp_rw [← add_comm_sub, sub_self, zero_add]
-  have h_rightinv : Function.RightInverse bij_inv bij := fun _ ↦ by
-    simp_rw [add_comm, add_sub_assoc, sub_self, add_zero]
-  have h_bij : Function.Bijective bij :=
-    Function.bijective_iff_has_inverse.mpr ⟨ bij_inv, ⟨ h_leftinv, h_rightinv ⟩ ⟩
-
-  use H₀, H₁, φ
+  obtain ⟨ S₁, S₂, f, φ, ⟨ hf, hf_inv ⟩ ⟩ := (H.toSubmodule (n := 2)).equivProdSubmodule
+  use S₁.toAddSubgroup, S₂.toAddSubgroup, φ
   constructor
-  exact h_bij'
-  rw [Nat.card_eq_of_bijective bij h_bij, Nat.card_prod H₀ H₁]
-
+  · exact fun x ↦ ⟨
+      fun hx ↦ ⟨ Set.mem_of_eq_of_mem (hf ⟨ x, hx ⟩).1.symm (f ⟨ x, hx ⟩).1.property,
+        Set.mem_of_eq_of_mem (hf ⟨ x, hx ⟩).2.symm (f ⟨ x, hx ⟩).2.property ⟩,
+      fun hx ↦ Set.mem_of_eq_of_mem (by rw [hf_inv, sub_add_cancel])
+        (f.symm (⟨ x.1, hx.1 ⟩, ⟨ x.2 - φ x.1, hx.2 ⟩)).property ⟩
+  · have : Nat.card H = Nat.card (H.toSubmodule (n := 2)) := rfl
+    rw [this, Nat.card_eq_of_bijective f f.bijective, Nat.card_prod S₁ S₂] ; rfl
 
 /- TODO: Find an appropriate home for these lemmas -/
 lemma Nat.card_image_le {α β: Type*} {s : Set α} {f : α → β} (hs : s.Finite) :
@@ -114,7 +50,7 @@ lemma Nat.card_prod_singleton {α β : Type*} (A : Set α) (b : β) : Nat.card (
   · rw[Set.Infinite.card_eq_zero hA, Set.Infinite.card_eq_zero <| Set.Infinite.prod_left hA ⟨b,by rfl⟩]
 
 open Set Fintype in
--- variable [DecidableEq G] [DecidableEq G'] in
+
 /-- Let $f: G \to G'$ be a function, and let $S$ denote the set
 $$ S := \{ f(x+y)-f(x)-f(y): x,y \in G \}.$$
 Then there exists a homomorphism $\phi: G \to G'$ such that
@@ -133,49 +69,40 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS: ∀ x y : G, f (x+y) -
     rw [Set.mem_sub]
     refine ⟨(x.1, f x.1), (0, f (a.1 + a'.1) - f a.1 - f a'.1), ?_, ?_⟩
     · simp
-    · simp only [singleton_prod, mem_image, mem_neg,
-      Prod.mk.injEq, true_and, exists_eq_right, Prod.mk_sub_mk,
-      sub_zero]
-      constructor
-      · apply hS
-      rw [←Prod.fst_add, ha, ha', sub_sub, ←Prod.snd_add, haa', ←sub_add, sub_self, zero_add]
+    · simp only [singleton_prod, mem_image, Prod.mk.injEq, true_and,
+        exists_eq_right, Prod.mk_sub_mk, sub_zero]
+      exact ⟨ hS a.1 a'.1,
+        by rw [← Prod.fst_add, ha, ha', sub_sub, ← Prod.snd_add, haa', sub_sub_self] ⟩
 
   have hB_card : Nat.card B ≤ Nat.card S * Nat.card A
-  · rw [mul_comm]
-    simpa only [Nat.card_singleton_prod, Nat.card_neg] using (Nat.card_sub_le A ({0} ×ˢ S))
+  · simpa only [mul_comm, Nat.card_singleton_prod] using (Nat.card_sub_le A ({0} ×ˢ S))
 
   have hA_le : Nat.card ((A:Set (G×G'))+(A:Set (G×G'))) ≤ (Nat.card S:ℝ) * Nat.card A
   · norm_cast
     exact (Nat.card_mono (toFinite B) hAB).trans hB_card
 
-  have hA_nonempty : A.Nonempty
-  · use (0, f 0)
-    exact ⟨0, rfl⟩
+  have hA_nonempty : A.Nonempty := by use (0, f 0) ; exact ⟨0, rfl⟩
 
   obtain ⟨H, c, hcS, hHA, hAcH⟩ := PFR_conjecture hA_nonempty hA_le
   obtain ⟨H₀, H₁, φ, hH₀₁, hH_card⟩ := goursat H
 
   let c' := (Prod.fst) '' c
   have hc'_card : Nat.card c' ≤ Nat.card c := Nat.card_image_le (toFinite c)
-  have h_fstH : Prod.fst '' (H:Set (G × G')) = (H₀ : Set G)
+  have h_fstH : Prod.fst '' (H : Set (G × G')) = (H₀ : Set G)
   · ext x
     simp only [mem_image, SetLike.mem_coe, hH₀₁, Prod.exists,
       exists_and_right, exists_and_left, exists_eq_right, and_iff_left_iff_imp]
-    intro _
-    use φ x
-    simp[AddSubgroup.zero_mem]
+    exact fun _ ↦ ⟨ φ x, by simp only [sub_self, AddSubgroup.zero_mem] ⟩
 
   have hG_cover : (univ : Set G) = c' + (H₀:Set G)
   · ext g
     refine ⟨fun _ => ?_, fun _ => mem_univ _⟩
     have := image_subset Prod.fst hAcH
-    rw[←AddHom.coe_fst, Set.image_add] at this
-    simp_rw[AddHom.coe_fst, image_fst_graph] at this
-    rw[←h_fstH]
+    rw [← AddHom.coe_fst, Set.image_add, AddHom.coe_fst, image_fst_graph] at this
+    rw [← h_fstH]
     convert this (mem_univ g)
 
-  have hc'_card_real : Nat.card c' ≤ (Nat.card c:ℝ)
-  · norm_cast
+  have hc'_card_real : Nat.card c' ≤ (Nat.card c:ℝ) := by norm_cast
 
   have hG_card_le : Nat.card G ≤ 2*(Nat.card S:ℝ)^(12:ℝ) * Nat.card H₀
   · apply_fun Nat.card at hG_cover
@@ -185,30 +112,23 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS: ∀ x y : G, f (x+y) -
       (Nat.card (c'+ (H₀:Set G)):ℝ) ≤ Nat.card c' * Nat.card H₀ := by norm_cast; apply Nat.card_add_le
       _ ≤  2*(Nat.card S:ℝ)^(12:ℝ) * Nat.card H₀ := by
         gcongr
-        apply hc'_card_real.trans
-        apply hcS.le
+        exact hc'_card_real.trans hcS.le
 
   have : Nat.card H₁ ≤ 2*(Nat.card S : ℝ)^(12:ℝ)
   · calc
-      (Nat.card H₁:ℝ) = (Nat.card H:ℝ) / Nat.card H₀ := by
-        field_simp[hH_card, mul_comm]
+      (Nat.card H₁:ℝ) = (Nat.card H:ℝ) / Nat.card H₀ := by field_simp [hH_card, mul_comm]
       _ ≤ (Nat.card G : ℝ) / Nat.card H₀ := by
         gcongr
-        rw[card_graph f] at hHA
-        exact hHA
+        rwa [← card_graph f]
       _ ≤ 2*(Nat.card S : ℝ)^(12:ℝ) := by
-        rw[div_le_iff]
-        · apply hG_card_le
-        simp[Nat.pos_iff_ne_zero]
+        rw [div_le_iff]
+        apply hG_card_le
+        simp [Nat.pos_iff_ne_zero]
 
   have : (H:Set (G×G')) ⊆ ({0} ×ˢ (H₁:Set G')) + {(x, φ x) | x : G}
   · rintro ⟨g, g'⟩ hg
-    rw [SetLike.mem_coe, hH₀₁] at hg
-    simp only [] at hg
-    rw [Set.mem_add]
-    use (0, g' - φ g)
-    use (g, φ g)
-    refine ⟨?_,?_⟩
+    simp only [SetLike.mem_coe, hH₀₁] at hg
+    refine Set.mem_add.mpr ⟨ (0, g' - φ g), (g, φ g), ⟨?_,?_⟩ ⟩
     · simp only [singleton_prod, mem_image, SetLike.mem_coe,
         Prod.mk.injEq, true_and, exists_eq_right, hg.2]
     · simp only [mem_setOf_eq, Prod.mk.injEq, exists_eq_left, Prod.mk_add_mk, zero_add, true_and,
@@ -218,15 +138,14 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS: ∀ x y : G, f (x+y) -
   · calc
       A ⊆ c + (H : Set _) := hAcH
       _ ⊆ c + (({0} ×ˢ (H₁:Set G')) + {(x, φ x) | x : G}) := add_subset_add_left this
-  rw[←add_assoc] at hA_sub
+  rw [← add_assoc] at hA_sub
 
   let T := (fun p ↦ p.2 - φ p.1) '' (c + {0} ×ˢ (H₁: Set G'))
   have : A ⊆ ⋃ (c ∈ T), {(x, φ x + c) | x : G}
   · convert hA_sub
-    rw[← Set.iUnion_add_left_image, ←graph_def]
-    simp_rw[graph_add, Set.biUnion_image]
-  use φ
-  use T
+    rw [← Set.iUnion_add_left_image, ← graph_def]
+    simp_rw [graph_add, Set.biUnion_image]
+  use φ, T
   constructor
   · calc
       (Nat.card T:ℝ) ≤ Nat.card (c + {(0:G)} ×ˢ (H₁:Set G')) := by
@@ -234,22 +153,19 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS: ∀ x y : G, f (x+y) -
       _ ≤ Nat.card c * Nat.card H₁ := by
         norm_cast
         apply (Nat.card_add_le _ _).trans
-        rw[Nat.card_singleton_prod]
-        rfl
-      _ ≤ (2 * (Nat.card S) ^(12:ℝ)) * (2 * (Nat.card S) ^(12:ℝ)) := by
-        gcongr
+        rw [Nat.card_singleton_prod] ; rfl
+      _ ≤ (2 * (Nat.card S) ^(12:ℝ)) * (2 * (Nat.card S) ^(12:ℝ)) := by gcongr
       _ ≤ _ := by
         ring_nf
-        rw[sq, ←Real.rpow_add]
+        rw [sq, ← Real.rpow_add]
         · norm_num
         · norm_cast
           rw [Nat.card_pos_iff]
-          refine ⟨⟨_, hS 0 0⟩, Subtype.finite⟩
+          exact ⟨⟨_, hS 0 0⟩, Subtype.finite⟩
   · intro g
     specialize this (⟨g, rfl⟩ : (g, f g) ∈ A)
-    simp only [exists_eq_right, iUnion_exists, mem_iUnion, mem_setOf_eq,
-      Prod.mk.injEq, exists_eq_left, exists_prop, exists_and_right] at this
+    simp only [mem_iUnion, mem_setOf_eq, Prod.mk.injEq, exists_eq_left] at this
     obtain ⟨t, ⟨ht, h⟩⟩ := this
-    rw[←h]
+    rw [← h]
     convert ht
     abel

--- a/PFR/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/PFR/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -1,0 +1,15 @@
+import Mathlib.Algebra.Module.Submodule.Map
+
+namespace LinearMap
+
+variable { M M' R : Type* } [Semiring R] [AddCommMonoid M] [AddCommMonoid M']
+  [Module R M] [Module R M']
+
+def submoduleMap (f : M →ₗ[R] M') (S : Submodule R M) : S →ₗ[R] S.map f where
+  toFun := fun x ↦ ⟨ f x, Submodule.apply_coe_mem_map f x ⟩
+  map_add' := by simp
+  map_smul' := by simp
+
+theorem submoduleMap_surjective (f : M →ₗ[R] M') (S : Submodule R M) :
+    Function.Surjective (f.submoduleMap S) :=
+  AddMonoidHom.addSubmonoidMap_surjective f.toAddMonoidHom S.toAddSubmonoid

--- a/PFR/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/PFR/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -1,0 +1,62 @@
+import PFR.Mathlib.Algebra.Module.Submodule.Map
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+
+namespace Submodule
+
+variable { B F R : Type* } [DivisionRing R] [AddCommGroup B] [AddCommGroup F]
+  [Module R B] [Module R F]
+
+open LinearMap
+
+/-- Given a submodule $E$ of $B \times F$, there is an equivalence $f : E \to B' \times F'$
+  where $B'$ and $F'$ are submodules of $B$ and $F$ respectively, and
+  $f$ agrees with the projection $E \to B$.
+  $\phi$ is the offset by which $F'$ can be unprojected from $B'$. -/
+theorem equivProdSubmodule (E : Submodule R (B × F)) :
+    ∃ (B' : Submodule R B) (F' : Submodule R F) (f : E ≃ₗ[R] B' × F') (φ : B →ₗ[R] F),
+    (∀ x, (f x).1 = x.val.1 ∧ (f x).2 = x.val.2 - φ x.val.1) ∧
+    (∀ x₁ x₂, f.symm (x₁, x₂) = (x₁.val, x₂.val + φ x₁.val)) := by
+  let π₁ := LinearMap.fst R B F
+  let f₁ := π₁.submoduleMap E
+  have f₁_surj := range_eq_top.mpr (π₁.submoduleMap_surjective E)
+
+  let ⟨ φ', hφ' ⟩ := f₁.exists_rightInverse_of_surjective f₁_surj
+  let ⟨ φ, hφ ⟩ := φ'.exists_extend
+
+  let p₂ := (LinearMap.snd R B F).domRestrict E
+  let f₂'' := LinearMap.id - φ'.comp f₁
+  let f₂' := p₂.comp f₂''
+  let f₂ := f₂'.rangeRestrict
+
+  have h_compl : IsCompl (ker f₁) (ker f₂) := by
+    refine IsCompl.of_eq ?_ ?_
+    · by_contra hc
+      obtain ⟨ x, ⟨ h_ker, h_nezero ⟩ ⟩ := exists_mem_ne_zero_of_ne_bot hc
+      simp_rw [mem_inf, mem_ker] at h_ker
+      have h_zero₁ : x.val.1 = 0 := by rw [show x.val.1 = f₁ x from rfl, h_ker.left] ; rfl
+      have h_zero₂: (f₂'' x).val.2 = 0 := (mk_eq_zero _ _).mp h_ker.right
+      simp [show φ' (f₁ x) = 0 by simp_all only [LinearMap.map_zero]] at h_zero₂
+      exact h_nezero (coe_eq_zero.mp (Prod.ext h_zero₁ h_zero₂))
+    · simp_rw [eq_top_iff', mem_sup']
+      intro x
+      have : φ x.val.1 = φ' (f₁ x) := by subst hφ ; rfl
+      have h_ker₁ : f₂'' x ∈ ker f₁ := by simp [hφ', ← f₁.comp_apply φ']
+      have h_ker₂ : φ x.val.1 ∈ ker f₂ := by simp [this, hφ', ← f₁.comp_apply φ']
+      use ⟨ f₂'' x, h_ker₁ ⟩, ⟨ φ x.val.1, h_ker₂ ⟩
+      simp [add_comm_sub, sub_eq_zero, ← hφ] ; rfl
+
+  let f := equivProdOfSurjectiveOfIsCompl f₁ f₂ f₁_surj f₂'.range_rangeRestrict h_compl
+  use E.map π₁, range f₂', f, p₂.comp φ
+  constructor
+  · intro _
+    rw [equivProdOfSurjectiveOfIsCompl_apply]
+    constructor ; rfl ; subst hφ ; rfl
+  · intro x₁ x₂
+    let x := f.symm (x₁, x₂)
+    have : (f₁ x, f₂ x) = (x₁, x₂) := f.apply_symm_apply (x₁, x₂)
+    have : x.val.2 - p₂ (φ x.val.1) = p₂ (x - φ' (f₁ x)) := by subst hφ ; rfl
+    have : (x₁.val, x₂.val + p₂ (φ x.val.1)) = (x.val.1, x.val.2)  := by
+      rw [← add_zero x₁.val, ← Prod.mk_add_mk, ← eq_sub_iff_add_eq, Prod.mk_sub_mk, sub_zero, this]
+      show (x₁.val, x₂.val) = ((f₁ x).val, (f₂ x).val)
+      simp_all only [Prod.mk.injEq]
+    subst hφ ; simp_all


### PR DESCRIPTION
The following are staged for mathlib:
```lean
AddSubmonoid.coe_toSubmodule [Module (ZMod (n + 1)) M]
AddMonoidHom.coe_toLinearMap [Module (ZMod (n + 1)) M]
AddSubGroup.coe_toSubmodule [Module (ZMod n) G]
AddMonoidHom.coe_toLinearMapGroup [Module (ZMod n) G]
LinearMap.submoduleMap_surjective
Submodule.equivProdSubmodule
```

Note the additions to Elementary.lean are stronger than necessary, otherwise everything else is golf. In particular `hahn_banach` and `goursat` are simplified by `LinearMap.exists_extend` and `LinearMap.equivProdOfSurjectiveOfIsComp` respectively.