### PR TITLE
improve constant 44 to 40 in weak_PFR

### DIFF
--- a/PFR/WeakPFR.lean
+++ b/PFR/WeakPFR.lean
@@ -14,7 +14,9 @@ Here we use the entropic form of PFR to deduce a weak form of PFR over the integ
 
 ## Main statement
 
-* `weak_PFR_int`: Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$. There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-44}\lvert A\rvert$ and $\dim A' \leq 60\log K$.
+* `weak_PFR_int`: Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$.
+  There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-20}\lvert A\rvert$ and
+  $\dim A' \leq (40/\log 2)\log K$.
 
 -/
 
@@ -179,7 +181,7 @@ variable {G : Type u} [AddCommGroup G] [ElementaryAddCommGroup G 2] [Fintype G] 
 [MeasurableSingletonClass G] {Ω Ω' : Type*}
 
 /-- Let $G=\mathbb{F}_2^n$ and $X,Y$ be $G$-valued random variables such that
-\[\mathbb{H}(X)+\mathbb{H}(Y)> 44d[X;Y].\]
+\[\mathbb{H}(X)+\mathbb{H}(Y)> 40d[X;Y].\]
 There is a non-trivial subgroup $H\leq G$ such that
 \[\log \lvert H\rvert <\mathbb{H}(X)+\mathbb{H}(Y)\] and
 \[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))< \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}\]
@@ -687,7 +689,7 @@ lemma single {Ω: Type u} [MeasurableSpace Ω] [DiscreteMeasurableSpace Ω] (μ:
   assumption
 
 /-- Given two non-empty finite subsets A, B of a rank n free Z-module G, there exists a subgroup N and points x, y in G/N such that the fibers Ax, By of A, B over x, y respectively are non-empty, one has the inequality
-$$ \log \frac{|A| |B|}{|A_x| |B_y|} ≤ 44 (d[U_A; U_B] - d[U_{A_x}; U_{B_y}])$$
+$$ \log \frac{|A| |B|}{|A_x| |B_y|} ≤ 40 (d[U_A; U_B] - d[U_{A_x}; U_{B_y}])$$
 and one has the dimension bound
 $$ n \log 2 ≤ \log |G/N| + 40 d[U_A; U_B].$$
  -/
@@ -1035,7 +1037,7 @@ lemma conclusion_transfers {A B : Set G} [Finite A] [Finite B] [Nonempty A] [Non
 
 
 /-- If $A,B\subseteq \mathbb{Z}^d$ are finite non-empty sets then there exist non-empty $A'\subseteq A$ and $B'\subseteq B$ such that
-\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_A;U_B]\]
+\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 40 d[U_A;U_B]\]
 such that $\max(\dim A',\dim B')\leq \frac{40}{\log 2} d[U_A;U_B]$. -/
 lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] [Nonempty A] [Nonempty B]: weak_PFR_asymm_conclusion A B  := by
   let P : ℕ → Prop := fun M ↦ (∀ (G : Type u) (hG_comm : AddCommGroup G) (_hG_free : Module.Free ℤ G) (_hG_fin : Module.Finite ℤ G) (_hG_count : Countable G) (hG_mes : MeasurableSpace G) (_hG_sing: MeasurableSingletonClass G) (A B: Set G) (_hA_fin: Finite A) (_hB_fin: Finite B) (_hA_non: Nonempty A) (_hB_non: Nonempty B) (_hM : (Nat.card A) + (Nat.card B) ≤ M), weak_PFR_asymm_conclusion A B)

