### PR TITLE
Prove rdist_of_hom_le

### DIFF
--- a/PFR/Fibring.lean
+++ b/PFR/Fibring.lean
@@ -19,10 +19,13 @@ open MeasureTheory ProbabilityTheory
 section GeneralFibring
 
 -- $\pi : H \to H'$ is a homomorphism between additive groups.
-variable {H : Type*} [AddCommGroup H] [Countable H] [hH : MeasurableSpace H] [MeasurableSingletonClass H]
-  {H' : Type*} [AddCommGroup H'] [Countable H'] [hH' : MeasurableSpace H'] [MeasurableSingletonClass H']
+variable {H : Type*} [AddCommGroup H] [Countable H] [hH : MeasurableSpace H] 
+  [MeasurableSingletonClass H]
+  {H' : Type*} [AddCommGroup H'] [Countable H'] [hH' : MeasurableSpace H'] 
+  [MeasurableSingletonClass H']
   (π : H →+ H')
-variable {Ω Ω' : Type*} [mΩ : MeasurableSpace Ω] [mΩ' : MeasurableSpace Ω'] {μ : Measure Ω} {μ' : Measure Ω'} [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
+variable {Ω Ω' : Type*} [mΩ : MeasurableSpace Ω] [mΩ' : MeasurableSpace Ω'] 
+  {μ : Measure Ω} {μ' : Measure Ω'} [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
 
 /-- If $Z_1, Z_2$ are independent, then $d[Z_1; Z_2]$ is equal to
 $$ d[\pi(Z_1);\pi(Z_2)] + d[Z_1|\pi(Z_1); Z_2 |\pi(Z_2)]$$
@@ -56,8 +59,9 @@ lemma rdist_of_indep_eq_sum_fibre {Z_1 Z_2: Ω → H} (h : IndepFun Z_1 Z_2 μ)
     condRuzsaDist_of_indep h1 (hπ.comp h1) h2 (hπ.comp h2) μ h']
   ring_nf
 
-lemma rdist_le_sum_fibre {Z_1: Ω → H} {Z_2: Ω' → H} (h1 : Measurable Z_1) (h2 : Measurable Z_2) [FiniteRange Z_1] [FiniteRange Z_2]:
-    d[Z_1; μ # Z_2; μ'] ≥ d[π ∘ Z_1; μ # π ∘ Z_2; μ'] + d[Z_1|π∘Z_1; μ # Z_2|π∘Z_2; μ'] := by
+lemma rdist_le_sum_fibre {Z_1: Ω → H} {Z_2: Ω' → H} 
+  (h1 : Measurable Z_1) (h2 : Measurable Z_2) [FiniteRange Z_1] [FiniteRange Z_2]:
+  d[π ∘ Z_1; μ # π ∘ Z_2; μ'] + d[Z_1|π∘Z_1; μ # Z_2|π∘Z_2; μ'] ≤ d[Z_1; μ # Z_2; μ']:= by
   obtain ⟨ν, W_1, W_2, hν, m1, m2, hi, hi1, hi2, _, _⟩ := ProbabilityTheory.independent_copies_finiteRange h1 h2 μ μ'
   have hπ : Measurable π := measurable_of_countable _
   have hφ : Measurable (fun x ↦ (x, π x)) := measurable_of_countable _
@@ -68,9 +72,14 @@ lemma rdist_le_sum_fibre {Z_1: Ω → H} {Z_2: Ω' → H} (h1 : Measurable Z_1) 
     condRuzsaDist_of_copy h1 (hπ.comp h1) h2 (hπ.comp h2) m1 (hπ.comp m1) m2 (hπ.comp m2) hπ1 hπ2]
   exact le_add_of_nonneg_right (condMutualInfo_nonneg (by measurability) (Measurable.prod_mk (hπ.comp m1) (hπ.comp m2)) _ _)
 
-/-- \[d[X;Y]\geq d[\pi(X);\pi(Y)].\] -/
-lemma rdist_of_hom_le {Z_1 Z_2: Ω → H}  (h1 : Measurable Z_1) (h2 : Measurable Z_2) [FiniteRange Z_1] [FiniteRange Z_2] : d[π ∘ Z_1; μ # π ∘ Z_2; μ] ≤d[Z_1; μ # Z_2; μ]  := sorry
 
+/-- \[d[X;Y]\geq d[\pi(X);\pi(Y)].\] -/
+lemma rdist_of_hom_le {Z_1 Z_2: Ω → H} 
+  (h1 : Measurable Z_1) (h2 : Measurable Z_2) [FiniteRange Z_1] [FiniteRange Z_2] : 
+  d[π ∘ Z_1; μ # π ∘ Z_2; μ] ≤ d[Z_1; μ # Z_2; μ] := by 
+    apply le_trans _ (rdist_le_sum_fibre π h1 h2 (μ := μ) (μ' := μ))
+    simp
+    exact condRuzsaDist_nonneg Z_1 (π ∘ Z_1) Z_2 (π ∘ Z_2)
 
 end GeneralFibring
 

--- a/PFR/ForMathlib/Entropy/RuzsaDist.lean
+++ b/PFR/ForMathlib/Entropy/RuzsaDist.lean
@@ -332,6 +332,10 @@ lemma condRuzsaDist_symm {X : Ω → G} {Z : Ω → S} {Y : Ω' → G} {W : Ω' 
     (μ' : Measure Ω') : d[X | Z ; 0 # Y | W ; μ'] = 0 := by
   simp [condRuzsaDist]
 
+lemma condRuzsaDist_nonneg (X : Ω → G) (Z : Ω → S) (Y : Ω' → G) (W : Ω' → T) 
+  [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] : 
+  0 ≤ d[X | Z ; μ # Y | W ; μ'] := by sorry
+
 /-- Ruzsa distance of random variables equals Ruzsa distance of the kernels. -/
 lemma rdist_eq_rdistm : d[X ; μ # Y ; μ'] = kernel.rdistm (μ.map X) (μ'.map Y) := rfl
 


### PR DESCRIPTION
Proves `rdist_of_hom_le` modulo a lemma that the conditional Ruzsa distance is nonnegative. 

The blueprint proof for this statement is quite different to the proof here. Showing that X and Y are independent is not necessary and there is no other Lemma ?? needed to complete the proof. 