### PR TITLE
perf(homomorphism): save ~10 seconds or so

### DIFF
--- a/PFR/Homomorphism.lean
+++ b/PFR/Homomorphism.lean
@@ -22,16 +22,22 @@ In particular, $|H| = |H_0| |H_1|$. -/
 lemma goursat (H : AddSubgroup (G × G')): ∃ (H₀ : AddSubgroup G) (H₁ : AddSubgroup G') (φ : G →+ G'),
     (∀ x : G × G', x ∈ H ↔ (x.1 ∈ H₀ ∧ x.2 - φ x.1 ∈ H₁)) ∧
     (Nat.card H) = (Nat.card H₀) * (Nat.card H₁) := by
-  obtain ⟨ S₁, S₂, f, φ, ⟨ hf, hf_inv ⟩ ⟩ := (H.toSubmodule (n := 2)).equivProdSubmodule
+  obtain ⟨ S₁, S₂, f, φ, ⟨ hf, hf_inv ⟩ ⟩ := (H.toSubmodule (n := 2)).exists_equiv_fst_sndModFst
   use S₁.toAddSubgroup, S₂.toAddSubgroup, φ
-  constructor
-  · exact fun x ↦ ⟨
-      fun hx ↦ ⟨ Set.mem_of_eq_of_mem (hf ⟨ x, hx ⟩).1.symm (f ⟨ x, hx ⟩).1.property,
-        Set.mem_of_eq_of_mem (hf ⟨ x, hx ⟩).2.symm (f ⟨ x, hx ⟩).2.property ⟩,
-      fun hx ↦ Set.mem_of_eq_of_mem (by rw [hf_inv, sub_add_cancel])
-        (f.symm (⟨ x.1, hx.1 ⟩, ⟨ x.2 - φ x.1, hx.2 ⟩)).property ⟩
-  · have : Nat.card H = Nat.card (H.toSubmodule (n := 2)) := rfl
-    rw [this, Nat.card_eq_of_bijective f f.bijective, Nat.card_prod S₁ S₂] ; rfl
+  constructor ; swap
+  · show Nat.card (H.toSubmodule (n := 2)) = _
+    exact Eq.trans (Nat.card_eq_of_bijective f f.bijective) (Nat.card_prod S₁ S₂)
+  · intro x
+    · constructor
+      · intro hx
+        let x : H := { val := x, property := hx }
+        · constructor
+          · exact Set.mem_of_eq_of_mem (hf x).1.symm (f x).1.property
+          · exact Set.mem_of_eq_of_mem (hf x).2.symm (f x).2.property
+      · intro hx
+        · let x₁ : S₁ := { val := x.1, property := hx.1 }
+          let x₂ : S₂ := { val := x.2 - φ x.1, property := hx.2 }
+          exact Set.mem_of_eq_of_mem (by rw [hf_inv, sub_add_cancel]) (f.symm (x₁, x₂)).property
 
 /- TODO: Find an appropriate home for these lemmas -/
 lemma Nat.card_image_le {α β: Type*} {s : Set α} {f : α → β} (hs : s.Finite) :

--- a/PFR/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/PFR/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -7,8 +7,8 @@ variable { M M' R : Type* } [Semiring R] [AddCommMonoid M] [AddCommMonoid M']
 
 def submoduleMap (f : M →ₗ[R] M') (S : Submodule R M) : S →ₗ[R] S.map f where
   toFun := fun x ↦ ⟨ f x, Submodule.apply_coe_mem_map f x ⟩
-  map_add' := by simp
-  map_smul' := by simp
+  map_add' x y := Subtype.eq <| f.map_add x y
+  map_smul' x y := Subtype.eq <| f.map_smul x y
 
 theorem submoduleMap_surjective (f : M →ₗ[R] M') (S : Submodule R M) :
     Function.Surjective (f.submoduleMap S) :=

--- a/PFR/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/PFR/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -9,19 +9,17 @@ variable { B F R : Type* } [DivisionRing R] [AddCommGroup B] [AddCommGroup F]
 open LinearMap
 
 /-- Given a submodule $E$ of $B \times F$, there is an equivalence $f : E \to B' \times F'$
-  where $B'$ and $F'$ are submodules of $B$ and $F$ respectively, and
-  $f$ agrees with the projection $E \to B$.
-  $\phi$ is the offset by which $F'$ can be unprojected from $B'$. -/
-theorem equivProdSubmodule (E : Submodule R (B × F)) :
+  given by the projections $E \to B$ and $E \to F$ "modulo" $φ : B \to F$. -/
+theorem exists_equiv_fst_sndModFst (E : Submodule R (B × F)) :
     ∃ (B' : Submodule R B) (F' : Submodule R F) (f : E ≃ₗ[R] B' × F') (φ : B →ₗ[R] F),
-    (∀ x, (f x).1 = x.val.1 ∧ (f x).2 = x.val.2 - φ x.val.1) ∧
-    (∀ x₁ x₂, f.symm (x₁, x₂) = (x₁.val, x₂.val + φ x₁.val)) := by
+    (∀ x : E, (f x).1.val = x.val.1 ∧ (f x).2.val = x.val.2 - φ x.val.1) ∧
+    (∀ (x₁ : B') (x₂ : F'), (f.symm (x₁, x₂)).val = (x₁.val, x₂.val + φ x₁.val)) := by
   let π₁ := LinearMap.fst R B F
   let f₁ := π₁.submoduleMap E
   have f₁_surj := range_eq_top.mpr (π₁.submoduleMap_surjective E)
 
-  let ⟨ φ', hφ' ⟩ := f₁.exists_rightInverse_of_surjective f₁_surj
-  let ⟨ φ, hφ ⟩ := φ'.exists_extend
+  obtain ⟨ φ', hφ' ⟩ := f₁.exists_rightInverse_of_surjective f₁_surj
+  obtain ⟨ φ, hφ ⟩ := φ'.exists_extend
 
   let p₂ := (LinearMap.snd R B F).domRestrict E
   let f₂'' := LinearMap.id - φ'.comp f₁
@@ -32,18 +30,30 @@ theorem equivProdSubmodule (E : Submodule R (B × F)) :
     refine IsCompl.of_eq ?_ ?_
     · by_contra hc
       obtain ⟨ x, ⟨ h_ker, h_nezero ⟩ ⟩ := exists_mem_ne_zero_of_ne_bot hc
-      simp_rw [mem_inf, mem_ker] at h_ker
-      have h_zero₁ : x.val.1 = 0 := by rw [show x.val.1 = f₁ x from rfl, h_ker.left] ; rfl
-      have h_zero₂: (f₂'' x).val.2 = 0 := (mk_eq_zero _ _).mp h_ker.right
-      simp [show φ' (f₁ x) = 0 by simp_all only [LinearMap.map_zero]] at h_zero₂
-      exact h_nezero (coe_eq_zero.mp (Prod.ext h_zero₁ h_zero₂))
-    · simp_rw [eq_top_iff', mem_sup']
+      rw [mem_inf, mem_ker, mem_ker] at h_ker
+      have h_zero₁ : x.val.1 = 0 := Subtype.ext_iff.mp h_ker.left
+      have h_zero₂ : x.val.2 = 0 := calc
+        x.val.2 = (f₂'' x).val.2 := by
+          show _ = (x - φ' (f₁ x)).val.2
+          rw [mem_ker.mp h_ker.left, φ'.map_zero, sub_zero]
+        _ = 0 := (mk_eq_zero _ _).mp h_ker.right
+      exact h_nezero (Subtype.ext (Prod.ext h_zero₁ h_zero₂))
+    · apply eq_top_iff'.mpr
       intro x
+      apply mem_sup'.mpr
       have : φ x.val.1 = φ' (f₁ x) := by subst hφ ; rfl
-      have h_ker₁ : f₂'' x ∈ ker f₁ := by simp [hφ', ← f₁.comp_apply φ']
-      have h_ker₂ : φ x.val.1 ∈ ker f₂ := by simp [this, hφ', ← f₁.comp_apply φ']
+      have h_ker₁ : f₂'' x ∈ ker f₁ := by
+        apply mem_ker.mpr
+        show f₁ x - (f₁.comp φ') (f₁ x) = 0
+        rw [hφ'] ; exact sub_self (f₁ x)
+      have h_ker₂ : φ x.val.1 ∈ ker f₂ := by
+        rewrite [ker_rangeRestrict]
+        show p₂ (φ x.val.1 - φ' (f₁ (φ x.val.1))) = 0
+        rw [this, ← f₁.comp_apply φ', hφ', LinearMap.id_apply, sub_self, p₂.map_zero]
       use ⟨ f₂'' x, h_ker₁ ⟩, ⟨ φ x.val.1, h_ker₂ ⟩
-      simp [add_comm_sub, sub_eq_zero, ← hφ] ; rfl
+      simp only
+      rewrite [← hφ]
+      exact sub_add_cancel x (φ x.val.1)
 
   let f := equivProdOfSurjectiveOfIsCompl f₁ f₂ f₁_surj f₂'.range_rangeRestrict h_compl
   use E.map π₁, range f₂', f, p₂.comp φ
@@ -52,11 +62,11 @@ theorem equivProdSubmodule (E : Submodule R (B × F)) :
     rw [equivProdOfSurjectiveOfIsCompl_apply]
     constructor ; rfl ; subst hφ ; rfl
   · intro x₁ x₂
-    let x := f.symm (x₁, x₂)
-    have : (f₁ x, f₂ x) = (x₁, x₂) := f.apply_symm_apply (x₁, x₂)
-    have : x.val.2 - p₂ (φ x.val.1) = p₂ (x - φ' (f₁ x)) := by subst hφ ; rfl
-    have : (x₁.val, x₂.val + p₂ (φ x.val.1)) = (x.val.1, x.val.2)  := by
-      rw [← add_zero x₁.val, ← Prod.mk_add_mk, ← eq_sub_iff_add_eq, Prod.mk_sub_mk, sub_zero, this]
-      show (x₁.val, x₂.val) = ((f₁ x).val, (f₂ x).val)
-      simp_all only [Prod.mk.injEq]
-    subst hφ ; simp_all
+    let x : E := f.symm (x₁, x₂)
+    have hf : f₁ x = x₁ ∧ f₂ x = x₂ := (Prod.mk.injEq _ _ _ _).mp (f.apply_symm_apply (x₁, x₂))
+    have : (f₂ x).val = x.val.2 - p₂ (φ x.val.1) := by subst hφ ; rfl
+    have : x₂.val + p₂ (φ x.val.1) = x.val.2 :=
+      eq_sub_iff_add_eq.mp (Eq.trans (Subtype.ext_iff.mp hf.right).symm this)
+    show x.val = _
+    rw [← hf.left]
+    exact (Prod.mk.injEq _ _ _ _).mpr ⟨ rfl (a := x.val.1), this.symm ⟩


### PR DESCRIPTION
mostly:
- ungolfing simp -> rw -> show/exact
- adding explicit types annotations and constructors wherever there's a simple way to do so