### PR TITLE
fix blueprint

### DIFF
--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -32,7 +32,7 @@ such that $f(x) = \phi(x)+c$ for at least $|G| / C_1^{13} C_3^{12}
 K^{24C_4+26 C_2}$ values of $x \in G$.
 \end{theorem}
 
-\begin{proof}\uses{goursat, cs-bound, bsg, PFR_conjecture_improv_aux} Consider the graph $A \subset G \times G'$ defined by
+\begin{proof}\uses{goursat, cs-bound, bsg, pfr_aux-improv} Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have $a+a' \in A$ for at least
 $|A|^2/K$ pairs $(a,a') \in A^2$. By Lemma \ref{cs-bound}, this implies that

--- a/blueprint/src/chapter/hom_pfr.tex
+++ b/blueprint/src/chapter/hom_pfr.tex
@@ -22,7 +22,7 @@ Then there exists a homomorphism $\phi: G \to G'$ such that
 $$ |\{ f(x) - \phi(x): x \in G \}| \leq |S|^{12}.$$
 \end{theorem}
 
-\begin{proof}\uses{goursat, PFR_conjecture_improv_aux} \leanok
+\begin{proof}\uses{goursat, pfr_aux-improv} \leanok
 Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have

--- a/blueprint/src/chapter/improved_exponent.tex
+++ b/blueprint/src/chapter/improved_exponent.tex
@@ -210,15 +210,15 @@ From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau
 \end{proof}
 
 One can then replace Lemma~\ref{pfr_aux} with
-\begin{lemma}\label{pfr_aux-improv}
-\lean{PFR_conjecture_improv_aux}\leanok If $A \subset {\bf F}_2^n$ is non-empty and
+\begin{lemma}\label{pfr_aux-improv} \lean{PFR_conjecture_improv_aux}\leanok
+If $A \subset {\bf F}_2^n$ is non-empty and
 $|A+A| \leq K|A|$, then $A$ can be covered by at most $K^6 |A|^{1/2}/|H|^{1/2}$ translates of a subspace $H$ of ${\bf F}_2^n$ with
 $$
   |H|/|A| \in [K^{-10}, K^{10}].
 $$
 \end{lemma}
 
-\begin{proof}\uses{entropy-pfr-improv, unif-exist, uniform-entropy-II, jensen-bound,ruz-dist-def,ruzsa-diff,bound-conc,ruz-cov}\leanok
+\begin{proof} \uses{entropy-pfr-improv, unif-exist, uniform-entropy-II, jensen-bound,ruz-dist-def,ruzsa-diff,bound-conc,ruz-cov}\leanok
 By repeating the proof of Lemma~\ref{pfr_aux} and using Theorem \ref{entropy-pfr-improv} one can obtain the claim with $13/2$
 replaced with $6$ and $11$ replaced by $10$.
 \end{proof}
@@ -229,7 +229,7 @@ This implies the following improved version of Theorem~\ref{pfr}:
   If $A \subset {\bf F}_2^n$ is non-empty and $|A+A| \leq K|A|$, then $A$ can be covered by most $2K^{11}$ translates of a subspace $H$ of ${\bf F}_2^n$ with $|H| \leq |A|$.
 \end{theorem}
 
-\begin{proof}\uses{PFR_conjecture_improv_aux}\leanok
+\begin{proof}\uses{pfr_aux-improv}\leanok
 By repeating the proof of Theorem \ref{pfr} and using Lemma \ref{pfr_aux-improv} one can obtain the claim with $11$ replaced by $10$.
 \end{proof}
 

--- a/blueprint/src/chapter/pfr.tex
+++ b/blueprint/src/chapter/pfr.tex
@@ -52,7 +52,7 @@ If $A \subset {\bf F}_2^n$ is non-empty and $|A+A| \leq K|A|$, then $A$ can be c
 \end{theorem}
 
 \begin{proof}
-  \uses{PFR_conjecture_aux}\leanok
+  \uses{pfr_aux}\leanok
   Let $H$ be given by Lemma~\ref{pfr_aux}.
   If $|H| \leq |A|$ then we are already done thanks to~\eqref{ah}.  If $|H| > |A|$ then we can cover $H$ by at most $2 |H|/|A|$ translates of a subspace $H'$ of $H$ with $|H'| \leq |A|$.  We can thus cover $A$ by at most
   \[2K^{13/2} \frac{|H|^{1/2}}{|A|^{1/2}}\]


### PR DESCRIPTION
Correct a mistake in my previous PR: I thought that in `\uses{...}`, I should mention the Lean names, while it should be the latex label. This results in a disconnected graph in the blueprint. It should be better with the current PR.