### PR TITLE
Build both PDF and web in texlive-action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,12 +66,6 @@ jobs:
       - name: Build documentation
         run: ~/.elan/bin/lake -Kenv=dev build PFR:docs
 
-      - name: Install Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: 'pip' # caching pip dependencies
-
       - name: Build blueprint and copy to `docs/blueprint`
         uses: xu-cheng/texlive-action@v2
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,18 +72,21 @@ jobs:
           python-version: '3.9'
           cache: 'pip' # caching pip dependencies
 
-      - name: Install blueprint apt dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz libgraphviz-dev pdf2svg dvisvgm texlive-full
-
-      - name: Install blueprint dependencies
-        run: |
-          cd blueprint && pip install -r requirements.txt
-
       - name: Build blueprint and copy to `docs/blueprint`
-        run: |
-          inv all
+        uses: xu-cheng/texlive-action@v2
+        with:
+          scheme: full
+          run: |
+            apk update
+            apk add --update make py3-pip git
+            apk add --update make py3-pip git pkgconfig graphviz graphviz-dev gcc musl-dev
+            git config --global --add safe.directory $GITHUB_WORKSPACE
+            git config --global --add safe.directory `pwd`
+            python3 -m pip install --upgrade pip requests wheel
+            python3 -m pip install pygraphviz --global-option=build_ext --global-option="-L/usr/lib/graphviz/" --global-option="-R/usr/lib/graphviz/"
+            pip install -r blueprint/requirements.txt
+            python3 -m pip install invoke
+            inv all
 
       - name: Copy documentation to `docs/docs`
         run: |

--- a/blueprint/requirements.txt
+++ b/blueprint/requirements.txt
@@ -1,4 +1,5 @@
-invoke==1.7.1
+# https://github.com/pyinvoke/invoke/issues/891
+invoke==2.2.0
 plasTeX @ git+https://github.com/plastex/plastex.git
 leanblueprint @ git+https://github.com/PatrickMassot/leanblueprint.git
 watchfiles==0.16.1


### PR DESCRIPTION
This PR improves CI to build both PDF and web in [texlive-action](https://github.com/xu-cheng/texlive-action), reduces CI by ~5 minutes:

## Before

<img width="1221" alt="image" src="https://github.com/teorth/pfr/assets/64258/c4b62d19-9994-4657-9368-d90360c312ce">

## After

<img width="1290" alt="image" src="https://github.com/teorth/pfr/assets/64258/6ee26bca-02cd-47db-86fd-75d7969926f3">