--- a/PFR/WeakPFR.lean
+++ b/PFR/WeakPFR.lean
@@ -224,7 +224,7 @@ lemma app_ent_PFR' [MeasureSpace Ω] [MeasureSpace Ω'] (X : Ω → G) (Y : Ω' 
     _ = 2 * (d[X # U] + d[Y # U]) := by ring
     _ ≤ 2 * (10 * d[X # Y]) := by gcongr
     _ = 20 * d[X # Y] := by ring
-  -- then the conclusion follows frpm the assumption `hent` and basic inequality manipulations
+  -- then the conclusion follows from the assumption `hent` and basic inequality manipulations
   exact ⟨by linarith [entropy_nonneg X ℙ, entropy_nonneg Y ℙ], by linarith⟩
 
 variable [MeasurableSpace Ω] [MeasurableSpace Ω'] (X : Ω → G) (Y : Ω' → G)

--- a/blueprint/src/chapter/weak_pfr.tex
+++ b/blueprint/src/chapter/weak_pfr.tex
@@ -51,7 +51,7 @@ and $\phi(2Y)=2\phi(Y)\equiv 0$ so the left-hand side is equal to $d[\phi(X);0]=
 
 \begin{lemma}\label{app-ent-pfr}\lean{app_ent_PFR}\leanok
 Let $G=\mathbb{F}_2^n$ and $X,Y$ be $G$-valued random variables such that
-\[\mathbb{H}(X)+\mathbb{H}(Y)> 44d[X;Y].\]
+\[\mathbb{H}(X)+\mathbb{H}(Y)> 40d[X;Y].\]
 There is a non-trivial subgroup $H\leq G$ such that
 \[\log \lvert H\rvert <\mathbb{H}(X)+\mathbb{H}(Y)\] and
 \[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))< \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}\]
@@ -59,12 +59,17 @@ where $\psi:G\to G/H$ is the natural projection homomorphism.
 \end{lemma}
 \begin{proof}
 \uses{entropy-pfr-improv, ruzsa-diff, dist-projection, ruzsa-nonneg}\leanok
-By Theorem \ref{entropy-pfr-improv} there exists a subgroup $H$ such that $d[X;U_H]\leq \frac{11}{2} d[X;Y]$ and $d[Y;U_H]\leq \frac{11}{2} d[X;Y]$. Using Lemma \ref{dist-projection} we deduce that $\mathbb{H}(\psi(X))\leq 11 d[X;Y]$ and $\mathbb{H}(\psi(Y))\leq 11d[X;Y]$. The second claim follows adding these inequalities and using the assumption on $\mathbb{H}(X)+\mathbb{H}(Y)$.
+By Theorem \ref{entropy-pfr-improv} there exists a subgroup $H$ such that
+$d[X;U_H] + d[Y;U_H] \leq 10 d[X;Y]$. Using Lemma \ref{dist-projection} we
+deduce that $\mathbb{H}(\psi(X)) + \mathbb{H}(\psi(X)) \leq 20 d[X;Y]$. The
+second claim follows adding these inequalities and using the assumption on
+$\mathbb{H}(X)+\mathbb{H}(Y)$.
 
 Furthermore we have by Lemma \ref{ruzsa-diff}
-\[\log \lvert H \rvert-\mathbb{H}(X)\leq 2d[X;U_H]\leq 11d[X;Y]\]
+\[\log \lvert H \rvert-\mathbb{H}(X)\leq 2d[X;U_H]\]
 and similarly for $Y$ and thus
-\[\log \lvert  H\rvert \leq \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}+12d[X;Y]< \mathbb{H}(X)+\mathbb{H}(Y).\]
+\[\log \lvert  H\rvert \leq \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}+d[X;U_H] + d[Y;U_H]
+\leq \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}+ 10d[X;Y] < \mathbb{H}(X)+\mathbb{H}(Y).\]
 Finally note that if $H$ were trivial then $\psi(X)=X$ and $\psi(Y)=Y$ and hence $\mathbb{H}(X)+\mathbb{H}(Y)=0$, which contradicts Lemma \ref{ruzsa-nonneg}.
 \end{proof}
 
@@ -73,12 +78,12 @@ Finally note that if $H$ were trivial then $\psi(X)=X$ and $\psi(Y)=Y$ and hence
 If $G=\mathbb{F}_2^d$ and $X,Y$ are $G$-valued random variables then there is a subgroup $H\leq \mathbb{F}_2^d$ such that
 \[\log \lvert H\rvert \leq 2(\mathbb{H}(X)+\mathbb{H}(Y))\]
 and if $\psi:G \to G/H$ is the natural projection then
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 44 d[\psi(X);\psi(Y)].\]
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 40 d[\psi(X);\psi(Y)].\]
 \end{lemma}
 \begin{proof}
 \uses{app-ent-pfr}\leanok
 Let $H\leq \mathbb{F}_2^d$ be a maximal subgroup such that
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))> 44d[\psi(X);\psi(Y)]\]
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))> 40d[\psi(X);\psi(Y)]\]
 and
 \[\log \lvert H\rvert \leq \left(2-2^{2-\lvert H\rvert}\right)(\mathbb{H}(X)+\mathbb{H}(Y))\]
 and
@@ -96,7 +101,7 @@ Since $H'$ is non-trivial we know that $H$ is a proper subgroup of $H''$. On the
 and
 \[\mathbb{H}(\psi''(X))+\mathbb{H}(\psi''(Y))< \frac{\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))}{2}\leq 2^{1-\lvert H'\rvert}(\mathbb{H}(X)+\mathbb{H}(Y)).\]
 Therefore (using the maximality of $H$) it must be the first condition that fails, whence
-\[\mathbb{H}(\psi''(X))+\mathbb{H}(\psi''(Y))\leq 48d[\psi''(X);\psi''(Y)].\]
+\[\mathbb{H}(\psi''(X))+\mathbb{H}(\psi''(Y))\leq 40d[\psi''(X);\psi''(Y)].\]
 \end{proof}
 
 
@@ -130,7 +135,7 @@ If $A\subseteq \mathbb{Z}^{d}$ then by $\dim(A)$ we mean the dimension of the sp
 
 \begin{theorem}\label{weak-pfr-asymm}\lean{weak_PFR_asymm}\leanok
 If $A,B\subseteq \mathbb{Z}^d$ are finite non-empty sets then there exist non-empty $A'\subseteq A$ and $B'\subseteq B$ such that
-\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_A;U_B]\]
+\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 40d[U_A;U_B]\]
 such that $\max(\dim A',\dim B')\leq \frac{40}{\log 2} d[U_A;U_B]$.
 \end{theorem}
 \begin{proof}
