### PR TITLE
chore: fix flipped sign in single_fibres blueprint

### DIFF
--- a/blueprint/src/chapter/weak_pfr.tex
+++ b/blueprint/src/chapter/weak_pfr.tex
@@ -113,13 +113,13 @@ The random variables $(U_A\mid \phi(U_A)=x)$ and $(U_B\mid \phi(U_B)=y)$ are equ
 &\leq d[U_A;U_B]-d[\phi(U_A);\phi(U_B)].
 \end{align*}
 Therefore with $M:=\mathbb{H}(\phi(U_A))+\mathbb{H}(\phi(U_B))$ we have
-\[\sum_{x,y\in H}\frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}Md[U_{A_x};U_{B_y}]+Md[\phi(U_A);\phi(U_B)]\leq Md[U_A;U_B].\]
+\[\left(\sum_{x,y\in H}\frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}Md[U_{A_x};U_{B_y}]\right)+Md[\phi(U_A);\phi(U_B)]\leq Md[U_A;U_B].\]
 Since
 \[M=\sum_{x,y\in H}\frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\]
 we have
-\[\sum_{x,y\in H} \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\left(Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\right)\leq  Md[U_A;U_B].\]
+\[\sum_{x,y\in H} \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\left(Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\right)\leq  Md[U_A;U_B].\]
 It follows that there exists some $x,y\in H$ such that $\lvert A_x\rvert,\lvert B_y\rvert\neq 0$ and
-\[Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\leq  Md[U_A;U_B].\]
+\[Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq  Md[U_A;U_B].\]
 \end{proof}
 
 


### PR DESCRIPTION
The proof is still fine, since the statement has the sign going the correct way.