### PR TITLE
chore: fix blueprint generation

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -70,8 +70,9 @@ jobs:
       - name: Build blueprint and copy to `docs/blueprint`
         uses: xu-cheng/texlive-action@v2
         with:
-          scheme: full
+          docker_image: ghcr.io/xu-cheng/texlive-full:20231201
           run: |
+            export PIP_BREAK_SYSTEM_PACKAGES=1
             apk update
             apk add --update make py3-pip git
             apk add --update make py3-pip git pkgconfig graphviz graphviz-dev gcc musl-dev


### PR DESCRIPTION
I've pinned the Docker image used for blueprint generation, as well as setting the `PIP_BREAK_SYSTEM_PACKAGES` environment variable to `1`. Either solution is enough to get a green build, but I think pinning the Docker image will make CI more robust in the future.