@@ -142,28 +147,28 @@ Let $\phi:\mathbb{Z}^d\to \mathbb{F}_2^d$ be the natural mod-2 homomorphism. By 
 We now apply Lemma \ref{pfr-projection}, obtaining some subgroup $H\leq \mathbb{F}_2^d$ such that
 \[\log \lvert H\rvert \leq 40d[U_A;U_B]\]
 and
-\[\mathbb{H}(\tilde{\phi}(U_A))+\mathbb{H}(\tilde{\phi}(U_B))\leq 44 d[\tilde{\phi}(U_A);\tilde{\phi}(U_B)]\]
+\[\mathbb{H}(\tilde{\phi}(U_A))+\mathbb{H}(\tilde{\phi}(U_B))\leq 40 d[\tilde{\phi}(U_A);\tilde{\phi}(U_B)]\]
 where $\tilde{\phi}:\mathbb{Z}^d\to \mathbb{F}_2^d/H$ is $\phi$ composed with the projection onto $\mathbb{F}_2^d/H$.
 
 
 By Lemma \ref{single-fibres} there exist $x,y\in \mathbb{F}_2^d/H$ such that, with $A_x=A\cap \tilde{\phi}^{-1}(x)$ and similarly for $B_y$,
-\[\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq 44(d[U_A;U_B]-d[U_{A_x};U_{B_y}]).\]
+\[\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq 40(d[U_A;U_B]-d[U_{A_x};U_{B_y}]).\]
 Suppose first that $\lvert A_x\rvert+\lvert B_y\rvert=\lvert A\rvert+\lvert B\rvert$. This means that $\tilde{\phi}(A)=\{x\}$ and $\tilde{\phi}(B)=\{y\}$, and hence both $A$ and $B$ are in cosets of $\ker \tilde{\phi}$. Since by assumption $A,B$ are not in cosets of a proper subgroup of $\mathbb{Z}^d$ this means $\ker\tilde{\phi}=\mathbb{Z}^d$, and so (examining the definition of $\tilde{\phi}$) we must have $H=\mathbb{F}_2^d$. Then our bound on $\log\lvert H\rvert$ forces $d\leq \frac{40}{\log 2}d[U_A;U_B]$ and we are done with $A'=A$ and $B'=B$.
 
 Otherwise,
 \[\lvert A_x\rvert+\lvert B_y\rvert <\lvert A\rvert+\lvert B\rvert.\]
 By induction we can find some $A'\subseteq A_x$ and $B'\subseteq B_y$ such that $\dim A',\dim B'\leq \frac{40}{\log 2} d[U_{A_x};U_{B_y}]\leq \frac{40}{\log 2}d[U_A;U_B]$ and
 
-\[\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_{A_x};U_{B_y}].\]
+\[\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 40d[U_{A_x};U_{B_y}].\]
 Adding these inequalities implies
 
-\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_A;U_B]\]
+\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 40d[U_A;U_B]\]
 as required.
 \end{proof}
 
 \begin{theorem}\label{weak-pfr-symm}\lean{weak_PFR_symm}\leanok
 If $A\subseteq \mathbb{Z}^d$ is a finite non-empty set with $d[U_A;U_A]\leq \log K$ then there exists a non-empty $A'\subseteq A$ such that
-\[\lvert A'\rvert\geq K^{-22}\lvert A\rvert\]
+\[\lvert A'\rvert\geq K^{-20}\lvert A\rvert\]
 and $\dim A'\leq \frac{40}{\log 2} \log K$.
 \end{theorem}
 \begin{proof}
@@ -172,7 +177,9 @@ Immediate from Theorem \ref{weak-pfr-asymm} and rearranging.
 \end{proof}
 
 \begin{theorem}\label{weak-pfr-int}\lean{weak_PFR_int}\leanok
-Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$. There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-22}\lvert A\rvert$ and $\dim A' \leq \frac{40}{\log 2}\log K$.
+Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$.
+There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-20}\lvert
+A\rvert$ and $\dim A' \leq \frac{40}{\log 2}\log K$.
 \end{theorem}
 \begin{proof}\leanok
 \uses{weak-pfr-symm,dimension-def}


### PR DESCRIPTION
This is a trivial improvement, using the collective bound $d[U_H, X] + d[U_H, Y] \le 10 d[X, Y]$ instead of the individual bounds $d[U_H, X] \le 11/2 d[X,Y]$ and $d[U_H, Y] \le 11/2 d[X,Y]$, as everything comes by pairs.