### PR TITLE
add empty line to workaround blueprint bug

### DIFF
--- a/blueprint/src/chapter/improved_exponent.tex
+++ b/blueprint/src/chapter/improved_exponent.tex
@@ -210,6 +210,7 @@ From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau
 \end{proof}
 
 One can then replace Lemma~\ref{pfr_aux} with
+
 \begin{lemma}\label{pfr_aux-improv}\lean{PFR_conjecture_improv_aux}\leanok
 If $A \subset {\bf F}_2^n$ is non-empty and
 $|A+A| \leq K|A|$, then $A$ can be covered by at most $K^6 |A|^{1/2}/|H|^{1/2}$ translates of a subspace $H$ of ${\bf F}_2^n$ with


### PR DESCRIPTION
This makes the blueprint graph connected again...