### PR TITLE
fix wrong `uses` in the blueprint

### DIFF
--- a/blueprint/.gitignore
+++ b/blueprint/.gitignore
@@ -2,6 +2,7 @@
 *.paux
 *.aux
 *.log
+*.synctex
 print
 web
 __pycache__

--- a/blueprint/src/chapter/distance.tex
+++ b/blueprint/src/chapter/distance.tex
@@ -256,7 +256,7 @@ Then
 \end{lemma}
 
 \begin{proof}
-  \uses{cond-indep-exist, cond-trial-ent, cond-entropy-def,submodularity, copy, relabeled-entropy, add-entropy, ruz-indep}
+  \uses{cond-indep-exist, cond-trial-ent, conditional-entropy-def,submodularity, copy-ent, relabeled-entropy, add-entropy, ruz-indep}
   \leanok
 Let $(A_1, B_1)$ and $(A_2, B_2)$ (and $Z'$, which by abuse of notation we call $Z$) be conditionally independent trials of $(A,B)$ relative to $Z$ as produced by Lemma \ref{cond-indep-exist}, thus $(A_1,B_1)$ and $(A_2,B_2)$ are coupled through the random variable $A_1 + B_1 = A_2 + B_2$, which by abuse of notation we shall also call $Z$.
 
@@ -321,7 +321,7 @@ Here, in the middle step we used Lemma \ref{cond-reduce}, and in the last step w
   \end{lemma}
 
   \begin{proof}
-    \uses{ruz-copy, ruz-lean, independent-exist, kv, ruz-indep, relabeled-entropy, cond-dist-fact}\leanok
+    \uses{ruz-copy, independent-exist, kv, ruz-indep, relabeled-entropy, cond-dist-fact}\leanok
   We first prove~\eqref{lem51-a}. We may assume (taking an independent copy, using Lemma \ref{independent-exist} and Lemma \ref{ruz-copy}, \ref{ruz-indep}) that $X$ is independent of $Y, Z$. Then we have
   \begin{align*}  d[X ;Y+ Z] & - d[X ;Y] \\ & = \bbH[X + Y + Z] - \bbH[X + Y] - \tfrac{1}{2}\bbH[Y + Z] + \tfrac{1}{2} \bbH[Y].\end{align*}
   Combining this with Lemma \ref{kv} gives the required bound. The second form of the result is immediate Lemma \ref{ruz-indep}.

--- a/blueprint/src/chapter/entropy_pfr.tex
+++ b/blueprint/src/chapter/entropy_pfr.tex
@@ -46,7 +46,7 @@ A pair $X_1, X_2$ of $\tau$-minimizers exist.
 In this section we assume that $X_1,X_2$ are $\tau$-minimizers. We also write $k := d[X_1;X_2]$.
 
 \begin{lemma}[Distance lower bound]\label{distance-lower}
-  \uses{tau-minimizes}\leanok
+  \uses{tau-min-def}\leanok
   \lean{distance_ge_of_min}
   For any $G$-valued random variables $X'_1,X'_2$, one has
 $$ d[X'_1;X'_2] \geq k - \eta (d[X^0_1;X'_1] - d[X^0_1;X_1] ) - \eta (d[X^0_2;X'_2] - d[X^0_2;X_2] ).$$
@@ -58,7 +58,7 @@ $$ d[X'_1;X'_2] \geq k - \eta (d[X^0_1;X'_1] - d[X^0_1;X_1] ) - \eta (d[X^0_2;X'
 \end{proof}
 
 \begin{lemma}[Conditional distance lower bound]\label{cond-distance-lower}
-  \uses{tau-minimizes, cond-dist-def}
+  \uses{tau-min-def, cond-dist-def}
   \lean{condRuzsaDistance_ge_of_min}\leanok
   For any $G$-valued random variables $X'_1,X'_2$ and random variables $Z,W$, one has
 $$ d[X'_1|Z;X'_2|W] \geq k - \eta (d[X^0_1;X'_1|Z] - d[X^0_1;X_1] ) - \eta (d[X^0_2;X'_2|W] - d[X^0_2;X_2] ).$$
@@ -253,7 +253,7 @@ This should follow from Lemma \ref{copy-ent}, Lemma \ref{conditional-mutual-alt}
 \end{proof}
 
 \begin{lemma}[Bound on conditional mutual informations]\label{uvw-s}
-\uses{conditional-information-def}
+\uses{conditional-mutual-def}
 \lean{I₃_eq,sum_condMutual_le}\leanok
 We have
 $$
@@ -335,7 +335,7 @@ For the next two lemmas, let $(T_1,T_2,T_3)$ be a $G^3$-valued random variable s
 
 (Note: in the paper, this lemma was phrased in a more intuitive formulation that is basically the contrapositive of the one here. Similarly for the next two lemmas.)
 
-\begin{proof}\uses{entropic-bsg, cond-dist-fact,distance_lower}\leanok
+\begin{proof}\uses{entropic-bsg, cond-dist-fact,distance-lower}\leanok
   We apply Lemma \ref{entropic-bsg} with $(A,B) = (T_1, T_2)$ there.
   Since $T_1 + T_2 = T_3$, the conclusion is that
   \begin{align} \nonumber \sum_{t_3} \bbP[T_3 = t_3] & d[(T_1 | T_3 = t_3); (T_2 | T_3 = t_3)] \\ & \leq 3 \bbI[T_1 : T_2] + 2 \bbH[T_3] - \bbH[T_1] - \bbH[T_2].\label{bsg-t1t2}

--- a/blueprint/src/chapter/fibring.tex
+++ b/blueprint/src/chapter/fibring.tex
@@ -59,7 +59,7 @@ The inequality follows from $d[X\mid \pi(X);Y\mid \pi(Y)]\geq 0$ (Lemma \ref{ruz
 \end{corollary}
 
 \begin{proof}
-  \uses{fibring-ident, add_entropy, relabeled-entropy-cond}\leanok
+  \uses{fibring-ident, add-entropy, relabeled-entropy-cond}\leanok
   We apply Proposition \ref{fibring-ident} with $H := G \times G$, $H' := G$, $\pi$ the addition homomorphism $\pi(x,y) := x+y$, and with the random variables $Z_1 := (Y_1,Y_3)$ and $Z_2 := (Y_2,Y_4)$.  Then by independence (Lemma \ref{add-entropy})
 \[
   d[Z_1; Z_2] = d[Y_1; Y_2] + d[Y_3; Y_4]

--- a/blueprint/src/chapter/hom_pfr.tex
+++ b/blueprint/src/chapter/hom_pfr.tex
@@ -22,7 +22,7 @@ Then there exists a homomorphism $\phi: G \to G'$ such that
 $$ |\{ f(x) - \phi(x): x \in G \}| \leq |S|^{12}.$$
 \end{theorem}
 
-\begin{proof}\uses{goursat, pfr_aux-improv} \leanok
+\begin{proof}\uses{goursat, pfr_aux-improv}\leanok
 Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have

--- a/blueprint/src/chapter/improved_exponent.tex
+++ b/blueprint/src/chapter/improved_exponent.tex
@@ -24,7 +24,7 @@ We have the following variant of Lemma \ref{construct-good-prelim}:
   \end{align*}
 \end{lemma}
 
-\begin{proof} \uses{entropic-bsg,distance_lower}\leanok
+\begin{proof} \uses{entropic-bsg,distance-lower}\leanok
   We apply Lemma \ref{entropic-bsg} with $(A,B) = (T_1, T_2)$ there.
   Since $T_1 + T_2 = T_3$, the conclusion is that
   \begin{align} \nonumber \sum_{t_3} \bbP[T_3 = t_3] & d[(T_1 | T_3 = t_3); (T_2 | T_3 = t_3)] \\ & \leq 3 \bbI[T_1 : T_2] + 2 \bbH[T_3] - \bbH[T_1] - \bbH[T_2].\label{bsg-t1t2'}
@@ -210,7 +210,7 @@ From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau
 \end{proof}
 
 One can then replace Lemma~\ref{pfr_aux} with
-\begin{lemma}\label{pfr_aux-improv} \lean{PFR_conjecture_improv_aux}\leanok
+\begin{lemma}\label{pfr_aux-improv}\lean{PFR_conjecture_improv_aux}\leanok
 If $A \subset {\bf F}_2^n$ is non-empty and
 $|A+A| \leq K|A|$, then $A$ can be covered by at most $K^6 |A|^{1/2}/|H|^{1/2}$ translates of a subspace $H$ of ${\bf F}_2^n$ with
 $$
@@ -218,7 +218,7 @@ $$
 $$
 \end{lemma}
 
-\begin{proof} \uses{entropy-pfr-improv, unif-exist, uniform-entropy-II, jensen-bound,ruz-dist-def,ruzsa-diff,bound-conc,ruz-cov}\leanok
+\begin{proof}\uses{entropy-pfr-improv, unif-exist, uniform-entropy-II, jensen-bound,ruz-dist-def,ruzsa-diff,bound-conc,ruz-cov}\leanok
 By repeating the proof of Lemma~\ref{pfr_aux} and using Theorem \ref{entropy-pfr-improv} one can obtain the claim with $13/2$
 replaced with $6$ and $11$ replaced by $10$.
 \end{proof}

--- a/blueprint/src/preamble/print.tex
+++ b/blueprint/src/preamble/print.tex
@@ -15,9 +15,9 @@
 \newcommand{\leanok}{}
 
 % Make sure that arguments of \uses are real labels, by using invisible refs:
-% latex will print a warning if the label is not defined.
-\usepackage{xparse}
+% latex prints a warning if the label is not defined, but nothing is shown in the pdf file.
 \ExplSyntaxOn
-\NewDocumentCommand{\uses}{ m }
- {\clist_map_inline:nn { #1 } {\vphantom{\ref{##1}}}}
+\NewDocumentCommand{\uses}{m}
+ {\clist_map_inline:nn{#1}{\vphantom{\ref{##1}}}%
+  \ignorespaces}
 \ExplSyntaxOff

--- a/blueprint/src/preamble/print.tex
+++ b/blueprint/src/preamble/print.tex
@@ -10,7 +10,14 @@
 \declaretheorem[sibling=theorem]{example}
 
 % We neutralise the Plastex commands
-\newcommand{\uses}[1]{}
 \newcommand{\proves}[1]{}
 \newcommand{\lean}[1]{}
 \newcommand{\leanok}{}
+
+% Make sure that arguments of \uses are real labels, by using invisible refs:
+% latex will print a warning if the label is not defined.
+\usepackage{xparse}
+\ExplSyntaxOn
+\NewDocumentCommand{\uses}{ m }
+ {\clist_map_inline:nn { #1 } {\vphantom{\ref{##1}}}}
+\ExplSyntaxOff


### PR DESCRIPTION
I've adapted the latex template to warn when in `uses` there is something which is not a latex label. And fixed the warnings.