### PR TITLE
Update blueprint installation procedure

### DIFF
--- a/blueprint/requirements.txt
+++ b/blueprint/requirements.txt
@@ -1,6 +1,8 @@
 # https://github.com/pyinvoke/invoke/issues/891
 invoke==2.2.0
 plasTeX @ git+https://github.com/plastex/plastex.git
+plastexdepgraph @ git+https://github.com/PatrickMassot/plastexdepgraph.git
+plastexshowmore @ git+https://github.com/PatrickMassot/plastexshowmore.git
 leanblueprint @ git+https://github.com/PatrickMassot/leanblueprint.git
 watchfiles==0.16.1
 pandoc==2.3

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,13 +35,7 @@ To build the web version of the blueprint, you need a working LaTeX installation
 Furthermore, you need some packages:
 ```
 sudo apt install graphviz libgraphviz-dev
-pip3 install invoke pandoc
-cd .. # go to folder where you are happy clone git repos
-git clone git@github.com:plastex/plastex
-pip3 install ./plastex
-git clone git@github.com:PatrickMassot/leanblueprint
-pip3 install ./leanblueprint
-cd sphere-eversion
+pip install -r blueprint/requirements.txt
 ```
 
 To actually build the blueprint, run


### PR DESCRIPTION
This is needed because the blueprint plugin was split into three pieces.