### PR TITLE
feat: `single_fibres`

### DIFF
--- a/PFR/ForMathlib/Entropy/RuzsaSetDist.lean
+++ b/PFR/ForMathlib/Entropy/RuzsaSetDist.lean
@@ -147,8 +147,15 @@ noncomputable def rdist_set (A B: Set G) : ℝ := kernel.rdistm (Measure.discret
 notation3:max "dᵤ[" A " # " B "]" => rdist_set A B
 
 /-- Relating Ruzsa distance between sets to Ruzsa distance between random variables -/
-lemma rdist_set_eq_rdist {A B: Set G} [Finite A] [Finite B]  [Nonempty A] [Nonempty B] {Ω Ω': Type*} [mΩ : MeasureSpace Ω] [mΩ' : MeasureSpace Ω'] (hμ: IsProbabilityMeasure (ℙ: Measure Ω)) (hμ': IsProbabilityMeasure (ℙ: Measure Ω')) {UA: Ω → G} {UB: Ω' → G} (hUA : IsUniform A UA ℙ) (hUB : IsUniform B UB ℙ) (hUA_mes : Measurable UA) (hUB_mes : Measurable UB) : dᵤ[A # B] = d[UA # UB] := by
-  rw [rdist_eq_rdistm, rdist_set, (Measure.isUniform_iff_uniform_dist A hμ hUA_mes).mp hUA, (Measure.isUniform_iff_uniform_dist B hμ' hUB_mes).mp hUB]
+lemma rdist_set_eq_rdist {A B: Set G} [Finite A] [Finite B]  [Nonempty A] [Nonempty B]
+    {Ω Ω': Type*} [mΩ : MeasureSpace Ω] [mΩ' : MeasureSpace Ω']
+    {μ : Measure Ω} {μ' : Measure Ω'}
+    (hμ: IsProbabilityMeasure μ) (hμ': IsProbabilityMeasure μ')
+    {UA: Ω → G} {UB: Ω' → G} (hUA : IsUniform A UA μ) (hUB : IsUniform B UB μ')
+    (hUA_mes : Measurable UA) (hUB_mes : Measurable UB) :
+    dᵤ[A # B] = d[UA ; μ # UB ; μ'] := by
+  rw [rdist_eq_rdistm, rdist_set, (Measure.isUniform_iff_uniform_dist A hμ hUA_mes).mp hUA,
+    (Measure.isUniform_iff_uniform_dist B hμ' hUB_mes).mp hUB]
 
 /-- Ruzsa distance between sets is nonnegative. -/
 lemma rdist_set_nonneg (A B: Set G) [Finite A] [Finite B]  [Nonempty A] [Nonempty B] : 0 ≤ dᵤ[A # B] := by

--- a/PFR/ForMathlib/Uniform.lean
+++ b/PFR/ForMathlib/Uniform.lean
@@ -1,4 +1,5 @@
 import Mathlib.Probability.IdentDistrib
+import Mathlib.Probability.ConditionalProbability
 import PFR.ForMathlib.MeasureReal
 import PFR.ForMathlib.FiniteRange
 
@@ -152,6 +153,35 @@ lemma IsUniform.measureReal_preimage_of_nmem (h : IsUniform H X μ) {s : S} (hs 
     μ.real (X ⁻¹' {s}) = 0 := by
   rw [measureReal_def, h.measure_preimage_of_nmem hs, ENNReal.zero_toReal]
 
+/-- $\mathbb{P}(U_H \in H') = \dfrac{|H' \cap H|}{|H|}$ -/
+lemma IsUniform.measure_preimage {H : Finset S} (h : IsUniform H X μ) (hX : Measurable X)
+    (H' : Set S) : μ (X ⁻¹' H') = (μ univ) * (Nat.card (H' ∩ H.toSet).Elem) / Nat.card H := calc
+  _ = μ (X ⁻¹' (H' ∩ H.toSet) ∪ X ⁻¹' (H' \ H.toSet)) := by simp
+  _ = μ (X ⁻¹' (H' ∩ H.toSet)) + μ (X ⁻¹' (H' \ H.toSet)) :=
+    measure_union (Disjoint.preimage X disjoint_inf_sdiff) (by measurability)
+  _ = μ (X ⁻¹' (H' ∩ H.toSet)) + 0 := congrArg _ <| by
+    rewrite [Set.diff_eq_compl_inter, ← le_zero_iff, ← h.measure_preimage_compl]
+    exact measure_mono (inter_subset_left _ _)
+  _ = μ (X ⁻¹' (H' ∩ H.toSet).toFinite.toFinset) := by simp
+  _ = (μ univ) * ∑ __ in (H' ∩ H.toSet).toFinite.toFinset, (1 : ENNReal) / Nat.card H := by
+    rewrite [← sum_measure_preimage_singleton _ (by measurability), Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun _ hx ↦ ?_)
+    rw [mul_one_div, h.measure_preimage_of_mem hX ((Finite.mem_toFinset _).mp hx).2]
+  _ = (μ univ) * (Nat.card (H' ∩ H.toSet).Elem) / Nat.card H := by
+    rw [Finset.sum_const, Nat.card_eq_card_finite_toFinset, nsmul_eq_mul, ← mul_assoc, mul_one_div]
+
+/-- $\mathbb{P}(U_H \in H') = \dfrac{|H' \cap H|}{|H|}$ -/
+lemma IsUniform.measureReal_preimage {H : Finset S} (h : IsUniform H X μ) (hX : Measurable X)
+    (H' : Set S) :
+    μ.real (X ⁻¹' H') = (μ.real univ) * (Nat.card (H' ∩ H.toSet).Elem) / Nat.card H := by
+  simp [measureReal_def, h.measure_preimage hX H', ENNReal.toReal_div]
+
+lemma IsUniform.nonempty_preimage_of_mem [NeZero μ] {H: Finset S} (h : IsUniform H X μ)
+    (hX : Measurable X) {s : S} (hs : s ∈ H) : Set.Nonempty (X ⁻¹' {s}) := by
+  apply MeasureTheory.nonempty_of_measure_ne_zero
+  rewrite [h.measure_preimage_of_mem hX hs]
+  simp [NeZero.ne]
+
 lemma IsUniform.full_measure (h : IsUniform H X μ) (hX: Measurable X) :
     (μ.map X) H = μ Set.univ := by
     rw [Measure.map_apply hX (by measurability)]
@@ -170,6 +200,34 @@ lemma IsUniform.of_identDistrib {Ω' : Type*} [MeasurableSpace Ω'] (h : IsUnifo
     apply h.eq_of_mem x y hx hy
   · rw [←h'.measure_mem_eq hH.compl]
     exact h.measure_preimage_compl
+
+/-- $\mathbb{P}(U_H \in H') \neq 0$ if $H'$ intersects $H$ and the measure is non-zero. -/
+lemma IsUniform.measure_preimage_ne_zero {H : Finset S} [NeZero μ] (h : IsUniform H X μ)
+    (hX : Measurable X) (H' : Set S) [Nonempty (H' ∩ H.toSet).Elem] : μ (X ⁻¹' H') ≠ 0 := by
+  simp_rw [h.measure_preimage hX H', ne_eq, ENNReal.div_eq_zero_iff, ENNReal.nat_ne_top, or_false,
+    mul_eq_zero, NeZero.ne, false_or, Nat.cast_eq_zero, ← Nat.pos_iff_ne_zero, Nat.card_pos]
+
+/-- If $X$ is uniform w.r.t. $\mu$ on $H$, then $X$ is uniform w.r.t. $\mu$ conditioned by
+$H'$ on $H' \cap H$. -/
+lemma IsUniform.restrict {H : Set S} (h : IsUniform H X μ) (hX : Measurable X) (H' : Set S) :
+    IsUniform (H' ∩ H) X (μ[|X ⁻¹' H']) where
+  eq_of_mem := fun x y hx hy ↦ by
+    show _ * _ = _ * _
+    rw [μ.restrict_eq_self (preimage_mono (singleton_subset_iff.mpr hx.1)),
+      μ.restrict_eq_self (preimage_mono (singleton_subset_iff.mpr hy.1)), h.eq_of_mem x y hx.2 hy.2]
+  measure_preimage_compl := le_zero_iff.mp <| by
+    rewrite [Set.compl_inter, Set.preimage_union]
+    calc
+      _ ≤ (μ[|X ⁻¹' H']) (X ⁻¹' H'ᶜ) + (μ[|X ⁻¹' H']) (X ⁻¹' Hᶜ) := measure_union_le _ _
+      _ = (μ[|X ⁻¹' H']) (X ⁻¹' H'ᶜ) + 0 := congrArg _ <| by
+        show _ * _ = _
+        rw [le_zero_iff.mp <| h.measure_preimage_compl.trans_ge <| Measure.restrict_apply_le _ _,
+          mul_zero]
+      _ = 0 := by
+        show _ * _ + 0 = 0
+        rw [add_zero, Set.preimage_compl, Measure.restrict_apply <|
+          MeasurableSet.compl (measurableSet_preimage hX (measurableSet_discrete H')),
+          compl_inter_self, measure_empty, mul_zero]
 
 lemma IdentDistrib.of_isUniform {Ω' : Type*}  [MeasurableSpace Ω'] {μ' : Measure Ω'} [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] [Finite H] {X: Ω → S} {X': Ω' → S} (hX: Measurable X) (hX': Measurable X') (hX_unif : IsUniform H X μ) (hX'_unif : IsUniform H X' μ') : IdentDistrib X X' μ μ' := by
   constructor

--- a/PFR/Mathlib/Probability/Independence/Basic.lean
+++ b/PFR/Mathlib/Probability/Independence/Basic.lean
@@ -319,8 +319,7 @@ lemma iIndepFun.prod (h : iIndepFun n f μ) :
 
 variable {β β' Ω : Type*} {mΩ : MeasurableSpace Ω} {μ : Measure Ω}
 
-/-- Improved version of `IndepFun.ae_eq` in which the ranges are allowed to be distinct.
-TODO: replace `IndepFun.ae_eq` with this one. -/
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem IndepFun.ae_eq' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'} {f f' : Ω → β}
     {g g' : Ω → β'} (hfg : IndepFun f g μ)
     (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : IndepFun f' g' μ := by
@@ -328,16 +327,14 @@ theorem IndepFun.ae_eq' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'} 
     simp only [ae_dirac_eq, Filter.eventually_pure, kernel.const_apply]
   exacts [hf, hg]
 
-/-- Improved version of `kernel.IndepFun.symm` in which the ranges are allowed to be distinct.
-TODO: replace `kernel.IndepFun.symm` with this one. -/
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem kernel.IndepFun.symm' {Ω α β γ : Type*} {_ : MeasurableSpace Ω} {_ : MeasurableSpace α}
     {_ : MeasurableSpace β} {_ : MeasurableSpace γ} {κ : kernel α Ω} {f : Ω → β} {g : Ω → γ}
     {μ : Measure α}
     (hfg : kernel.IndepFun f g κ μ) : kernel.IndepFun g f κ μ :=
   kernel.Indep.symm hfg
 
-/-- Improved version of `IndepFun.symm` in which the ranges are allowed to be distinct.
-TODO: replace `IndepFun.symm` with this one. -/
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem IndepFun.symm' {γ β Ω : Type*} {_ : MeasurableSpace γ}
     {_ : MeasurableSpace β} {_ : MeasurableSpace Ω} {μ : Measure Ω} {f : Ω → β} {g : Ω → γ}
     (hfg : IndepFun f g μ) :

--- a/PFR/Mathlib/Probability/Independence/Kernel.lean
+++ b/PFR/Mathlib/Probability/Independence/Kernel.lean
@@ -6,8 +6,8 @@ namespace ProbabilityTheory.kernel
 variable {β β' γ γ' : Type*} {_mα : MeasurableSpace α} {_mΩ : MeasurableSpace Ω}
   {κ : kernel α Ω} {μ : Measure α} {f : Ω → β} {g : Ω → β'}
 
-/-- Improved version of `IndepFun.ae_eq` in which the ranges are allowed to be distinct. Perhap
-can serve as a replacement of that method? -/
+
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem IndepFun.ae_eq' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'} {f f' : Ω → β}
     {g g' : Ω → β'} (hfg : IndepFun f g κ μ) (hf : ∀ᵐ a ∂μ, f =ᵐ[κ a] f')
     (hg : ∀ᵐ a ∂μ, g =ᵐ[κ a] g') : IndepFun f' g' κ μ := by


### PR DESCRIPTION
I add the hypotheses:
`(hUA_mem : ∀ ω, UA ω ∈ A) (hUB_mem : ∀ ω, UB ω ∈ B)`
which are returned from `exists_isUniform`.