### PR TITLE
chore: Update bump to master

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,6 +60,7 @@ jobs:
             .lake/build/doc/Std
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
+            !.lake/build/doc/declarations/declaration-data-PFR*
           key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
             MathlibDoc-

--- a/PFR/ApproxHomPFR.lean
+++ b/PFR/ApproxHomPFR.lean
@@ -145,12 +145,209 @@ def C₄ := 4
 /-- Let $G$ be an abelian group, and let $A$ be a finite non-empty set with $E(A) \geq |A|^3 / K$ for some $K \geq 1$.  Then there is a subset $A'$ of $A$ with $|A'| \geq |A| / (C_1 K^{C_2})$ and $|A'-A'| \leq C_3 K^{C_4} |A'|$ -/
 lemma bsg (A : Finset G) (K : ℝ) (hK: 0 < K) (hE: E[A] ≥ (A.card)^3 / K): ∃ A' : Finset G, A' ⊆ A ∧ A'.card ≥ A.card / (C₁ * K^C₂) ∧ (A' - A').card ≤ C₃ * K^C₄ * A'.card := sorry
 
-
+open scoped BigOperators
 variable {G G' : Type*} [AddCommGroup G] [Fintype G] [AddCommGroup G'] [Fintype G']
   [ElementaryAddCommGroup G 2] [ElementaryAddCommGroup G' 2]
 
-/-- Let $G,G'$ be finite abelian $2$-groups.
-  Let $f: G \to G'$ be a function, and suppose that there are at least $|G|^2 / K$ pairs $(x,y) \in G^2$ such that
-$$ f(x+y) = f(x) + f(y).$$
-Then there exists a homomorphism $\phi: G \to G'$ and a constant $c \in G'$ such that $f(x) = \phi(x)+c$ for at least $|G| / 4C_1^{21} C_3^{20} K^{46C_4+44 C_2}$ values of $x \in G$. -/
-theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK: K > 0) (hf: Nat.card { x : G × G| f (x.1+x.2) = (f x.1) + (f x.2) } ≥ (Nat.card G)^2/ K) : ∃ (φ : G →+ G') (c : G'), Nat.card { x : G | f x = φ x + c } ≥ (Nat.card G) / (4 * C₁^21 * C₃^20 * K^(46 * C₄ + 44 * C₂)) := sorry
+lemma equiv_filter_graph (f : G → G') :
+    let A := (Set.graph f).toFinite.toFinset
+    (A ×ˢ A).filter (fun (a, a') ↦ a + a' ∈ A) ≃
+    { x : G × G | f (x.1 + x.2) = (f x.1) + (f x.2) } where
+  toFun := fun ⟨a, ha⟩ ↦ by
+    let A := (Set.graph f).toFinite.toFinset
+    use (a.1.1, a.2.1)
+    apply Finset.mem_filter.mp at ha
+    have h {a} (h' : a ∈ A) := (Set.mem_graph _).mp <| (Set.graph f).toFinite.mem_toFinset.mp h'
+    show f (a.1.1 + a.2.1) = (f a.1.1) + (f a.2.1)
+    rw [h (Finset.mem_product.mp ha.1).1, h (Finset.mem_product.mp ha.1).2]
+    exact h ha.2
+  invFun := fun ⟨a, ha⟩ ↦ by
+    use ((a.1, f a.1), (a.2, f a.2))
+    refine Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨?_, ?_⟩, ?_⟩
+    <;> apply (Set.graph f).toFinite.mem_toFinset.mpr
+    · exact ⟨a.1, rfl⟩
+    · exact ⟨a.2, rfl⟩
+    · exact (Set.mem_graph _).mpr ha
+  left_inv := fun ⟨x, hx⟩ ↦ by
+    apply Subtype.ext
+    show ((x.1.1, f x.1.1), x.2.1, f x.2.1) = x
+    obtain ⟨hx1, hx2⟩ := Finset.mem_product.mp (Finset.mem_filter.mp hx).1
+    rewrite [(Set.graph f).toFinite.mem_toFinset] at hx1 hx2
+    rw [(Set.mem_graph x.1).mp hx1, (Set.mem_graph x.2).mp hx2]
+  right_inv := fun _ ↦ rfl
+
+set_option maxHeartbeats 400000 in
+/-- Let $G, G'$ be finite abelian $2$-groups.
+Let $f: G \to G'$ be a function, and suppose that there are at least
+$|G|^2 / K$ pairs $(x,y) \in G^2$ such that $$ f(x+y) = f(x) + f(y).$$
+Then there exists a homomorphism $\phi: G \to G'$ and a constant $c \in G'$ such that
+$f(x) = \phi(x)+c$ for at least $|G| / C_1 C_3^{12} K^{24C_4 + 2C_2}$ values of $x \in G$. -/
+theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK: K > 0)
+    (hf: Nat.card { x : G × G | f (x.1+x.2) = (f x.1) + (f x.2) } ≥ (Nat.card G)^2 / K) :
+    ∃ (φ : G →+ G') (c : G'), Nat.card { x : G | f x = φ x + c } ≥
+    (Nat.card G) / (C₁ * C₃^12 * K^(24 * C₄ + 2 * C₂)) := by
+  let A := (Set.graph f).toFinite.toFinset
+
+  have h_cs : ((A ×ˢ A).filter (fun (a, a') ↦ a + a' ∈ A) |>.card : ℝ) ^ 2 ≤
+      Finset.card A * E[A] := by norm_cast; convert cauchy_schwarz A A
+  rewrite [← Nat.card_eq_finsetCard, ← Nat.card_eq_finsetCard,
+    Nat.card_congr (equiv_filter_graph f)] at h_cs
+
+  have hA : Nat.card A = Nat.card G := by
+    rewrite [← Set.card_graph f, Nat.card_eq_finsetCard, Set.Finite.card_toFinset]; simp
+  have hA_pos : 0 < (Nat.card A : ℝ) := Nat.cast_pos.mpr <| Nat.card_pos.trans_eq hA.symm
+  have : ((Nat.card G)^2 / K)^2 ≤ Nat.card A * E[A] := LE.le.trans (by gcongr) h_cs
+  rewrite [← hA] at this
+  replace : E[A] ≥ (Finset.card A)^3 / K^2 := calc
+    _ ≥ ((Nat.card A)^2 / K)^2 / Nat.card A := (div_le_iff' <| hA_pos).mpr this
+    _ = ((Nat.card A)^4 / (Nat.card A)) / K^2 := by ring
+    _ = (Finset.card A)^3 / K^2 := by
+      rw [pow_succ, mul_comm, mul_div_assoc, div_self (ne_of_gt hA_pos), mul_one,
+        Nat.card_eq_finsetCard]
+  obtain ⟨A', hA', hA'1, hA'2⟩ := bsg A (K^2) (sq_pos_of_pos hK) (by convert this)
+  clear h_cs hf this
+
+  let A'' := A'.toSet
+  have hA''_coe : Nat.card A'' = Finset.card A' := Nat.card_eq_finsetCard A'
+  have h_pos1 : 0 < (C₁ : ℝ) * (K ^ 2) ^ C₂ :=
+    mul_pos (by unfold C₁; norm_num) (pow_pos (pow_pos hK 2) C₂)
+  have hA''_pos : 0 < Nat.card A'' := by
+    rewrite [hA''_coe, ← Nat.cast_pos (α := ℝ)]
+    exact LT.lt.trans_le (div_pos (by rwa [← Nat.card_eq_finsetCard]) h_pos1) hA'1
+  have hA''_nonempty : Set.Nonempty A'' := nonempty_subtype.mp (Finite.card_pos_iff.mp hA''_pos)
+  have : Finset.card (A' - A') = Nat.card (A'' + A'') := calc
+    _ = Nat.card (A' - A').toSet := (Nat.card_eq_finsetCard _).symm
+    _ = Nat.card (A'' + A'') := by rw [Finset.coe_sub, sumset_eq_sub]
+  replace :  Nat.card (A'' + A'') ≤ C₃ * (K ^ 2) ^ C₄ * (Nat.card A'') := by
+    rewrite [← this, hA''_coe]
+    convert hA'2
+  obtain ⟨H, c, hc_card, hH_le, hH_ge, hH_cover⟩ := PFR_conjecture_improv_aux hA''_nonempty this
+  clear hA'2 hA''_coe hH_le hH_ge hA_pos
+  obtain ⟨H₀, H₁, φ, hH₀H₁, hH₀H₁_card⟩ := goursat H
+
+  have h_le_H₀ : Nat.card A'' ≤ Nat.card c * Nat.card H₀ := by
+    have h_le := Nat.card_mono (Set.toFinite _) (Set.image_subset Prod.fst hH_cover)
+    have h_proj_A'' : Nat.card A'' = Nat.card (Prod.fst '' A'') := Nat.card_congr
+      (Equiv.Set.imageOfInjOn Prod.fst A'' <|
+        Set.InjOn.mono (Set.Finite.subset_toFinset.mp hA') (Set.fst_injOn_graph f))
+    have h_proj_c : Prod.fst '' (c + H : Set (G × G')) = (Prod.fst '' c) + H₀ := by
+      ext x ; constructor <;> intro hx
+      · obtain ⟨x, ⟨⟨c, h, hc, hh, hch⟩, hx⟩⟩ := hx
+        rewrite [← hx]
+        use c.1, h.1
+        exact ⟨Set.mem_image_of_mem Prod.fst hc, ((hH₀H₁ h).mp hh).1, (Prod.ext_iff.mp hch).1⟩
+      · obtain ⟨_, h, ⟨c, hc⟩, hh, hch⟩ := hx
+        refine ⟨c + Prod.mk h (φ h), ⟨⟨c, Prod.mk h (φ h), ?_⟩,  by rwa [← hc.2] at hch⟩⟩
+        exact ⟨hc.1, (hH₀H₁ ⟨h, φ h⟩).mpr ⟨hh, by rw [sub_self]; apply zero_mem⟩, rfl⟩
+    rewrite [← h_proj_A'', h_proj_c] at h_le
+    apply (h_le.trans Set.card_add_le).trans
+    gcongr
+    exact Nat.card_image_le c.toFinite
+
+  have hH₀_pos : (0 : ℝ) < Nat.card H₀ := Nat.cast_pos.mpr Nat.card_pos
+  have h_le_H₁ : (Nat.card H₁ : ℝ) ≤ (Nat.card c) * (Nat.card H) / Nat.card A'' := calc
+    _ = (Nat.card H : ℝ) / (Nat.card H₀) :=
+      (eq_div_iff <| ne_of_gt <| hH₀_pos).mpr <| by rw [mul_comm, ← Nat.cast_mul, hH₀H₁_card]
+    _ ≤ (Nat.card c : ℝ) * (Nat.card H) / Nat.card A'' := by
+      nth_rewrite 1 [← mul_one (Nat.card H : ℝ), mul_comm (Nat.card c : ℝ)]
+      repeat rewrite [mul_div_assoc]
+      refine mul_le_mul_of_nonneg_left ?_ (Nat.cast_nonneg _)
+      refine le_of_mul_le_mul_right ?_ hH₀_pos
+      refine le_of_mul_le_mul_right ?_ (Nat.cast_pos.mpr hA''_pos)
+      rewrite [div_mul_cancel 1, mul_right_comm, one_mul,  div_mul_cancel, ← Nat.cast_mul]
+      · exact Nat.cast_le.mpr h_le_H₀
+      · exact ne_of_gt (Nat.cast_pos.mpr hA''_pos)
+      · exact ne_of_gt hH₀_pos
+  clear h_le_H₀ hA''_pos hH₀_pos hH₀H₁_card
+
+  let translate (c : G × G') (h : G') := A'' ∩ ({c} + {(0, h)} + Set.graph φ.toFun)
+  have h_translate (c : G × G') (h : G') :
+      Prod.fst '' translate c h ⊆ { x : G | f x = φ x + (-φ c.1 + c.2 + h) } := by
+    intro x hx
+    obtain ⟨x, ⟨⟨hxA'', ⟨_, x', ⟨c', h', hc, hh, hch⟩, hx, hchx⟩⟩, hxx⟩⟩ := hx
+    show f _ = φ _ + (-φ c.1 + c.2 + h)
+    replace := (Set.mem_graph x).mp <| (Set.graph f).toFinite.mem_toFinset.mp (hA' hxA'')
+    rewrite [← hxx, this, ← hchx, ← hch, hc, hh]
+    show c.2 + h + x'.2 = φ (c.1 + 0 + x'.1) + (-φ c.1 + c.2 + h)
+    replace : φ x'.1 = x'.2 := (Set.mem_graph x').mp hx
+    rw [map_add, map_add, map_zero, add_zero, this, add_comm (φ c.1), add_assoc x'.2,
+      ← add_assoc (φ c.1), ← add_assoc (φ c.1), add_neg_self, zero_add, add_comm]
+  have h_translate_card c h : Nat.card (translate c h) = Nat.card (Prod.fst '' translate c h) :=
+    Nat.card_congr (Equiv.Set.imageOfInjOn Prod.fst (translate c h) <|
+      Set.InjOn.mono (fun _ hx ↦ Set.Finite.subset_toFinset.mp hA' hx.1) (Set.fst_injOn_graph f))
+
+  let cH₁ := (c ×ˢ H₁).toFinite.toFinset
+  haveI A_nonempty : Nonempty A'' := Set.nonempty_coe_sort.mpr hA''_nonempty
+  replace : Nonempty c := by
+    obtain ⟨c, _, hc, _, _⟩ := hH_cover (Classical.choice A_nonempty).property
+    exact ⟨c, hc⟩
+  replace h_nonempty : Set.Nonempty (c ×ˢ H₁) :=
+    Set.Nonempty.prod (Set.nonempty_coe_sort.mp this) (Set.nonempty_coe_sort.mp inferInstance)
+  replace : A' = Finset.biUnion cH₁ fun ch ↦ (translate ch.1 ch.2).toFinite.toFinset := by
+    ext x ; constructor <;> intro hx
+    · obtain ⟨c', h, hc, hh, hch⟩ := hH_cover hx
+      refine Finset.mem_biUnion.mpr ⟨(c', h.2 - φ h.1), ?_⟩
+      refine ⟨(Set.Finite.mem_toFinset _).mpr ⟨hc, ((hH₀H₁ h).mp hh).2⟩, ?_⟩
+      refine (Set.Finite.mem_toFinset _).mpr ⟨hx, ⟨c' + (0, h.2 - φ h.1), (h.1, φ h.1), ?_⟩⟩
+      refine ⟨⟨c', (0, h.2 - φ h.1), rfl, rfl, rfl⟩, ⟨⟨h.1, rfl⟩, ?_⟩⟩
+      beta_reduce
+      rewrite [add_assoc]
+      show c' + (0 + h.1, h.2 - φ h.1 + φ h.1) = x
+      rewrite [zero_add, sub_add_cancel]
+      exact hch
+    · obtain ⟨ch, hch⟩ := Finset.mem_biUnion.mp hx
+      exact ((Set.Finite.mem_toFinset _).mp hch.2).1
+
+  replace : ∑ __ in cH₁, ((Finset.card A) / (C₁ * (K ^ 2) ^ C₂) / cH₁.card : ℝ) ≤
+      ∑ ch in cH₁, ((translate ch.1 ch.2).toFinite.toFinset.card : ℝ) := by
+    rewrite [Finset.sum_const, nsmul_eq_mul, ← mul_div_assoc, mul_div_right_comm, div_self, one_mul]
+    · apply hA'1.trans
+      norm_cast
+      exact (congrArg Finset.card this).trans_le Finset.card_biUnion_le
+    · symm
+      refine ne_of_lt <| Nat.cast_zero.symm.trans_lt <| Nat.cast_lt.mpr <| Finset.card_pos.mpr ?_
+      exact (Set.Finite.toFinset_nonempty _).mpr h_nonempty
+  replace : ∃ c' : G × G', ∃ h : G', (Finset.card A) / (C₁ * (K ^ 2) ^ C₂) / cH₁.card ≤
+      Nat.card { x : G | f x = φ x + (-φ c'.1 + c'.2 + h) } := by
+    obtain ⟨ch, hch⟩ :=
+      Finset.exists_le_of_sum_le ((Set.Finite.toFinset_nonempty _).mpr h_nonempty) this
+    refine ⟨ch.1, ch.2, hch.2.trans ?_⟩
+    rewrite [Set.Finite.card_toFinset, ← Nat.card_eq_fintype_card, h_translate_card]
+    exact Nat.cast_le.mpr <| Nat.card_mono (Set.toFinite _) (h_translate ch.1 ch.2)
+  clear hA' hA'1 hH_cover hH₀H₁ translate h_translate h_translate_card
+
+  obtain ⟨c', h, hch⟩ := this
+  use φ, -φ c'.1 + c'.2 + h
+  refine LE.le.trans ?_ hch
+  unfold_let cH₁
+  rewrite [← Nat.card_eq_finsetCard, div_div, hA]
+  apply div_le_div_of_le_left (Nat.cast_nonneg _) <| mul_pos h_pos1 <| Nat.cast_pos.mpr <|
+    Finset.card_pos.mpr <| (Set.Finite.toFinset_nonempty _).mpr h_nonempty
+  rewrite [← c.toFinite.toFinset_prod (H₁ : Set G').toFinite, Finset.card_product]
+  repeat rewrite [Set.Finite.card_toFinset, ← Nat.card_eq_fintype_card]
+  rewrite [Nat.cast_mul, ← mul_assoc _ (Nat.card c : ℝ)]
+  replace := mul_nonneg h_pos1.le (Nat.cast_nonneg (Nat.card c))
+  apply (mul_le_mul_of_nonneg_left h_le_H₁ this).trans
+  rewrite [mul_div_assoc, ← mul_assoc, mul_comm _ (Nat.card c : ℝ), mul_assoc]
+  have hHA := div_nonneg (α := ℝ) (Nat.cast_nonneg (Nat.card H)) <| Nat.cast_nonneg (Nat.card A'')
+  apply (mul_le_mul_of_nonneg_right hc_card <| mul_nonneg this hHA).trans
+  rewrite [mul_comm, mul_assoc, mul_comm _ (Nat.card c : ℝ), mul_assoc]
+  refine (mul_le_mul_of_nonneg_right hc_card ?_).trans_eq ?_
+  · exact mul_nonneg h_pos1.le <| mul_nonneg hHA <| by positivity
+  have h_pos2 : 0 < (C₃ : ℝ) * (K ^ 2) ^ C₄ :=
+    mul_pos (by unfold C₃; norm_num) (pow_pos (pow_pos hK 2) C₄)
+  rewrite [mul_comm, mul_assoc, mul_assoc, mul_assoc, mul_mul_mul_comm,
+    ← Real.rpow_add (Nat.cast_pos.mpr Nat.card_pos), mul_mul_mul_comm,
+    ← Real.rpow_add (Nat.cast_pos.mpr Nat.card_pos), ← Real.rpow_add h_pos2]
+  norm_num
+  rewrite [mul_comm _ (Finset.card A' : ℝ), mul_assoc (Finset.card A' : ℝ),
+    ← mul_assoc _ (Finset.card A' : ℝ), div_mul_cancel _ <|
+    Nat.cast_ne_zero.mpr (Finset.card_pos.mpr hA''_nonempty).ne.symm, Real.rpow_neg_one,
+    mul_comm (Fintype.card H : ℝ), mul_assoc _ _ (Fintype.card H : ℝ),
+    inv_mul_cancel <| NeZero.natCast_ne _ _, mul_one, ← pow_mul,
+    Real.mul_rpow (by norm_num) (pow_nonneg (sq_nonneg K) C₄), ← pow_mul,
+    mul_comm (K ^ _), mul_assoc _ _ (K ^ _)]
+  repeat rewrite [show (12 : ℝ) = ((12 : ℕ) : ℝ) from rfl]
+  repeat rewrite [Real.rpow_nat_cast]
+  rewrite [← pow_mul, ← pow_add, mul_right_comm, ← mul_assoc]
+  norm_num

--- a/PFR/ApproxHomPFR.lean
+++ b/PFR/ApproxHomPFR.lean
@@ -38,9 +38,9 @@ lemma nat_cauchy_schwartz {B : Type*} [Fintype B] (v w : B → ℕ) :
 lemma nat_cauchy_schwartz' {X : Type*} (B : Finset X) (v w : X → ℕ) :
   (B.sum (v * w))^2 ≤ B.sum (v^2) * B.sum (w^2) := by
   have := nat_cauchy_schwartz (fun b : B => v b) (fun b : B => w b)
-  rwa [← (show Finset.univ.sum (fun b : B => (v * w) b) = B.sum (v * w) from Finset.sum_attach _ _),
-    ← (show Finset.univ.sum (fun b : B => (v^2 : X → ℕ) b) = B.sum (v^2) from Finset.sum_attach _ _),
-    ← (show Finset.univ.sum (fun b : B => (w^2 : X → ℕ) b) = B.sum (w^2) from Finset.sum_attach _ _)]
+  rwa [← (show Finset.univ.sum (fun b : B => (v * w) b) = B.sum (v * w) from Finset.sum_attach ..),
+    ← (show Finset.univ.sum (fun b : B => (v^2 : X → ℕ) b) = B.sum (v^2) from Finset.sum_attach ..),
+    ← (show Finset.univ.sum (fun b : B => (w^2 : X → ℕ) b) = B.sum (w^2) from Finset.sum_attach ..)]
 
 /--  If $G$ is a group, $A,B$ are finite subsets of $G$, then
 $$ E(A) \geq \frac{|\{ (a,a') \in A \times A: a+a' \in B \}|^2}{|B|}.$$ -/

--- a/PFR/ApproxHomPFR.lean
+++ b/PFR/ApproxHomPFR.lean
@@ -38,9 +38,9 @@ lemma nat_cauchy_schwartz {B : Type*} [Fintype B] (v w : B → ℕ) :
 lemma nat_cauchy_schwartz' {X : Type*} (B : Finset X) (v w : X → ℕ) :
   (B.sum (v * w))^2 ≤ B.sum (v^2) * B.sum (w^2) := by
   have := nat_cauchy_schwartz (fun b : B => v b) (fun b : B => w b)
-  rwa [← (show Finset.univ.sum (fun b : B => (v * w) b) = B.sum (v * w) from Finset.sum_attach),
-    ← (show Finset.univ.sum (fun b : B => (v^2 : X → ℕ) b) = B.sum (v^2) from Finset.sum_attach),
-    ← (show Finset.univ.sum (fun b : B => (w^2 : X → ℕ) b) = B.sum (w^2) from Finset.sum_attach)]
+  rwa [← (show Finset.univ.sum (fun b : B => (v * w) b) = B.sum (v * w) from Finset.sum_attach _ _),
+    ← (show Finset.univ.sum (fun b : B => (v^2 : X → ℕ) b) = B.sum (v^2) from Finset.sum_attach _ _),
+    ← (show Finset.univ.sum (fun b : B => (w^2 : X → ℕ) b) = B.sum (w^2) from Finset.sum_attach _ _)]
 
 /--  If $G$ is a group, $A,B$ are finite subsets of $G$, then
 $$ E(A) \geq \frac{|\{ (a,a') \in A \times A: a+a' \in B \}|^2}{|B|}.$$ -/

--- a/PFR/ApproxHomPFR.lean
+++ b/PFR/ApproxHomPFR.lean
@@ -232,13 +232,12 @@ theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK: K > 0)
         Set.InjOn.mono (Set.Finite.subset_toFinset.mp hA') (Set.fst_injOn_graph f))
     have h_proj_c : Prod.fst '' (c + H : Set (G × G')) = (Prod.fst '' c) + H₀ := by
       ext x ; constructor <;> intro hx
-      · obtain ⟨x, ⟨⟨c, h, hc, hh, hch⟩, hx⟩⟩ := hx
+      · obtain ⟨x, ⟨⟨c, hc, h, hh, hch⟩, hx⟩⟩ := hx
         rewrite [← hx]
-        use c.1, h.1
-        exact ⟨Set.mem_image_of_mem Prod.fst hc, ((hH₀H₁ h).mp hh).1, (Prod.ext_iff.mp hch).1⟩
-      · obtain ⟨_, h, ⟨c, hc⟩, hh, hch⟩ := hx
-        refine ⟨c + Prod.mk h (φ h), ⟨⟨c, Prod.mk h (φ h), ?_⟩,  by rwa [← hc.2] at hch⟩⟩
-        exact ⟨hc.1, (hH₀H₁ ⟨h, φ h⟩).mpr ⟨hh, by rw [sub_self]; apply zero_mem⟩, rfl⟩
+        exact ⟨c.1, Set.mem_image_of_mem Prod.fst hc, h.1, ((hH₀H₁ h).mp hh).1, (Prod.ext_iff.mp hch).1⟩
+      · obtain ⟨_, ⟨c, hc⟩, h, hh, hch⟩ := hx
+        refine ⟨c + Prod.mk h (φ h), ⟨⟨c, hc.1, Prod.mk h (φ h), ?_⟩, by rwa [← hc.2] at hch⟩⟩
+        exact ⟨(hH₀H₁ ⟨h, φ h⟩).mpr ⟨hh, by rw [sub_self]; apply zero_mem⟩, rfl⟩
     rewrite [← h_proj_A'', h_proj_c] at h_le
     apply (h_le.trans Set.card_add_le).trans
     gcongr
@@ -264,7 +263,7 @@ theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK: K > 0)
   have h_translate (c : G × G') (h : G') :
       Prod.fst '' translate c h ⊆ { x : G | f x = φ x + (-φ c.1 + c.2 + h) } := by
     intro x hx
-    obtain ⟨x, ⟨⟨hxA'', ⟨_, x', ⟨c', h', hc, hh, hch⟩, hx, hchx⟩⟩, hxx⟩⟩ := hx
+    obtain ⟨x, ⟨⟨hxA'', ⟨_, ⟨c', hc, h', hh, hch⟩, x', hx, hchx⟩⟩, hxx⟩⟩ := hx
     show f _ = φ _ + (-φ c.1 + c.2 + h)
     replace := (Set.mem_graph x).mp <| (Set.graph f).toFinite.mem_toFinset.mp (hA' hxA'')
     rewrite [← hxx, this, ← hchx, ← hch, hc, hh]
@@ -279,17 +278,17 @@ theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK: K > 0)
   let cH₁ := (c ×ˢ H₁).toFinite.toFinset
   haveI A_nonempty : Nonempty A'' := Set.nonempty_coe_sort.mpr hA''_nonempty
   replace : Nonempty c := by
-    obtain ⟨c, _, hc, _, _⟩ := hH_cover (Classical.choice A_nonempty).property
+    obtain ⟨c, hc, _, _, _⟩ := hH_cover (Classical.choice A_nonempty).property
     exact ⟨c, hc⟩
   replace h_nonempty : Set.Nonempty (c ×ˢ H₁) :=
     Set.Nonempty.prod (Set.nonempty_coe_sort.mp this) (Set.nonempty_coe_sort.mp inferInstance)
   replace : A' = Finset.biUnion cH₁ fun ch ↦ (translate ch.1 ch.2).toFinite.toFinset := by
     ext x ; constructor <;> intro hx
-    · obtain ⟨c', h, hc, hh, hch⟩ := hH_cover hx
+    · obtain ⟨c', hc, h, hh, hch⟩ := hH_cover hx
       refine Finset.mem_biUnion.mpr ⟨(c', h.2 - φ h.1), ?_⟩
       refine ⟨(Set.Finite.mem_toFinset _).mpr ⟨hc, ((hH₀H₁ h).mp hh).2⟩, ?_⟩
-      refine (Set.Finite.mem_toFinset _).mpr ⟨hx, ⟨c' + (0, h.2 - φ h.1), (h.1, φ h.1), ?_⟩⟩
-      refine ⟨⟨c', (0, h.2 - φ h.1), rfl, rfl, rfl⟩, ⟨⟨h.1, rfl⟩, ?_⟩⟩
+      refine (Set.Finite.mem_toFinset _).mpr ⟨hx, c' + (0, h.2 - φ h.1), ?_⟩
+      refine ⟨⟨c', rfl, (0, h.2 - φ h.1), rfl, rfl⟩, (h.1, φ h.1), ⟨h.1, rfl⟩, ?_⟩
       beta_reduce
       rewrite [add_assoc]
       show c' + (0 + h.1, h.2 - φ h.1 + φ h.1) = x

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -906,6 +906,22 @@ lemma entropy_submodular (hX : Measurable X) (hY : Measurable Y) (hZ : Measurabl
     all_goals measurability
   exact kernel.entropy_congr (condDistrib_snd_ae_eq hY hX hZ _)
 
+/-- Data-processing inequality for the conditional entropy:
+$$ H[Y|f(X)] \geq H[Y|X]$$
+To upgrade this to equality, see `condEntropy_of_injective'` -/
+lemma condEntropy_comp_ge [FiniteRange X] [FiniteRange Y] (μ : Measure Ω) [IsProbabilityMeasure μ]
+    (hX : Measurable X) (hY : Measurable Y) (f : S → U) : H[Y | f ∘ X ; μ] ≥ H[Y | X; μ] := by
+  have h_joint : H[⟨Y, ⟨X, f ∘ X⟩⟩ ; μ] = H[⟨Y, X⟩ ; μ] := by
+    let g : T × S → T × S × U := fun (y, x) ↦ (y, (x, f x))
+    show H[g ∘ ⟨Y, X⟩ ; μ] = H[⟨Y, X⟩ ; μ]
+    refine entropy_comp_of_injective μ (by exact Measurable.prod hY hX) g (fun _ _ h => ?_)
+    repeat rewrite [Prod.mk.injEq] at h
+    exact Prod.ext h.1 h.2.1
+  have hZ : Measurable (f ∘ X) := (measurable_of_countable _).comp hX
+  rewrite [chain_rule'' μ hY hX, ← entropy_prod_comp hX μ f, ← h_joint,
+    ← chain_rule'' μ hY (Measurable.prod (by exact hX) (by exact hZ))]
+  exact entropy_submodular μ hY hX hZ
+
 /-- The submodularity inequality:
 $$ H[X, Y, Z] + H[Z] \leq H[X, Z] + H[Y, Z].$$ -/
 lemma entropy_triple_add_entropy_le (hX : Measurable X) (hY : Measurable Y) (hZ : Measurable Z) [FiniteRange X] [FiniteRange Y] [FiniteRange Z] :

--- a/PFR/ForMathlib/Entropy/Group.lean
+++ b/PFR/ForMathlib/Entropy/Group.lean
@@ -114,8 +114,8 @@ lemma condEntropy_mul_right (hX : Measurable X) (hY : Measurable Y) :
     H[X * Y | Y ; μ] = H[X | Y ; μ] :=
   condEntropy_of_injective μ hX hY (fun y x ↦ x * y) mul_left_injective
 
-/-- $$H[X / Y | Y] = H[X | Y]$$ -/
-@[to_additive "$$H[X - Y | Y] = H[X | Y]$$"]
+/-- $$H[Y / X | Y] = H[X | Y]$$ -/
+@[to_additive "$$H[Y - X | Y] = H[X | Y]$$"]
 lemma condEntropy_div_left (hX : Measurable X) (hY : Measurable Y) :
     H[Y / X | Y ; μ] = H[X | Y ; μ] :=
   condEntropy_of_injective μ hX hY (fun y x ↦ y / x) fun _ ↦ div_right_injective

--- a/PFR/ForMathlib/Entropy/RuzsaDist.lean
+++ b/PFR/ForMathlib/Entropy/RuzsaDist.lean
@@ -244,12 +244,89 @@ lemma rdist_nonneg [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
     (hX : Measurable X) (hY : Measurable Y) : 0 ≤ d[X ; μ # Y ; μ'] := by
   linarith [ge_trans (diff_ent_le_rdist hX hY) (abs_nonneg (H[X ; μ] - H[Y ; μ']))]
 
-/-- If $G$ is an additive group and $X$ is a $G$-valued random variable and $H\leq G$ is a finite subgroup then, with $\pi:G\to G/H$ the natural homomorphism we have (if $U_H$ is the  uniform distribution on $H$, independent of $X$)
-\[\mathbb{H}(\pi(X))\leq 2d[X;U_H].\] -/
-lemma ent_of_proj_le [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] (UH: Ω' → G) (hX : Measurable X) (hU: Measurable UH) (hunif: IsUniform H UH μ') [FiniteRange X] (H: AddSubgroup G) : H[ (QuotientAddGroup.mk' H) ∘ X; μ] ≤ 2 * d[ X; μ # UH ; μ' ] := by sorry
-
-
-
+/-- If $G$ is an additive group and $X$ is a $G$-valued random variable and
+$H\leq G$ is a finite subgroup then, with $\pi:G\to G/H$ the natural homomorphism we have
+(where $U_H$ is uniform on $H$) $\mathbb{H}(\pi(X))\leq 2d[X;U_H].$ -/
+lemma ent_of_proj_le {UH: Ω' → G} [FiniteRange X] [FiniteRange UH]
+    [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
+    (hX : Measurable X) (hU: Measurable UH) {H: AddSubgroup G} [Finite H] -- TODO: infer from [FiniteRange UH]?
+    (hunif: IsUniform H UH μ')
+    : H[(QuotientAddGroup.mk' H) ∘ X; μ] ≤ 2 * d[X; μ # UH ; μ'] := by
+  obtain ⟨ν, X', UH', hν, hX', hUH', h_ind, h_id_X', h_id_UH', _, _⟩ :=
+    independent_copies_finiteRange hX hU μ μ'
+  replace hunif : IsUniform H UH' ν :=
+    IsUniform.of_identDistrib hunif h_id_UH'.symm (measurableSet_discrete _)
+  rewrite [← (h_id_X'.comp (measurable_discrete _)).entropy_eq, ← h_id_X'.rdist_eq h_id_UH']
+  let π := ⇑(QuotientAddGroup.mk' H)
+  let νq := Measure.map (π ∘ X') ν
+  haveI : Countable (HasQuotient.Quotient G H) := Quotient.countable
+  haveI : MeasurableSingletonClass (HasQuotient.Quotient G H) :=
+    { measurableSet_singleton := fun _ ↦ measurableSet_quotient.mpr (measurableSet_discrete _) }
+  have : H[X' - UH' | π ∘ X' ; ν] = H[UH' ; ν] := by
+    have h_meas_le : ∀ y ∈ FiniteRange.toFinset (π ∘ X'),
+        (νq {y}).toReal * H[X' - UH' | (π ∘ X') ← y ; ν] ≤ (νq {y}).toReal * H[UH' ; ν] := by
+      intro x _
+      refine mul_le_mul_of_nonneg_left ?_ ENNReal.toReal_nonneg
+      let ν' := ν[|π ∘ X' ← x]
+      let π' := QuotientAddGroup.mk (s := H)
+      have h_card : Nat.card (π' ⁻¹' {x}) = Nat.card H := Nat.card_congr <|
+        (QuotientAddGroup.preimageMkEquivAddSubgroupProdSet H _).trans <| Equiv.prodUnique H _
+      haveI : Finite (π' ⁻¹' {x}) :=
+        Nat.finite_of_card_ne_zero <| h_card.trans_ne <| Nat.pos_iff_ne_zero.mp Nat.card_pos
+      let H_x := (π' ⁻¹' {x}).toFinite.toFinset
+      have h : ∀ᵐ ω ∂ν', (X' - UH') ω ∈ H_x := by
+        let T : Set (G × G) := ((π' ∘ X') ⁻¹' {x})ᶜ
+        let U : Set (G × G) := UH' ⁻¹' Hᶜ
+        have h_subset : (X' - UH') ⁻¹' H_xᶜ ⊆ T ∪ U :=
+          fun ω hω ↦ Classical.byContradiction fun _ ↦ by simp_all [not_or]
+        refine MeasureTheory.mem_ae_iff.mpr (le_zero_iff.mp ?_)
+        calc
+          _ ≤ (ν' T) + (ν' U) := (measure_mono h_subset).trans (measure_union_le T U)
+          _ = (ν' T) + 0 := congrArg _ <| by
+            show _ * _ = 0
+            rw [le_zero_iff.mp <| (restrict_apply_le _ U).trans_eq hunif.measure_preimage_compl,
+              mul_zero]
+          _ = 0 := (add_zero _).trans <| by
+            have : restrict ν (π ∘ X' ⁻¹' {x}) T = 0 := by
+              simp [restrict_apply (measurableSet_discrete T)]
+            show _ * _ = 0
+            rw [this, mul_zero]
+      convert entropy_le_log_card_of_mem (Measurable.sub hX' hUH') h
+      simp_rw [hunif.entropy_eq' hUH', Set.Finite.mem_toFinset, h_card, SetLike.coe_sort_coe]
+    have h_one : (∑ x in FiniteRange.toFinset (π ∘ X'), (νq {x}).toReal) = 1 := by
+      rewrite [Finset.sum_toReal_measure_singleton]
+      apply (ENNReal.toReal_eq_one_iff _).mpr
+      haveI := isProbabilityMeasure_map <| (measurable_discrete (π ∘ X')).aemeasurable (μ := ν)
+      rewrite [← measure_univ (μ := νq), ← FiniteRange.range]
+      let rng := Set.range (π ∘ X')
+      have h_compl : νq rngᶜ = 0 := ae_map_mem_range (π ∘ X') (measurableSet_discrete _) ν
+      rw [← MeasureTheory.measure_add_measure_compl (measurableSet_discrete rng), h_compl, add_zero]
+    haveI := FiniteRange.sub X' UH'
+    have h_ge : H[X' - UH' | π ∘ X' ; ν] ≥ H[UH' ; ν] := calc
+      _ ≥ H[X' - UH' | X' ; ν] := condEntropy_comp_ge ν hX' (hX'.sub hUH') π
+      _ = H[UH' | X' ; ν] := condEntropy_sub_left hUH' hX'
+      _ = H[UH' ; ν] := h_ind.symm.condEntropy_eq_entropy hUH' hX'
+    have h_le : H[X' - UH' | π ∘ X' ; ν] ≤ H[UH' ; ν] := by
+      rewrite [condEntropy_eq_sum _ _ _ (measurable_discrete _)]
+      apply (Finset.sum_le_sum h_meas_le).trans
+      rewrite [← Finset.sum_mul, h_one, one_mul]
+      rfl
+    exact h_le.ge_iff_eq.mp h_ge
+  have : H[X' - UH' ; ν] = H[π ∘ X' ; ν] + H[UH' ; ν] := by calc
+    _ = H[⟨X' - UH', π ∘ (X' - UH')⟩ ; ν] := (entropy_prod_comp (hX'.sub hUH') ν π).symm
+    _ = H[⟨X' - UH', π ∘ X'⟩ ; ν] := by
+      apply IdentDistrib.entropy_eq
+      apply IdentDistrib.of_ae_eq (Measurable.aemeasurable (measurable_discrete _))
+      apply MeasureTheory.mem_ae_iff.mpr
+      convert hunif.measure_preimage_compl
+      ext; simp
+    _ = H[π ∘ X' ; ν] + H[UH' ; ν] := by
+      rewrite [chain_rule ν (by exact hX'.sub hUH') (measurable_discrete _)]
+      congr
+  have : d[X' ; ν # UH' ; ν] = H[π ∘ X' ; ν] + (H[UH' ; ν] - H[X' ; ν]) / 2 := by
+    rewrite [h_ind.rdist_eq hX' hUH']
+    linarith only [this]
+  linarith only [this, (abs_le.mp (diff_ent_le_rdist hX' hUH' (μ := ν) (μ' := ν))).2]
 
 /-- Adding a constant to a random variable does not change the Rusza distance. -/
 lemma rdist_add_const [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
@@ -588,7 +665,7 @@ lemma condRuzsaDist'_eq_integral (X : Ω → G) {Y : Ω' → G} {W : Ω' → T}
   rw [Measure.map_apply hW (MeasurableSet.singleton _)]
 
 /-- Conditioning by a constant does not affect Ruzsa distance. -/
-lemma condRuzsaDist_of_const {X : Ω → G} (hX : Measurable X) (Y : Ω' → G) {W : Ω' → T} (c : S)
+lemma condRuzsaDist_of_const {X : Ω → G} (hX : Measurable X) (Y : Ω' → G) (W : Ω' → T) (c : S)
     [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] [FiniteRange W] :
     d[X|(fun _ ↦ c) ; μ # Y | W ; μ'] = d[X ; μ # Y | W ; μ'] := by
   rw [condRuzsaDist_def, condRuzsaDist'_def, Measure.map_const,measure_univ,one_smul, kernel.rdist,
@@ -899,7 +976,8 @@ lemma condRuzsaDist'_of_inj_map [IsProbabilityMeasure μ] [elem: ElementaryAddCo
     fin_cases i
     exacts [hX.neg, hC, measurable_const, hB.add hC]
   calc d[X ; μ # B | B + C ; μ]
-    = d[X | fun _ : Ω ↦ (0 : G) ; μ # B | B + C ; μ] := by rw [condRuzsaDist_of_const hX]
+    = d[X | fun _ : Ω ↦ (0 : G) ; μ # B | B + C ; μ] := by
+        rw [condRuzsaDist_of_const hX _ _]
   _ = d[π ∘ ⟨-X, fun _ : Ω ↦ (0 : G)⟩ | fun _ : Ω ↦ (0 : G) ; μ # π ∘ ⟨C, B + C⟩ | B + C ; μ] := by
         congr
         · ext1 ω; simp
@@ -1197,7 +1275,7 @@ lemma condRuzsaDist_le' {X : Ω → G} {Y : Ω' → G} {W : Ω' → T}
     (hX : Measurable X) (hY : Measurable Y) (hW : Measurable W)
     [FiniteRange X] [FiniteRange Y] [FiniteRange W] :
     d[X ; μ # Y|W ; μ'] ≤ d[X ; μ # Y ; μ'] + I[Y : W ; μ']/2 := by
-  rw [← condRuzsaDist_of_const hX _ (0 : Fin 1)]
+  rw [← condRuzsaDist_of_const hX _ _ (0 : Fin 1)]
   refine' (condRuzsaDist_le μ μ' hX measurable_const hY hW).trans _
   simp [mutualInfo_const hX (0 : Fin 1)]
 

--- a/PFR/ForMathlib/Entropy/RuzsaSetDist.lean
+++ b/PFR/ForMathlib/Entropy/RuzsaSetDist.lean
@@ -147,8 +147,15 @@ noncomputable def rdist_set (A B: Set G) : ℝ := kernel.rdistm (Measure.discret
 notation3:max "dᵤ[" A " # " B "]" => rdist_set A B
 
 /-- Relating Ruzsa distance between sets to Ruzsa distance between random variables -/
-lemma rdist_set_eq_rdist {A B: Set G} [Finite A] [Finite B]  [Nonempty A] [Nonempty B] {Ω Ω': Type*} [mΩ : MeasureSpace Ω] [mΩ' : MeasureSpace Ω'] (hμ: IsProbabilityMeasure (ℙ: Measure Ω)) (hμ': IsProbabilityMeasure (ℙ: Measure Ω')) {UA: Ω → G} {UB: Ω' → G} (hUA : IsUniform A UA ℙ) (hUB : IsUniform B UB ℙ) (hUA_mes : Measurable UA) (hUB_mes : Measurable UB) : dᵤ[A # B] = d[UA # UB] := by
-  rw [rdist_eq_rdistm, rdist_set, (Measure.isUniform_iff_uniform_dist A hμ hUA_mes).mp hUA, (Measure.isUniform_iff_uniform_dist B hμ' hUB_mes).mp hUB]
+lemma rdist_set_eq_rdist {A B: Set G} [Finite A] [Finite B]  [Nonempty A] [Nonempty B]
+    {Ω Ω': Type*} [mΩ : MeasureSpace Ω] [mΩ' : MeasureSpace Ω']
+    {μ : Measure Ω} {μ' : Measure Ω'}
+    (hμ: IsProbabilityMeasure μ) (hμ': IsProbabilityMeasure μ')
+    {UA: Ω → G} {UB: Ω' → G} (hUA : IsUniform A UA μ) (hUB : IsUniform B UB μ')
+    (hUA_mes : Measurable UA) (hUB_mes : Measurable UB) :
+    dᵤ[A # B] = d[UA ; μ # UB ; μ'] := by
+  rw [rdist_eq_rdistm, rdist_set, (Measure.isUniform_iff_uniform_dist A hμ hUA_mes).mp hUA,
+    (Measure.isUniform_iff_uniform_dist B hμ' hUB_mes).mp hUB]
 
 /-- Ruzsa distance between sets is nonnegative. -/
 lemma rdist_set_nonneg (A B: Set G) [Finite A] [Finite B]  [Nonempty A] [Nonempty B] : 0 ≤ dᵤ[A # B] := by

--- a/PFR/ForMathlib/Graph.lean
+++ b/PFR/ForMathlib/Graph.lean
@@ -7,6 +7,7 @@ namespace Set
 
 variable {G G' : Type*}
 
+-- TODO: maybe `Function.graph` for dot notation?
 def graph (f : G → G') : Set (G×G') := {(x, f x) | x : G}
 
 lemma graph_def (f : G → G') : graph f = {(x, f x) | x : G} := rfl
@@ -22,6 +23,9 @@ lemma mem_graph {f : G → G'} (x : G × G') : x ∈ graph f ↔ f x.1 = x.2 := 
   · rintro ⟨_, rfl⟩; rfl
   · refine fun h ↦ ⟨x.1, ?_⟩
     rw [h]
+
+lemma fst_injOn_graph (f : G → G') : (graph f).InjOn Prod.fst := fun x hx y hy h ↦
+  Prod.ext h <| ((mem_graph x).mp hx).symm.trans <| (congr_arg f h).trans <| (mem_graph y).mp hy
 
 @[simp]
 lemma image_fst_graph {f : G → G'} : Prod.fst '' (graph f) = Set.univ := by

--- a/PFR/ForMathlib/Uniform.lean
+++ b/PFR/ForMathlib/Uniform.lean
@@ -1,4 +1,5 @@
 import Mathlib.Probability.IdentDistrib
+import Mathlib.Probability.ConditionalProbability
 import PFR.ForMathlib.MeasureReal
 import PFR.ForMathlib.FiniteRange
 
@@ -152,6 +153,35 @@ lemma IsUniform.measureReal_preimage_of_nmem (h : IsUniform H X μ) {s : S} (hs 
     μ.real (X ⁻¹' {s}) = 0 := by
   rw [measureReal_def, h.measure_preimage_of_nmem hs, ENNReal.zero_toReal]
 
+/-- $\mathbb{P}(U_H \in H') = \dfrac{|H' \cap H|}{|H|}$ -/
+lemma IsUniform.measure_preimage {H : Finset S} (h : IsUniform H X μ) (hX : Measurable X)
+    (H' : Set S) : μ (X ⁻¹' H') = (μ univ) * (Nat.card (H' ∩ H.toSet).Elem) / Nat.card H := calc
+  _ = μ (X ⁻¹' (H' ∩ H.toSet) ∪ X ⁻¹' (H' \ H.toSet)) := by simp
+  _ = μ (X ⁻¹' (H' ∩ H.toSet)) + μ (X ⁻¹' (H' \ H.toSet)) :=
+    measure_union (Disjoint.preimage X disjoint_inf_sdiff) (by measurability)
+  _ = μ (X ⁻¹' (H' ∩ H.toSet)) + 0 := congrArg _ <| by
+    rewrite [Set.diff_eq_compl_inter, ← le_zero_iff, ← h.measure_preimage_compl]
+    exact measure_mono (inter_subset_left _ _)
+  _ = μ (X ⁻¹' (H' ∩ H.toSet).toFinite.toFinset) := by simp
+  _ = (μ univ) * ∑ __ in (H' ∩ H.toSet).toFinite.toFinset, (1 : ENNReal) / Nat.card H := by
+    rewrite [← sum_measure_preimage_singleton _ (by measurability), Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun _ hx ↦ ?_)
+    rw [mul_one_div, h.measure_preimage_of_mem hX ((Finite.mem_toFinset _).mp hx).2]
+  _ = (μ univ) * (Nat.card (H' ∩ H.toSet).Elem) / Nat.card H := by
+    rw [Finset.sum_const, Nat.card_eq_card_finite_toFinset, nsmul_eq_mul, ← mul_assoc, mul_one_div]
+
+/-- $\mathbb{P}(U_H \in H') = \dfrac{|H' \cap H|}{|H|}$ -/
+lemma IsUniform.measureReal_preimage {H : Finset S} (h : IsUniform H X μ) (hX : Measurable X)
+    (H' : Set S) :
+    μ.real (X ⁻¹' H') = (μ.real univ) * (Nat.card (H' ∩ H.toSet).Elem) / Nat.card H := by
+  simp [measureReal_def, h.measure_preimage hX H', ENNReal.toReal_div]
+
+lemma IsUniform.nonempty_preimage_of_mem [NeZero μ] {H: Finset S} (h : IsUniform H X μ)
+    (hX : Measurable X) {s : S} (hs : s ∈ H) : Set.Nonempty (X ⁻¹' {s}) := by
+  apply MeasureTheory.nonempty_of_measure_ne_zero
+  rewrite [h.measure_preimage_of_mem hX hs]
+  simp [NeZero.ne]
+
 lemma IsUniform.full_measure (h : IsUniform H X μ) (hX: Measurable X) :
     (μ.map X) H = μ Set.univ := by
     rw [Measure.map_apply hX (by measurability)]
@@ -170,6 +200,34 @@ lemma IsUniform.of_identDistrib {Ω' : Type*} [MeasurableSpace Ω'] (h : IsUnifo
     apply h.eq_of_mem x y hx hy
   · rw [← h'.measure_mem_eq hH.compl]
     exact h.measure_preimage_compl
+
+/-- $\mathbb{P}(U_H \in H') \neq 0$ if $H'$ intersects $H$ and the measure is non-zero. -/
+lemma IsUniform.measure_preimage_ne_zero {H : Finset S} [NeZero μ] (h : IsUniform H X μ)
+    (hX : Measurable X) (H' : Set S) [Nonempty (H' ∩ H.toSet).Elem] : μ (X ⁻¹' H') ≠ 0 := by
+  simp_rw [h.measure_preimage hX H', ne_eq, ENNReal.div_eq_zero_iff, ENNReal.nat_ne_top, or_false,
+    mul_eq_zero, NeZero.ne, false_or, Nat.cast_eq_zero, ← Nat.pos_iff_ne_zero, Nat.card_pos]
+
+/-- If $X$ is uniform w.r.t. $\mu$ on $H$, then $X$ is uniform w.r.t. $\mu$ conditioned by
+$H'$ on $H' \cap H$. -/
+lemma IsUniform.restrict {H : Set S} (h : IsUniform H X μ) (hX : Measurable X) (H' : Set S) :
+    IsUniform (H' ∩ H) X (μ[|X ⁻¹' H']) where
+  eq_of_mem := fun x y hx hy ↦ by
+    show _ * _ = _ * _
+    rw [μ.restrict_eq_self (preimage_mono (singleton_subset_iff.mpr hx.1)),
+      μ.restrict_eq_self (preimage_mono (singleton_subset_iff.mpr hy.1)), h.eq_of_mem x y hx.2 hy.2]
+  measure_preimage_compl := le_zero_iff.mp <| by
+    rewrite [Set.compl_inter, Set.preimage_union]
+    calc
+      _ ≤ (μ[|X ⁻¹' H']) (X ⁻¹' H'ᶜ) + (μ[|X ⁻¹' H']) (X ⁻¹' Hᶜ) := measure_union_le _ _
+      _ = (μ[|X ⁻¹' H']) (X ⁻¹' H'ᶜ) + 0 := congrArg _ <| by
+        show _ * _ = _
+        rw [le_zero_iff.mp <| h.measure_preimage_compl.trans_ge <| Measure.restrict_apply_le _ _,
+          mul_zero]
+      _ = 0 := by
+        show _ * _ + 0 = 0
+        rw [add_zero, Set.preimage_compl, Measure.restrict_apply <|
+          MeasurableSet.compl (measurableSet_preimage hX (measurableSet_discrete H')),
+          compl_inter_self, measure_empty, mul_zero]
 
 lemma IdentDistrib.of_isUniform {Ω' : Type*}  [MeasurableSpace Ω'] {μ' : Measure Ω'} [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] [Finite H] {X: Ω → S} {X': Ω' → S} (hX: Measurable X) (hX': Measurable X') (hX_unif : IsUniform H X μ) (hX'_unif : IsUniform H X' μ') : IdentDistrib X X' μ μ' := by
   constructor

--- a/PFR/HomPFR.lean
+++ b/PFR/HomPFR.lean
@@ -73,10 +73,10 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS: ∀ x y : G, f (x+y) -
     let B := A - {0}×ˢS
     have hAB : A + A ⊆ B := by
       intro x hx
-      obtain ⟨a, a', ha, ha', haa'⟩ := Set.mem_add.mp hx
+      obtain ⟨a, ha, a', ha', haa'⟩ := Set.mem_add.mp hx
       simp at ha ha'
       rw [Set.mem_sub]
-      refine ⟨(x.1, f x.1), (0, f (a.1 + a'.1) - f a.1 - f a'.1), ?_, ?_⟩
+      refine ⟨(x.1, f x.1), ?_, (0, f (a.1 + a'.1) - f a.1 - f a'.1), ?_⟩
       · simp
       · simp only [singleton_prod, mem_image, Prod.mk.injEq, true_and,
           exists_eq_right, Prod.mk_sub_mk, sub_zero]
@@ -128,7 +128,7 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS: ∀ x y : G, f (x+y) -
     have : (H : Set (G × G')) ⊆ ({0} ×ˢ (H₁:Set G')) + {(x, φ x) | x : G} := by
       rintro ⟨g, g'⟩ hg
       simp only [SetLike.mem_coe, hH₀₁] at hg
-      refine ⟨(0, g' - φ g), (g, φ g), ?_,?_⟩
+      refine ⟨(0, g' - φ g), ?_, (g, φ g), ?_⟩
       · simp only [singleton_prod, mem_image, SetLike.mem_coe,
           Prod.mk.injEq, true_and, exists_eq_right, hg.2]
       · simp only [mem_setOf_eq, Prod.mk.injEq, exists_eq_left, Prod.mk_add_mk, zero_add, true_and,

--- a/PFR/ImprovedPFR.lean
+++ b/PFR/ImprovedPFR.lean
@@ -972,7 +972,7 @@ lemma PFR_conjecture_improv_aux (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ 
     rw [add_sub_assoc]
     apply add_subset_add_left
     apply (sub_subset_sub (inter_subset_right _ _) (inter_subset_right _ _)).trans
-    rintro - ⟨-, -, ⟨y, xy, hy, hxy, rfl⟩, ⟨z, xz, hz, hxz, rfl⟩, rfl⟩
+    rintro - ⟨-, ⟨y, hy, xy, hxy, rfl⟩, -, ⟨z, hz, xz, hxz, rfl⟩, rfl⟩
     simp only [mem_singleton_iff] at hxy hxz
     simpa [hxy, hxz, -ElementaryAddCommGroup.sub_eq_add] using H.sub_mem hy hz
   exact ⟨H, u, Iu, IHA, IAH, A_subset_uH⟩

--- a/PFR/ImprovedPFR.lean
+++ b/PFR/ImprovedPFR.lean
@@ -812,6 +812,34 @@ theorem entropic_PFR_conjecture_improv (hpη : p.η = 1/8) :
   have : d[p.X₀₂ # U] ≤ d[p.X₀₂ # X₂] + d[X₂ # U] := rdist_triangle p.hmeas2 hX₂ hU
   linarith
 
+/-- `entropic_PFR_conjecture_improv'`: For two $G$-valued random variables $X^0_1, X^0_2$, there is some
+    subgroup $H \leq G$ such that $d[X^0_1;U_H] + d[X^0_2;U_H] \le 10 d[X^0_1;X^0_2]$., and d[X^0_1; U_H] and d[X^0_2; U_H] are at most 5/2 * d[X^0_1;X^0_2] -/
+theorem entropic_PFR_conjecture_improv' (hpη : p.η = 1/8) :
+    ∃ H : AddSubgroup G, ∃ Ω : Type uG, ∃ mΩ : MeasureSpace Ω, ∃ U : Ω → G,
+    IsProbabilityMeasure (ℙ : Measure Ω) ∧ Measurable U ∧
+    IsUniform H U ∧ d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 10 * d[p.X₀₁ # p.X₀₂] ∧ d[p.X₀₁ # U] ≤ 11/2 * d[p.X₀₁ # p.X₀₂] ∧ d[p.X₀₂ # U] ≤ 11/2 * d[p.X₀₁ # p.X₀₂] := by
+  obtain ⟨Ω', mΩ', X₁, X₂, hX₁, hX₂, hP, htau_min, hdist⟩ := tau_minimizer_exists_rdist_eq_zero p
+  obtain ⟨H, U, hU, hH_unif, hdistX₁, hdistX₂⟩ := exists_isUniform_of_rdist_eq_zero hX₁ hX₂ hdist
+  have : d[p.X₀₁ # p.X₀₂] = d[p.X₀₂ # p.X₀₁] := rdist_symm
+  have goal₁ :  d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 10 * d[p.X₀₁ # p.X₀₂]
+  · have h : τ[X₁ # X₂ | p] ≤ τ[p.X₀₂ # p.X₀₁ | p] := is_tau_min p htau_min p.hmeas2 p.hmeas1
+    rw [tau, tau, hpη] at h
+    norm_num at h
+    have : d[p.X₀₁ # U] ≤ d[p.X₀₁ # X₁] + d[X₁ # U] := rdist_triangle p.hmeas1 hX₁ hU
+    have : d[p.X₀₂ # U] ≤ d[p.X₀₂ # X₂] + d[X₂ # U] := rdist_triangle p.hmeas2 hX₂ hU
+    linarith
+  have : d[p.X₀₁ # U] ≤ d[p.X₀₁ # p.X₀₂] + d[p.X₀₂ # U] := rdist_triangle p.hmeas1 p.hmeas2 hU
+  have : d[p.X₀₂ # U] ≤ d[p.X₀₂ # p.X₀₁] + d[p.X₀₁ # U] := rdist_triangle p.hmeas2 p.hmeas1 hU
+  refine ⟨H, Ω', inferInstance, U, inferInstance, hU, hH_unif, goal₁, by linarith, by linarith⟩
+
+
+
+
+
+
+
+
+
 end EntropicPFR
 
 section PFR

--- a/PFR/Main.lean
+++ b/PFR/Main.lean
@@ -152,6 +152,12 @@ theorem rdist_le_of_isUniform_of_card_add_le (h₀A : A.Nonempty) (hA : Nat.card
 
 variable [ElementaryAddCommGroup G 2] [Fintype G]
 
+lemma sumset_eq_sub : A + A = A - A := by
+  rw [← Set.image2_add, ← Set.image2_sub]
+  congr! 1 with a _ b _
+  show a + b = a - b
+  simp
+
 /-- Auxiliary statement towards the polynomial Freiman-Ruzsa (PFR) conjecture: if $A$ is a subset of
 an elementary abelian 2-group of doubling constant at most $K$, then there exists a subgroup $H$
 such that $A$ can be covered by at most $K^{13/2} |A|^{1/2} / |H|^{1/2}$ cosets of $H$, and $H$ has
@@ -162,12 +168,7 @@ lemma PFR_conjecture_aux (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K * Nat
       ∧ Nat.card H ≤ K ^ 11 * Nat.card A ∧ Nat.card A ≤ K ^ 11 * Nat.card H ∧ A ⊆ c + H := by
   classical
   let _mG : MeasurableSpace G := ⊤
-  have hadd_sub : A + A = A - A := by
-    rw [← Set.image2_add, ← Set.image2_sub]
-    congr! 1 with a _ b _
-    rw [(show a+b=a-b by simp)]
-    rfl
-  rw [hadd_sub] at hA
+  rw [sumset_eq_sub] at hA
   have : MeasurableSingletonClass G := ⟨λ _ ↦ trivial⟩
   obtain ⟨A_pos, -, K_pos⟩ : (0 : ℝ) < Nat.card A ∧ (0 : ℝ) < Nat.card (A - A) ∧ 0 < K :=
     PFR_conjecture_pos_aux h₀A hA
@@ -179,7 +180,7 @@ lemma PFR_conjecture_aux (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K * Nat
   rcases exists_isUniform_measureSpace A' h₀A' with ⟨Ω₀, mΩ₀, UA, hP₀, UAmeas, UAunif, -, -⟩
   rw [hAA'] at UAunif
   have : d[UA # UA] ≤ log K := rdist_le_of_isUniform_of_card_add_le h₀A hA UAunif UAmeas
-  rw [← hadd_sub] at hA
+  rw [← sumset_eq_sub] at hA
   let p : refPackage Ω₀ Ω₀ G := ⟨UA, UA, UAmeas, UAmeas, 1/9, (by norm_num), (by norm_num)⟩
   -- entropic PFR gives a subgroup `H` which is close to `A` for the Rusza distance
   rcases entropic_PFR_conjecture p (by norm_num) with ⟨H, Ω₁, mΩ₁, UH, hP₁, UHmeas, UHunif, hUH⟩

--- a/PFR/Mathlib/Probability/Independence/Basic.lean
+++ b/PFR/Mathlib/Probability/Independence/Basic.lean
@@ -319,8 +319,7 @@ lemma iIndepFun.prod (h : iIndepFun n f μ) :
 
 variable {β β' Ω : Type*} {mΩ : MeasurableSpace Ω} {μ : Measure Ω}
 
-/-- Improved version of `IndepFun.ae_eq` in which the ranges are allowed to be distinct.
-TODO: replace `IndepFun.ae_eq` with this one. -/
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem IndepFun.ae_eq' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'} {f f' : Ω → β}
     {g g' : Ω → β'} (hfg : IndepFun f g μ)
     (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : IndepFun f' g' μ := by
@@ -328,16 +327,14 @@ theorem IndepFun.ae_eq' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'} 
     simp only [ae_dirac_eq, Filter.eventually_pure, kernel.const_apply]
   exacts [hf, hg]
 
-/-- Improved version of `kernel.IndepFun.symm` in which the ranges are allowed to be distinct.
-TODO: replace `kernel.IndepFun.symm` with this one. -/
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem kernel.IndepFun.symm' {Ω α β γ : Type*} {_ : MeasurableSpace Ω} {_ : MeasurableSpace α}
     {_ : MeasurableSpace β} {_ : MeasurableSpace γ} {κ : kernel α Ω} {f : Ω → β} {g : Ω → γ}
     {μ : Measure α}
     (hfg : kernel.IndepFun f g κ μ) : kernel.IndepFun g f κ μ :=
   kernel.Indep.symm hfg
 
-/-- Improved version of `IndepFun.symm` in which the ranges are allowed to be distinct.
-TODO: replace `IndepFun.symm` with this one. -/
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem IndepFun.symm' {γ β Ω : Type*} {_ : MeasurableSpace γ}
     {_ : MeasurableSpace β} {_ : MeasurableSpace Ω} {μ : Measure Ω} {f : Ω → β} {g : Ω → γ}
     (hfg : IndepFun f g μ) :

--- a/PFR/Mathlib/Probability/Independence/Kernel.lean
+++ b/PFR/Mathlib/Probability/Independence/Kernel.lean
@@ -6,8 +6,8 @@ namespace ProbabilityTheory.kernel
 variable {β β' γ γ' : Type*} {_mα : MeasurableSpace α} {_mΩ : MeasurableSpace Ω}
   {κ : kernel α Ω} {μ : Measure α} {f : Ω → β} {g : Ω → β'}
 
-/-- Improved version of `IndepFun.ae_eq` in which the ranges are allowed to be distinct. Perhap
-can serve as a replacement of that method? -/
+
+/-- in mathlib as of `4d385393cd569f08ac30425ef886a57bb10daaa5` (TODO: bump) -/
 theorem IndepFun.ae_eq' {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'} {f f' : Ω → β}
     {g g' : Ω → β'} (hfg : IndepFun f g κ μ) (hf : ∀ᵐ a ∂μ, f =ᵐ[κ a] f')
     (hg : ∀ᵐ a ∂μ, g =ᵐ[κ a] g') : IndepFun f' g' κ μ := by

--- a/PFR/WeakPFR.lean
+++ b/PFR/WeakPFR.lean
@@ -414,18 +414,18 @@ lemma PFR_projection (hX : Measurable X) (hY : Measurable Y) :
 
 end F2_projection
 
-open MeasureTheory ProbabilityTheory Real
+open MeasureTheory ProbabilityTheory Real Set
 open scoped BigOperators
 
 lemma four_logs {a b c d : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d) :
     log ((a*b)/(c*d)) = log a + log b - log c - log d := by
   rw [log_div, log_mul, log_mul, sub_sub] <;> positivity
 
-lemma sum_prob_preimage {G H : Type*} {X : Finset H} {A : Set G} [Nonempty A] [Finite A] {φ : A → X}
-    {A_ : H → Set G} (hφ : ∀ x : X, A_ x = Subtype.val '' (φ ⁻¹' {x})) :
+lemma sum_prob_preimage {G H : Type*} {X : Finset H} {A : Set G} [Finite A] {φ : A → X}
+    {A_ : H → Set G} (hA : A.Nonempty) (hφ : ∀ x : X, A_ x = Subtype.val '' (φ ⁻¹' {x})) :
     ∑ x in X, (Nat.card (A_ x) : ℝ) / (Nat.card A) = 1 := by
   apply Finset.sum_div.symm.trans
-  apply (div_eq_one_iff_eq <| Nat.cast_ne_zero.mpr <| Nat.pos_iff_ne_zero.mp Nat.card_pos).mpr
+  apply (div_eq_one_iff_eq <| Nat.cast_ne_zero.mpr <| Nat.pos_iff_ne_zero.mp (@Nat.card_pos _ hA.to_subtype _)).mpr
   classical
   haveI := Fintype.ofFinite A
   rewrite [Nat.card_eq_fintype_card, ← Finset.card_univ, Finset.card_eq_sum_card_fiberwise
@@ -443,14 +443,16 @@ lemma single_fibres {G H Ω Ω': Type u}
     [MeasureSpace Ω] [MeasureSpace Ω']
     [IsProbabilityMeasure (ℙ : Measure Ω)] [IsProbabilityMeasure (ℙ : Measure Ω')]
     (φ : G →+ H)
-    {A B : Set G} [Finite A] [Finite B] [Nonempty A] [Nonempty B] {UA : Ω → G} {UB: Ω' → G}
+    {A B : Set G} [Finite A] [Finite B] {UA : Ω → G} {UB: Ω' → G} (hA : A.Nonempty) (hB : B.Nonempty)
     (hUA': Measurable UA) (hUB': Measurable UB) (hUA: IsUniform A UA) (hUB: IsUniform B UB)
     (hUA_mem : ∀ ω, UA ω ∈ A) (hUB_mem : ∀ ω, UB ω ∈ B) :
     ∃ (x y : H) (Ax By: Set G),
-    Ax = A ∩ φ.toFun ⁻¹' {x} ∧ By = B ∩ φ.toFun ⁻¹' {y} ∧ Nonempty Ax ∧ Nonempty By ∧
+    Ax = A ∩ φ.toFun ⁻¹' {x} ∧ By = B ∩ φ.toFun ⁻¹' {y} ∧ Ax.Nonempty ∧ By.Nonempty ∧
     d[φ.toFun ∘ UA # φ.toFun ∘ UB]
     * log ((Nat.card A) * (Nat.card B) / ((Nat.card Ax) * (Nat.card By))) ≤
     (H[φ.toFun ∘ UA] + H[φ.toFun ∘ UB]) * (d[UA # UB] - dᵤ[Ax # By]) := by
+  have : Nonempty A := hA.to_subtype
+  have : Nonempty B := hB.to_subtype
   haveI : FiniteRange UA := finiteRange_of_finset UA A.toFinite.toFinset (by simpa)
   haveI : FiniteRange UB := finiteRange_of_finset UB B.toFinite.toFinset (by simpa)
   have hUA_coe : IsUniform A.toFinite.toFinset.toSet UA := by rwa [Set.Finite.coe_toFinset]
@@ -464,7 +466,7 @@ lemma single_fibres {G H Ω Ω': Type u}
   haveI h_Ax (x : X) : Nonempty (A_ x.val) := by
     obtain ⟨ω, hω⟩ := (FiniteRange.mem_iff _ _).mp x.property
     use UA ω; exact Set.mem_inter (hUA_mem ω) (by exact hω)
-  haveI h_By (y : Y): Nonempty (B_ y.val) := by
+  haveI h_By (y : Y) : Nonempty (B_ y.val) := by
     obtain ⟨ω, hω⟩ := (FiniteRange.mem_iff _ _).mp y.property
     use UB ω; exact Set.mem_inter (hUB_mem ω) (by exact hω)
   have h_AX (a : A) : φ.toFun a.val ∈ X := by
@@ -538,8 +540,8 @@ lemma single_fibres {G H Ω Ω': Type u}
       Set.preimage_comp, hUB_coe.measure_preimage hUB']
     simp? [mul_div_mul_comm, Set.inter_comm, ENNReal.toReal_div]
       says simp only [ZeroHom.toFun_eq_coe, AddMonoidHom.toZeroHom_coe,
-        measure_univ, inv_one, Set.Finite.coe_toFinset, Set.inter_comm, one_mul,
-        Set.Finite.mem_toFinset, smul_eq_mul, ENNReal.toReal_mul, ENNReal.toReal_div,
+        measure_univ, inv_one, Finite.coe_toFinset, inter_comm, one_mul,
+        Finite.mem_toFinset, smul_eq_mul, ENNReal.toReal_mul, ENNReal.toReal_div,
         ENNReal.toReal_nat, mul_div_mul_comm]
   have h_sum : ∑ x in X, ∑ y in Y,
       (p x y) * (M * dᵤ[A_ x # B_ y] + d[φ.toFun ∘ UA # φ.toFun ∘ UB] * -Real.log (p x y)) ≤
@@ -579,11 +581,11 @@ lemma single_fibres {G H Ω Ω': Type u}
     replace hc := Finset.sum_lt_sum_of_nonempty h_nonempty hc
     have h_p_one : ∑ x in X ×ˢ Y, p x.1 x.2 = 1 := by
       simp_rw [Finset.sum_product, mul_div_mul_comm, ← Finset.mul_sum,
-        ← sum_prob_preimage h_φ_AX, sum_prob_preimage h_φ_BY, mul_one]
+        ← sum_prob_preimage hA h_φ_AX, sum_prob_preimage hB h_φ_BY, mul_one]
     rewrite [← Finset.sum_mul, h_p_one, one_mul, Finset.sum_product] at hc
     exact not_le_of_gt hc h_sum
   obtain ⟨x, y, hxy⟩ := this
-  refine ⟨x, y, A_ x.val, B_ y.val, rfl, rfl, h_Ax x, h_By y, ?_⟩
+  refine ⟨x, y, A_ x.val, B_ y.val, rfl, rfl, @nonempty_of_nonempty_subtype _ _ (h_Ax x), @nonempty_of_nonempty_subtype _ _ (h_By y), ?_⟩
   rewrite [← inv_div, Real.log_inv]
   show _ * -log (p x.val y.val) ≤ M * _
   linarith only [hxy]
@@ -622,7 +624,7 @@ end dim
 
 variable {G : Type u} [AddCommGroup G] [Module.Free ℤ G] [Module.Finite ℤ G] [Countable G] [MeasurableSpace G] [MeasurableSingletonClass G]
 
-open Real MeasureTheory ProbabilityTheory Pointwise
+open Real MeasureTheory ProbabilityTheory Pointwise Set
 
 /-- Move to Mathlib? `Finsupp.mapRange` of a surjective function is surjective. -/
 lemma Finsupp.mapRange_surjective {α : Type u_1} {M : Type u_5} {N : Type u_7} [Zero M] [Zero N] (f : M → N) (hf : f 0 = 0)
@@ -778,13 +780,15 @@ $$ \log \frac{|A| |B|}{|A_x| |B_y|} ≤ 34 (d[U_A; U_B] - d[U_{A_x}; U_{B_y}])$$
 and one has the dimension bound
 $$ n \log 2 ≤ \log |G/N| + 40 d[U_A; U_B].$$
  -/
-lemma weak_PFR_asymm_prelim (A B : Set G) [Finite A] [Finite B] [hnA : Nonempty A] [hnB : Nonempty B]:
-    ∃ (N : AddSubgroup G) (x y : G ⧸ N) (Ax By : Set G), Nonempty Ax ∧ Nonempty By ∧
+lemma weak_PFR_asymm_prelim (A B : Set G) [Finite A] [Finite B] (hnA : A.Nonempty) (hnB : B.Nonempty):
+    ∃ (N : AddSubgroup G) (x y : G ⧸ N) (Ax By : Set G), Ax.Nonempty ∧ By.Nonempty ∧
     Set.Finite Ax ∧ Set.Finite By ∧ Ax = {z:G | z ∈ A ∧ QuotientAddGroup.mk' N z = x } ∧
     By = {z:G | z ∈ B ∧ QuotientAddGroup.mk' N z = y } ∧
     (log 2) * FiniteDimensional.finrank ℤ G ≤ log (Nat.card (G ⧸ N)) +
       40 * dᵤ[ A # B ] ∧ log (Nat.card A) + log (Nat.card B) - log (Nat.card Ax) - log (Nat.card By)
       ≤ 34 * (dᵤ[ A # B ] - dᵤ[ Ax # By ]) := by
+  have : Nonempty A := hnA.to_subtype
+  have : Nonempty B := hnB.to_subtype
   obtain ⟨ h_elem, h_finite, h_card ⟩ := weak_PFR_quotient_prelim (G := G)
   set ψ : G →+ G := zsmulAddGroupHom 2
   set G₂ := AddMonoidHom.range ψ
@@ -808,9 +812,11 @@ lemma weak_PFR_asymm_prelim (A B : Set G) [Finite A] [Finite B] [hnA : Nonempty 
     exact MeasurableSpace.map_def.mpr (measurableSet_discrete _)
 
   rcases third_iso H' with ⟨ e : H ⧸ H' ≃+ G ⧸ N, he ⟩
-  rcases single_fibres φ' hUA_mes hUB_mes hUA_unif hUB_unif hUA_mem hUB_mem with
+  rcases single_fibres φ' hnA hnB hUA_mes hUB_mes hUA_unif hUB_unif hUA_mem hUB_mem with
     ⟨x, y, Ax, By, hAx, hBy, hnAx, hnBy, hcard_ineq⟩
 
+  have : Nonempty Ax := hnAx.to_subtype
+  have : Nonempty By := hnBy.to_subtype
   have Axf : Finite Ax := by rw [hAx]; infer_instance
   have Byf : Finite By := by rw [hBy]; infer_instance
 
@@ -947,107 +953,14 @@ lemma weak_PFR_asymm_prelim (A B : Set G) [Finite A] [Finite B] [hnA : Nonempty 
   exact (mul_le_mul_left h).mp this
 
 /-- Separating out the conclusion of `weak_PFR_asymm` for convenience of induction arguments.-/
-def weak_PFR_asymm_conclusion (A B : Set G) : Prop :=
-  ∃ A' B' : Set G, A' ⊆ A ∧ B' ⊆ B ∧ Nonempty A' ∧ Nonempty B' ∧
+def WeakPFRAsymmConclusion (A B : Set G) : Prop :=
+  ∃ A' B' : Set G, A' ⊆ A ∧ B' ⊆ B ∧ A'.Nonempty ∧ B'.Nonempty ∧
   log (((Nat.card A) * (Nat.card B)) / ((Nat.card A') * (Nat.card B'))) ≤ 34 * dᵤ[A # B] ∧
   max (dimension A') (dimension B') ≤ (40 / log 2) * dᵤ[A # B]
 
 /-- The property of two sets A,B of a group G not being contained in cosets of the same proper subgroup -/
 def not_in_coset {G: Type u} [AddCommGroup G] (A B : Set G) : Prop := AddSubgroup.closure ((A-A) ∪ (B-B)) = ⊤
 
-/-- The property of a set in a group being a translate of a subset of a subgroup. -/
-def is_shift {G: Type u} [AddCommGroup G] {H: AddSubgroup G} (A : Set G) (A' : Set H) : Prop :=
-  ∃ x, A = (A' : Set G) + {x}
-
-lemma sub_of_shift  {G: Type u} [AddCommGroup G] {H: AddSubgroup G} {A : Set G} {A' : Set H} (hA: is_shift A A') : A - A = (A' - A': Set H) := by
-  rcases hA with ⟨ x, hA ⟩
-  ext z; constructor
-  . intro hz
-    rw [hA, Set.mem_sub] at hz
-    rcases hz with ⟨ a1, a2, ha1, ha2, ha12 ⟩
-    rw [Set.add_singleton, Set.image_add_right, Set.mem_preimage, Set.mem_image] at ha1 ha2
-    rcases ha1 with ⟨ a1', ha1', ha1 ⟩
-    rcases ha2 with ⟨ a2', ha1', ha2 ⟩
-    have : z = (a1' - a2':H) := by push_cast; rw [ha1, ha2, <-ha12]; abel
-    rw [this]
-    convert Set.mem_image_of_mem Subtype.val ?_
-    rw [Set.mem_sub]
-    use a1', a2'
-  intro hz
-  rw [Set.mem_image] at hz
-  rcases hz with ⟨ z', hz, hzz ⟩
-  rw [Set.mem_sub] at hz
-  rcases hz with ⟨ a1, a2, ha1, ha2, ha12 ⟩
-  rw [Set.mem_sub, <-hzz, <-ha12, hA]
-  use a1+x, a2+x
-  simp [ha1, ha2]
-
-lemma card_of_shift  {G: Type u} [AddCommGroup G] {H: AddSubgroup G} {A : Set G} {A' : Set H} (hA: is_shift A A') [Finite A] [Nonempty A] : Finite A' ∧ Nonempty A' ∧ Nat.card A' = Nat.card A := by
-  rcases hA with ⟨ x, hA ⟩
-  set f : H → G := fun a ↦ (a:G) + x
-  have hf : Function.Injective f := by
-    intro y z hyz
-    simp at hyz
-    exact hyz
-  have hA' : A = f '' A' := by
-    rw [hA]
-    ext a
-    simp_rw [Set.add_singleton, Set.mem_image]
-    constructor
-    . rintro ⟨ a', ⟨ b, hb, hb' ⟩, ha ⟩
-      use b; rw [<-hb'] at ha; exact ⟨ hb, ha ⟩
-    rintro ⟨ a', ha, ha' ⟩
-    use a'; refine ⟨?_, ha' ⟩
-    use a'
-  have hA'_card : Nat.card A' = Nat.card A := by
-    rw [hA', Nat.card_image_of_injective hf]
-  have hA'_nonfin : Nonempty A' ∧ Finite A' := by
-    have := Nat.card_pos (α := A)
-    rw [<-hA'_card, Nat.card_pos_iff] at this
-    exact this
-  exact ⟨ hA'_nonfin.2, hA'_nonfin.1, hA'_card ⟩
-
-
-
-/-- Without loss of generality, one can move (up to translation and embedding) any pair A, B of non-empty sets into a subgroup where they are not in a coset. -/
-lemma wlog_not_in_coset {G: Type u} [AddCommGroup G] (A B : Set G) [hA: Nonempty A] [hB: Nonempty B] : ∃ (G': AddSubgroup G) (A' B' : Set G'), is_shift A A' ∧ is_shift B B' ∧ not_in_coset A' B' := by
-  set G' := AddSubgroup.closure ((A-A) ∪ (B-B))
-  obtain ⟨ x ⟩ := hA
-  obtain ⟨ y ⟩ := hB
-  set A' : Set G' := { a : G' | (a:G) + x ∈ A }
-  set B' : Set G' := { b : G' | (b:G) + y ∈ B }
-  use G', A', B'
-  have hA : is_shift A A' := by
-    use x; ext z; simp
-    intro hz
-    apply AddSubgroup.subset_closure
-    rw [Set.mem_union]; left
-    rw [Set.mem_sub]
-    use z, x
-    refine ⟨ hz, Subtype.mem x, sub_eq_add_neg z x ⟩
-  have hB : is_shift B B' := by
-    use y; ext z; simp
-    intro hz
-    apply AddSubgroup.subset_closure
-    rw [Set.mem_union]; right
-    rw [Set.mem_sub]
-    use z, y
-    refine ⟨ hz, Subtype.mem y, sub_eq_add_neg z y ⟩
-
-  refine ⟨ hA, hB, ?_ ⟩
-  unfold not_in_coset
-  rw [AddSubgroup.eq_top_iff']
-  intro z
-  rw [AddSubgroup.mem_closure]
-  intro K hK
-  replace hK := Set.image_mono (f := Subtype.val) hK
-  rw [Set.image_union] at hK
-  change ((A'-A':Set G'):Set G) ∪ ((B'-B':Set G'):Set G) ⊆ (K:Set G') at hK
-  rw [<-sub_of_shift hA, <-sub_of_shift hB, <- AddSubgroup.coeSubtype, <-AddSubgroup.coe_map (AddSubgroup.subtype G') K, <-AddSubgroup.closure_le] at hK
-  change G' ≤ AddSubgroup.map (AddSubgroup.subtype G') K at hK
-  replace hK := hK (SetLike.coe_mem z)
-  simp at hK
-  exact hK
 
 /-- In fact one has equality here, but this is tricker to prove and not needed for the argument. -/
 lemma dimension_of_shift {G: Type u} [AddCommGroup G]
@@ -1070,8 +983,10 @@ lemma dimension_of_shift {G: Type u} [AddCommGroup G]
 
 lemma conclusion_transfers {A B : Set G}
     (G': AddSubgroup G) (A' B' : Set G')
-    (hA : is_shift A A') (hB : is_shift B B') [Finite A'] [Finite B'] [Nonempty A'] [Nonempty B']
-    (h : weak_PFR_asymm_conclusion A' B') : weak_PFR_asymm_conclusion A B := by
+    (hA : IsShift A A') (hB : IsShift B B') [Finite A'] [Finite B'] (hA' : A'.Nonempty) (hB' : B'.Nonempty)
+    (h : WeakPFRAsymmConclusion A' B') : WeakPFRAsymmConclusion A B := by
+  have : Nonempty A' := hA'.to_subtype
+  have : Nonempty B' := hB'.to_subtype
   rcases h with ⟨A'', B'', hA'', hB'', hA''_non, hB''_non, hcard_ineq, hdim_ineq⟩
   rcases hA with ⟨ x, hA ⟩
   set f : G' → G := fun a ↦ (a : G) + x
@@ -1122,9 +1037,12 @@ lemma conclusion_transfers {A B : Set G}
     . use h
     abel
 
-  refine ⟨ ?_, ?_, (by infer_instance), (by infer_instance), ?_, ?_ ⟩
+
+  refine ⟨ ?_, ?_, ?_, ?_, ?_, ?_ ⟩
   . simp [hA', hf, hA'']
   . simp [hB', hg, hB'']
+  . simp [hA''_non]
+  . simp [hB''_non]
   . convert hcard_ineq using 2
     . congr 3
       . rw [hA', Nat.card_image_of_injective hf]
@@ -1148,7 +1066,7 @@ lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] (hA : A.Nonempty) (hB :
     convert (Nat.strong_induction_on (p := P) M this) G ‹_› ‹_› ‹_› ‹_› _ ‹_› A B ‹_› ‹_› ‹_› ‹_› hM
   intro M h_induct
   -- wlog we can assume A, B are not in cosets of a smaller subgroup
-  suffices : ∀ (G : Type u) (hG_comm : AddCommGroup G) (_hG_free : Module.Free ℤ G) (_hG_fin : Module.Finite ℤ G) (_hG_count : Countable G) (hG_mes : MeasurableSpace G) (_hG_sing: MeasurableSingletonClass G) (A B: Set G) (_hA_fin: Finite A) (_hB_fin: Finite B) (_hA_non: Nonempty A) (_hB_non: Nonempty B) (_hM : (Nat.card A) + (Nat.card B) ≤ M) (_hnot: NotInCoset A B), WeakPFRAsymmConclusion A B
+  suffices : ∀ (G : Type u) (hG_comm : AddCommGroup G) (_hG_free : Module.Free ℤ G) (_hG_fin : Module.Finite ℤ G) (_hG_count : Countable G) (hG_mes : MeasurableSpace G) (_hG_sing: MeasurableSingletonClass G) (A B: Set G) (_hA_fin: Finite A) (_hB_fin: Finite B) (_hA_non: A.Nonempty) (_hB_non: B.Nonempty) (_hM : (Nat.card A) + (Nat.card B) ≤ M) (_hnot: NotInCoset A B), WeakPFRAsymmConclusion A B
   . intro G hG_comm hG_free hG_fin hG_count hG_mes hG_sing A B hA_fin hB_fin hA_non hB_non hM
 
     obtain ⟨ G', A', B', hAA', hBB', hnot' ⟩ := wlog_notInCoset hA_non hB_non
@@ -1165,23 +1083,25 @@ lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] (hA : A.Nonempty) (hB :
 
     rw [hAA'_card, hBB'_card] at hM
 
-    have hA'_nonfin : Nonempty A'  ∧ Finite A' := by
+    have hA'_nonfin : A'.Nonempty ∧ Finite A' := by
       have := Nat.card_pos (α := A)
-      rwa [hAA'_card, Nat.card_pos_iff] at this
-    have hB'_nonfin : Nonempty B' ∧ Finite B' := by
+      rw [hAA'_card, Nat.card_pos_iff] at this
+      exact ⟨@nonempty_of_nonempty_subtype _ _ this.1, this.2⟩
+    have hB'_nonfin : B'.Nonempty ∧ Finite B' := by
       have := Nat.card_pos (α := B)
-      rwa [hBB'_card, Nat.card_pos_iff] at this
+      rw [hBB'_card, Nat.card_pos_iff] at this
+      exact ⟨@nonempty_of_nonempty_subtype _ _ this.1, this.2⟩
     obtain ⟨ hA'_non, hA'_fin ⟩ := hA'_nonfin
     obtain ⟨ hB'_non, hB'_fin ⟩ := hB'_nonfin
 
     replace this := this G' _ hG'_free hG'_fin (by infer_instance) (by infer_instance) (by infer_instance) A' B' hA'_fin hB'_fin hA'_non hB'_non hM hnot'
-    exact conclusion_transfers G' A' B' hAA' hBB' this
+    exact conclusion_transfers G' A' B' hAA' hBB' hA'_non hB'_non this
   intro G hG_comm hG_free hG_fin hG_count hG_mes hG_sing A B hA_fin hB_fin hA_non hB_non hM hnot
-  rcases weak_PFR_asymm_prelim (Set.nonempty_coe_sort.mp hA_non) (Set.nonempty_coe_sort.mp hB_non) with ⟨ N, x, y, Ax, By, hAx_non, hBy_non, hAx_fin, hBy_fin, hAx, hBy, hdim, hcard⟩
+  rcases weak_PFR_asymm_prelim A B hA_non hB_non with ⟨ N, x, y, Ax, By, hAx_non, hBy_non, hAx_fin, hBy_fin, hAx, hBy, hdim, hcard⟩
   have hAxA : Ax ⊆ A := by rw [hAx]; simp
   have hByB : By ⊆ B := by rw [hBy]; simp
-  have hA_pos : (0 : ℝ) < Nat.card A := Nat.cast_pos.mpr Nat.card_pos
-  have hB_pos : (0 : ℝ) < Nat.card B := Nat.cast_pos.mpr Nat.card_pos
+  have hA_pos : (0 : ℝ) < Nat.card A := Nat.cast_pos.mpr (@Nat.card_pos _ hA_non.to_subtype _)
+  have hB_pos : (0 : ℝ) < Nat.card B := Nat.cast_pos.mpr (@Nat.card_pos _ hB_non.to_subtype _)
 
   rcases lt_or_ge (Nat.card Ax + Nat.card By) (Nat.card A + Nat.card B) with h | h
   . replace h := h_induct (Nat.card Ax + Nat.card By) (h.trans_le hM) G hG_comm hG_free hG_fin hG_count hG_mes hG_sing Ax By (Set.finite_coe_iff.mpr hAx_fin) (Set.finite_coe_iff.mpr hBy_fin) hAx_non hBy_non (Eq.le rfl)
@@ -1193,6 +1113,8 @@ lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] (hA : A.Nonempty) (hB :
     have hB'_fin' := Set.finite_coe_iff.mpr (Set.Finite.subset hBy_fin hB')
     have hAx_non' := Set.nonempty_coe_sort.mpr hAx_non
     have hBy_non' := Set.nonempty_coe_sort.mpr hBy_non
+    have hA'_non' := Set.nonempty_coe_sort.mpr hA'_non
+    have hB'_non' := Set.nonempty_coe_sort.mpr hB'_non
     have hAx_pos : (0 : ℝ) < Nat.card Ax := Nat.cast_pos.mpr Nat.card_pos
     have hBy_pos : (0 : ℝ) < Nat.card By := Nat.cast_pos.mpr Nat.card_pos
     have hA'_pos : (0 : ℝ) < Nat.card A' := Nat.cast_pos.mpr Nat.card_pos
@@ -1209,7 +1131,9 @@ lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] (hA : A.Nonempty) (hB :
     linarith only [Real.log_le_log hAx_pos hAxA_le, Real.log_le_log hBy_pos hByB_le, hcard]
   use A, B
   refine ⟨ Eq.subset rfl, Eq.subset rfl, hA_non, hB_non, ?_, ?_ ⟩
-  . apply LE.le.trans _ <| mul_nonneg (by norm_num) <| rdist_set_nonneg A B
+  . have := hA_non.to_subtype
+    have := hB_non.to_subtype
+    apply LE.le.trans _ <| mul_nonneg (by norm_num) <| rdist_set_nonneg A B
     rw [div_self (by positivity)]
     simp
   have hAx_eq : Ax = A := by
@@ -1246,10 +1170,10 @@ lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] (hA : A.Nonempty) (hB :
 /-- If $A\subseteq \mathbb{Z}^d$ is a finite non-empty set with $d[U_A;U_A]\leq \log K$ then there exists a non-empty $A'\subseteq A$ such that
 $\lvert A'\rvert\geq K^{-17}\lvert A\rvert$
 and $\dim A'\leq \frac{40}{\log 2} \log K$. -/
-lemma weak_PFR {A : Set G} [Finite A]  [Nonempty A]  {K : ℝ} (hK: 0 < K) (hdist: dᵤ[A # A] ≤ log K):
+lemma weak_PFR {A : Set G} [Finite A] {K : ℝ} (hA : A.Nonempty) (hK: 0 < K) (hdist: dᵤ[A # A] ≤ log K):
     ∃ A' : Set G, A' ⊆ A ∧ (Nat.card A') ≥ K^(-17 : ℝ) * (Nat.card A)
     ∧ (dimension A') ≤ (40 / log 2) * log K := by
-  rcases weak_PFR_asymm A A with ⟨A', A'', hA', hA'', hA'nonempty, hA''nonempty, hcard, hdim⟩
+  rcases weak_PFR_asymm A A hA hA with ⟨A', A'', hA', hA'', hA'nonempty, hA''nonempty, hcard, hdim⟩
 
   have : ∃ B : Set G, B ⊆ A ∧ (Nat.card B) ≥ (Nat.card A') ∧ (Nat.card B) ≥ (Nat.card A'') ∧ (dimension B) ≤
 max (dimension A') (dimension A'') := by
@@ -1266,10 +1190,10 @@ max (dimension A') (dimension A'') := by
     exact ⟨hA.to_subtype, inferInstance⟩
   have hA'pos : Nat.card A' > 0 := by
     rw [gt_iff_lt, Nat.card_pos_iff]
-    refine ⟨ (by infer_instance), Finite.Set.subset _ hA' ⟩
+    refine ⟨ hA'nonempty.to_subtype, Finite.Set.subset _ hA' ⟩
   have hA''pos : Nat.card A'' > 0 := by
     rw [gt_iff_lt, Nat.card_pos_iff]
-    refine ⟨ (by infer_instance), Finite.Set.subset _ hA'' ⟩
+    refine ⟨ hA''nonempty.to_subtype, Finite.Set.subset _ hA'' ⟩
   have hBpos : Nat.card B > 0 := by linarith
 
   refine ⟨hB, ?_, ?_⟩
@@ -1300,18 +1224,17 @@ max (dimension A') (dimension A'') := by
 /-- Let $A\subseteq \mathbb{Z}^d$ and $\lvert A-A\rvert\leq K\lvert A\rvert$.
 There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-17}\lvert A\rvert$
 and $\dim A' \leq \frac{40}{\log 2} \log K$.-/
-theorem weak_PFR_int {A : Set G} [Finite A] [Nonempty A] {K : ℝ} (hK : 0 < K)
+theorem weak_PFR_int {A : Set G} [Finite A] (hnA : A.Nonempty) {K : ℝ} (hK : 0 < K)
     (hA: Nat.card (A-A) ≤ K * Nat.card A) :
     ∃ A' : Set G, A' ⊆ A ∧ Nat.card A' ≥ K ^ (-17 : ℝ) * (Nat.card A) ∧
       dimension A' ≤ (40 / log 2) * log K := by
-  apply weak_PFR hK ((rdist_set_le A A).trans _)
+  apply weak_PFR hnA hK ((rdist_set_le A A hnA hnA).trans _)
   suffices log (Nat.card (A-A)) ≤ log K + log (Nat.card A) by linarith
   rw [← log_mul (by positivity) _]
   . apply log_le_log _ hA
     norm_cast
     have : Nonempty (A-A) := by
-      have : Set.Nonempty A := Set.nonempty_coe_sort.mp ‹_›
-      exact Set.Nonempty.coe_sort (Set.Nonempty.sub this this)
+      exact Set.Nonempty.coe_sort (Set.Nonempty.sub hnA hnA)
     apply Nat.card_pos
   norm_cast
-  apply ne_of_gt Nat.card_pos
+  apply ne_of_gt (@Nat.card_pos _ hnA.to_subtype _)

--- a/PFR/WeakPFR.lean
+++ b/PFR/WeakPFR.lean
@@ -5,6 +5,7 @@ import Mathlib.GroupTheory.Torsion
 import Mathlib.LinearAlgebra.FreeModule.PID
 import PFR.Mathlib.Data.Set.Pointwise.SMul
 import PFR.EntropyPFR
+import PFR.ImprovedPFR
 import PFR.ForMathlib.Entropy.RuzsaSetDist
 import PFR.Mathlib.GroupTheory.Torsion
 
@@ -15,7 +16,9 @@ Here we use the entropic form of PFR to deduce a weak form of PFR over the integ
 
 ## Main statement
 
-* `weak_PFR_int` : Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$. There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-44}\lvert A\rvert$ and $\dim A' \leq 60\log K$.
+* `weak_PFR_int`: Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$.
+  There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-17}\lvert A\rvert$ and
+  $\dim A' \leq (40/\log 2)\log K$.
 
 -/
 
@@ -202,7 +205,7 @@ $\phi : G\to \mathbb{F}_2^d$ is a homomorphism then
 \[\mathbb{H}(\phi(X))\leq 10d[X;Y].\] -/
 lemma torsion_dist_shrinking {H : Type u} [FiniteRange X] [FiniteRange Y] (hX : Measurable X)
   (hY : Measurable Y) [AddCommGroup H] [ElementaryAddCommGroup H 2]
-  [Fintype H] [MeasurableSpace H] [MeasurableSingletonClass H] [Countable H]
+  [MeasurableSpace H] [MeasurableSingletonClass H] [Countable H]
   (hG : AddMonoid.IsTorsionFree G) (φ : G →+ H) :
   H[φ ∘ X ; μ] ≤ 10 * d[X; μ # Y ; μ'] := by
   have :=
@@ -215,50 +218,375 @@ lemma torsion_dist_shrinking {H : Type u} [FiniteRange X] [FiniteRange Y] (hX : 
 
 end Torsion
 
+instance {G : Type u} [AddCommGroup G] [Fintype G] [MeasurableSpace G] [MeasurableSingletonClass G] (H : AddSubgroup G)
+    : MeasurableSingletonClass (G ⧸ H) :=
+  ⟨λ _ ↦ by { rw [measurableSet_quotient]; simp [measurableSet_discrete] }⟩
+
 section F2_projection
 
 open Real ProbabilityTheory MeasureTheory
 
-variable {G : Type u} [AddCommGroup G] [ElementaryAddCommGroup G 2] [Fintype G] [MeasurableSpace G] [MeasurableSingletonClass G]
- {Ω Ω' : Type u} [MeasurableSpace Ω] [MeasurableSpace Ω'] (X : Ω → G) (Y : Ω' → G) (μ : Measure Ω := by volume_tac) (μ' : Measure Ω' := by volume_tac) [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
+variable {G : Type u} [AddCommGroup G] [ElementaryAddCommGroup G 2] [Fintype G] [MeasurableSpace G]
+[MeasurableSingletonClass G] {Ω Ω' : Type*}
 
 /-- Let $G=\mathbb{F}_2^n$ and $X,Y$ be $G$-valued random variables such that
-\[\mathbb{H}(X)+\mathbb{H}(Y)> 44d[X;Y].\]
+\[\mathbb{H}(X)+\mathbb{H}(Y)> (20/\alpha) d[X;Y],\]
+for some $\alpha > 0$.
 There is a non-trivial subgroup $H\leq G$ such that
-\[\log \lvert H\rvert <\mathbb{H}(X)+\mathbb{H}(Y)\] and
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))< \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}\]
-where $\psi : G\to G/H$ is the natural projection homomorphism.
+\[\log \lvert H\rvert <(1+\alpha)/2 (\mathbb{H}(X)+\mathbb{H}(Y))\] and
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))< \alpha (\mathbb{H}(X)+\mathbb{H}(Y))\]
+where $\psi:G\to G/H$ is the natural projection homomorphism.
 -/
-proof_wanted app_ent_PFR (hent : H[ X; μ] + H[Y; μ'] > 44 * d[X;μ # Y;μ']) : ∃ H : AddSubgroup G, log (Nat.card H) < H[X; μ] + H[Y;μ'] ∧ H[QuotientAddGroup.mk' H ∘ X; μ ] + H[QuotientAddGroup.mk' H ∘ Y; μ' ] < (H[ X; μ] + H[Y; μ'])/2
+lemma app_ent_PFR' [MeasureSpace Ω] [MeasureSpace Ω'] (X : Ω → G) (Y : Ω' → G)
+  [IsProbabilityMeasure (ℙ : Measure Ω)] [IsProbabilityMeasure (ℙ : Measure Ω')]
+  {α : ℝ} (hent : 20 * d[X # Y] < α * (H[X] + H[Y])) (hX : Measurable X) (hY : Measurable Y) :
+  ∃ H : AddSubgroup G, log (Nat.card H) < (1 + α) / 2 * (H[X] + H[Y]) ∧
+  H[(QuotientAddGroup.mk' H) ∘ X] + H[(QuotientAddGroup.mk' H) ∘ Y] < α * (H[X] + H[Y]) := by
+  let p : refPackage Ω Ω' G := {
+    X₀₁ := X
+    X₀₂ := Y
+    hmeas1 := hX
+    hmeas2 := hY
+    η := 1/8
+    hη := by norm_num
+    hη' := by norm_num }
+  obtain ⟨H, Ω'', hΩ'', U, _, hUmeas, hUunif, ineq⟩ := entropic_PFR_conjecture_improv p rfl
+  let ψ := (QuotientAddGroup.mk' H)
+  use H
+  haveI : Finite H := Subtype.finite
+  -- Note that  H[ψ ∘ X] + H[ψ ∘ Y] ≤ 20 * d[X # Y]
+  have ent_le : H[ψ ∘ X] + H[ψ ∘ Y] ≤ 20 * d[X # Y] := calc
+    H[ψ ∘ X] + H[ψ ∘ Y] ≤ 2 * d[X # U] + 2 * d[Y # U] := by
+      gcongr
+      · exact ent_of_proj_le hX hUmeas hUunif
+      · exact ent_of_proj_le hY hUmeas hUunif
+    _ = 2 * (d[X # U] + d[Y # U]) := by ring
+    _ ≤ 2 * (10 * d[X # Y]) := by gcongr
+    _ = 20 * d[X # Y] := by ring
+  -- Note that (log (Nat.card H) - H[X]) + (log (Nat.card H) - H[Y]) ≤ 20 * d[X # Y]
+  have log_sub_le : (log (Nat.card H) - H[X]) + (log (Nat.card H) - H[Y]) ≤ 20 * d[X # Y] := calc
+    (log (Nat.card H) - H[X]) + (log (Nat.card H) - H[Y]) =
+      (H[U] - H[X]) + (H[U] - H[Y]) := by
+        rw [IsUniform.entropy_eq' hUunif hUmeas, SetLike.coe_sort_coe]
+    _ ≤ |(H[U] - H[X])| + |(H[U] - H[Y])| := by gcongr <;> exact le_abs_self _
+    _ ≤ 2 * d[X # U] + 2 * d[Y # U] := by
+      gcongr
+      · rw [rdist_symm]; exact diff_ent_le_rdist hUmeas hX
+      · rw [rdist_symm]; exact diff_ent_le_rdist hUmeas hY
+    _ = 2 * (d[X # U] + d[Y # U]) := by ring
+    _ ≤ 2 * (10 * d[X # Y]) := by gcongr
+    _ = 20 * d[X # Y] := by ring
+  -- then the conclusion follows from the assumption `hent` and basic inequality manipulations
+  exact ⟨by linarith, by linarith⟩
 
-/-- If $G=\mathbb{F}_2^d$ and $X,Y$ are $G$-valued random variables then there is a subgroup $H\leq \mathbb{F}_2^d$ such that
-\[\log \lvert H\rvert \leq 2(\mathbb{H}(X)+\mathbb{H}(Y))\]
-and if $\psi : G \to G/H$ is the natural projection then
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 44 d[\psi(X);\psi(Y)].\] -/
-lemma PFR_projection :
-    ∃ H : AddSubgroup G, log (Nat.card H) ≤ 2 * (H[X; μ] + H[Y ; μ']) ∧
-      H[QuotientAddGroup.mk' H ∘ X; μ ] + H[QuotientAddGroup.mk' H ∘ Y; μ' ] ≤
-        44 * d[ QuotientAddGroup.mk' H ∘ X;μ # QuotientAddGroup.mk' H ∘ Y;μ'] := by sorry
+variable [MeasurableSpace Ω] [MeasurableSpace Ω'] (X : Ω → G) (Y : Ω' → G)
+(μ : Measure Ω := by volume_tac) (μ' : Measure Ω' := by volume_tac)
+[IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
+
+lemma app_ent_PFR (α : ℝ) (hent: 20 * d[X;μ # Y;μ'] < α * (H[X; μ] + H[Y; μ'])) (hX : Measurable X)
+    (hY : Measurable Y) :
+    ∃ H : AddSubgroup G, log (Nat.card H) < (1 + α) / 2 * (H[X; μ] + H[Y;μ']) ∧
+    H[(QuotientAddGroup.mk' H) ∘ X; μ] + H[(QuotientAddGroup.mk' H) ∘ Y; μ']
+      < α * (H[ X; μ] + H[Y; μ']) :=
+  @app_ent_PFR' _ _ _ _ _ _ _ _ (MeasureSpace.mk μ) (MeasureSpace.mk μ') _ _ _ _ α hent hX hY
+
+set_option maxHeartbeats 300000 in
+/-- If $G=\mathbb{F}_2^d$ and $X,Y$ are $G$-valued random variables and $\alpha < 1$ then there is
+a subgroup  $H\leq \mathbb{F}_2^d$ such that
+\[\log \lvert H\rvert \leq (1 + α) / (2 * (1 - α)) * (\mathbb{H}(X)+\mathbb{H}(Y))\]
+and if $\psi:G \to G/H$ is the natural projection then
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 20/\alpha * d[\psi(X);\psi(Y)].\] -/
+lemma PFR_projection'
+    (α : ℝ) (hX : Measurable X) (hY : Measurable Y) (αpos : 0 < α) (αone : α < 1) :
+    ∃ H : AddSubgroup G, log (Nat.card H) ≤ (1 + α) / (2 * (1 - α)) * (H[X ; μ] + H[Y ; μ']) ∧
+    α * (H[(QuotientAddGroup.mk' H) ∘ X ; μ] + H[(QuotientAddGroup.mk' H) ∘ Y ; μ']) ≤
+      20 * d[(QuotientAddGroup.mk' H) ∘ X ; μ # (QuotientAddGroup.mk' H) ∘ Y ; μ'] := by
+  let S := { H : AddSubgroup G | (∃ (c : ℝ), 0 ≤ c ∧
+      log (Nat.card H) ≤ (1 + α) / (2 * (1 - α)) * (1 - c) * (H[X; μ] + H[Y;μ']) ∧
+    H[(QuotientAddGroup.mk' H) ∘ X; μ] + H[(QuotientAddGroup.mk' H) ∘ Y; μ'] ≤
+      c * (H[X; μ] + H[Y;μ'])) ∧
+    20 * d[(QuotientAddGroup.mk' H) ∘ X ; μ # (QuotientAddGroup.mk' H) ∘ Y ; μ'] <
+      α * (H[ (QuotientAddGroup.mk' H) ∘ X; μ ] + H[ (QuotientAddGroup.mk' H) ∘ Y; μ']) }
+  have : 0 ≤ H[X ; μ] + H[Y ; μ'] := by linarith [entropy_nonneg X μ, entropy_nonneg Y μ']
+  have : 0 < 1 - α := sub_pos.mpr αone
+  by_cases hE : (⊥ : AddSubgroup G) ∈ S
+  · classical
+    obtain ⟨H, ⟨⟨c, hc, hlog, hup⟩, hent⟩, hMaxl⟩ :=
+      S.toFinite.exists_maximal_wrt id S (Set.nonempty_of_mem hE)
+    set ψ : G →+ G ⧸ H := QuotientAddGroup.mk' H
+    have surj : Function.Surjective ψ := QuotientAddGroup.mk'_surjective H
+
+    set G' := G ⧸ H
+    have : ElementaryAddCommGroup G' 2 := ElementaryAddCommGroup.quotient_group (by decide)
+      (by simp [AddSubgroup.zero_mem])
+
+    obtain ⟨H', hlog', hup'⟩ := app_ent_PFR _ _ _ _ α hent ((measurable_discrete _).comp hX)
+      ((measurable_discrete _).comp hY)
+    have H_ne_bot: H' ≠ ⊥ := by
+      by_contra!
+      rcases this with rfl
+      have inj : Function.Injective (QuotientAddGroup.mk' (⊥ : AddSubgroup G')) :=
+          (QuotientAddGroup.quotientBot : (G' ⧸ ⊥) ≃+ G').symm.injective
+      rw [entropy_comp_of_injective _ ((measurable_discrete _).comp hX) _ inj,
+          entropy_comp_of_injective _ ((measurable_discrete _).comp hY) _ inj] at hup'
+      nlinarith [entropy_nonneg (ψ ∘ X) μ, entropy_nonneg (ψ ∘ Y) μ']
+    let H'' := H'.comap ψ
+    use H''
+
+    rw [← (AddSubgroup.map_comap_eq_self_of_surjective surj _ : H''.map ψ = H')] at hup' hlog'
+    set H' := H''.map ψ
+
+    have Hlt : H < H'' := by
+      have : H = (⊥ : AddSubgroup G').comap ψ := by
+        simp only [AddMonoidHom.comap_bot, QuotientAddGroup.ker_mk']
+      rw [this, AddSubgroup.comap_lt_comap_of_surjective surj]
+      exact Ne.bot_lt H_ne_bot
+
+    let φ : G' ⧸ H' ≃+ G ⧸ H'' := QuotientAddGroup.quotientQuotientEquivQuotient H H'' Hlt.le
+    set ψ' : G' →+ G' ⧸ H' := QuotientAddGroup.mk' H'
+    set ψ'' : G →+ G ⧸ H'' := QuotientAddGroup.mk' H''
+    have diag : ψ' ∘ ψ = φ.symm ∘ ψ'' := rfl
+    rw [← Function.comp.assoc, ← Function.comp.assoc, diag, Function.comp.assoc,
+        Function.comp.assoc] at hup'
+
+    have cond : log (Nat.card H'') ≤
+        (1 + α) / (2 * (1 - α)) * (1 - α * c) * (H[X; μ] + H[Y;μ']) := by
+      have cardprod : Nat.card H'' = Nat.card H' * Nat.card H := by
+        have hcard₀ := Nat.card_congr <| (AddSubgroup.addSubgroupOfEquivOfLe Hlt.le).toEquiv
+        have hcard₁ := Nat.card_congr <|
+          (QuotientAddGroup.quotientKerEquivRange (ψ.restrict H'')).toEquiv
+        have hcard₂ := AddSubgroup.card_eq_card_quotient_add_card_addSubgroup (H.addSubgroupOf H'')
+        rw [ψ.ker_restrict H'', QuotientAddGroup.ker_mk', ψ.restrict_range H''] at hcard₁
+        simpa only [← Nat.card_eq_fintype_card, hcard₀, hcard₁] using hcard₂
+      calc
+          log (Nat.card H'')
+      _ = log ((Nat.card H' : ℝ) * (Nat.card H : ℝ)) := by rw [cardprod]; norm_cast
+      _ = log (Nat.card H') + log (Nat.card H) := by
+        rw [Real.log_mul (Nat.cast_ne_zero.2 (@Nat.card_pos H').ne')
+              (Nat.cast_ne_zero.2 (@Nat.card_pos H).ne')]
+      _ ≤ (1 + α) / 2 * (H[⇑ψ ∘ X ; μ] + H[⇑ψ ∘ Y ; μ']) + log (Nat.card H) := by gcongr
+      _ ≤ (1 + α) / 2 * (c * (H[X; μ] + H[Y;μ'])) +
+            (1 + α) / (2 * (1 - α)) * (1 - c) * (H[X ; μ] + H[Y ; μ']) := by gcongr
+      _ = (1 + α) / (2 * (1 - α)) * (1 - α * c) * (H[X ; μ] + H[Y ; μ']) := by
+        field_simp; ring
+
+    have HS : H'' ∉ S := λ Hs => Hlt.ne (hMaxl H'' Hs Hlt.le)
+    simp only [Set.mem_setOf_eq, not_and, not_lt] at HS
+    refine ⟨?_, HS ⟨α * c, by positivity, cond, ?_⟩⟩
+    · calc
+      log (Nat.card H'')
+      _ ≤ (1 + α) / (2 * (1 - α)) * (1 - α * c) * (H[X; μ] + H[Y;μ']) := cond
+      _ ≤ (1 + α) / (2 * (1 - α)) * 1 * (H[X; μ] + H[Y;μ']) := by gcongr; simp; positivity
+      _ = (1 + α) / (2 * (1 - α)) * (H[X; μ] + H[Y;μ']) := by simp only [mul_one]
+    · calc
+      H[ ψ'' ∘ X; μ ] + H[ ψ'' ∘ Y; μ' ]
+      _ = H[ φ.symm ∘ ψ'' ∘ X; μ ] + H[ φ.symm ∘ ψ'' ∘ Y; μ' ] := by
+        simp_rw [← entropy_comp_of_injective _ ((measurable_discrete _).comp hX) _ φ.symm.injective,
+                 ← entropy_comp_of_injective _ ((measurable_discrete _).comp hY) _ φ.symm.injective]
+      _ ≤ α * (H[ ψ ∘ X; μ ] + H[ ψ ∘ Y; μ' ]) := hup'.le
+      _ ≤ α * (c * (H[X ; μ] + H[Y ; μ'])) := by gcongr
+      _ = (α * c) * (H[X ; μ] + H[Y ; μ']) := by ring
+  · use ⊥
+    constructor
+    · simp only [AddSubgroup.mem_bot, Nat.card_eq_fintype_card, Fintype.card_ofSubsingleton,
+        Nat.cast_one, log_one]
+      positivity
+    · simp only [Set.mem_setOf_eq, not_and, not_lt] at hE
+      exact hE ⟨1, by norm_num, by
+        norm_num; exact add_le_add (entropy_comp_le μ hX _) (entropy_comp_le μ' hY _)⟩
+
+/-- If $G=\mathbb{F}_2^d$ and $X,Y$ are $G$-valued random variables then there is
+a subgroup  $H\leq \mathbb{F}_2^d$ such that
+\[\log \lvert H\rvert \leq 2 * (\mathbb{H}(X)+\mathbb{H}(Y))\]
+and if $\psi:G \to G/H$ is the natural projection then
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 34 * d[\psi(X);\psi(Y)].\] -/
+lemma PFR_projection (hX : Measurable X) (hY : Measurable Y) :
+    ∃ H : AddSubgroup G, log (Nat.card H) ≤ 2 * (H[X; μ] + H[Y;μ']) ∧
+    H[(QuotientAddGroup.mk' H) ∘ X; μ] + H[(QuotientAddGroup.mk' H) ∘ Y; μ'] ≤
+      34 * d[(QuotientAddGroup.mk' H) ∘ X;μ # (QuotientAddGroup.mk' H) ∘ Y;μ'] := by
+  rcases PFR_projection' X Y μ μ' ((3 : ℝ) / 5) hX hY (by norm_num) (by norm_num) with ⟨H, h, h'⟩
+  refine ⟨H, ?_, ?_⟩
+  · convert h
+    norm_num
+  · have : 0 ≤ d[⇑(QuotientAddGroup.mk' H) ∘ X ; μ # ⇑(QuotientAddGroup.mk' H) ∘ Y ; μ'] :=
+      rdist_nonneg ((measurable_discrete _).comp hX) ((measurable_discrete _).comp hY)
+    linarith
 
 end F2_projection
 
 open MeasureTheory ProbabilityTheory Real
+open scoped BigOperators
 
 lemma four_logs {a b c d : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d) :
     log ((a*b)/(c*d)) = log a + log b - log c - log d := by
   rw [log_div, log_mul, log_mul, sub_sub] <;> positivity
 
+lemma sum_prob_preimage {G H : Type*} {X : Finset H} {A : Set G} [Nonempty A] [Finite A] {φ : A → X}
+    {A_ : H → Set G} (hφ : ∀ x : X, A_ x = Subtype.val '' (φ ⁻¹' {x})) :
+    ∑ x in X, (Nat.card (A_ x) : ℝ) / (Nat.card A) = 1 := by
+  apply Finset.sum_div.symm.trans
+  apply (div_eq_one_iff_eq <| Nat.cast_ne_zero.mpr <| Nat.pos_iff_ne_zero.mp Nat.card_pos).mpr
+  classical
+  haveI := Fintype.ofFinite A
+  rewrite [Nat.card_eq_fintype_card, ← Finset.card_univ, Finset.card_eq_sum_card_fiberwise
+    <| fun a _ ↦ Finset.mem_univ (φ a), ← Finset.sum_coe_sort]
+  norm_cast
+  congr; ext
+  rewrite [← Set.Finite.toFinset_setOf, (Set.toFinite _).card_toFinset, ← Nat.card_eq_fintype_card,
+    hφ, Nat.card_image_of_injective Subtype.val_injective]; rfl
+
 /-- Let $\phi : G\to H$ be a homomorphism and $A,B\subseteq G$ be finite subsets. If $x,y\in H$ then let $A_x=A\cap \phi^{-1}(x)$ and $B_y=B\cap \phi^{-1}(y)$. There exist $x,y\in H$ such that $A_x,B_y$ are both non-empty and
 \[d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq (\mathbb{H}(\phi(U_A))+\mathbb{H}(\phi(U_B)))(d(U_A,U_B)-d(U_{A_x},U_{B_y}).\] -/
-lemma single_fibres {G H Ω Ω' : Type u} [AddCommGroup G] [Countable G] [MeasurableSpace G]
-    [MeasurableSingletonClass G] [AddCommGroup H] [Countable H] [MeasurableSpace H]
-    [MeasurableSingletonClass H] (φ : G →+ H) {A B : Set G} [Finite A] [Finite B] (hA : A.Nonempty)
-    (hB : B.Nonempty) [MeasureSpace Ω] [MeasureSpace Ω'] [IsProbabilityMeasure (ℙ : Measure Ω)]
-    [IsProbabilityMeasure  (ℙ : Measure Ω')] {UA : Ω → G} {UB : Ω' → G} (hUA' : Measurable UA)
-    (hUB' : Measurable UB) (hUA : IsUniform A UA) (hUB : IsUniform B UB) :
-    ∃ (x y : H) (Ax By : Set G), Ax = A ∩ φ⁻¹' {x} ∧ By = B ∩ φ⁻¹' {y} ∧ Ax.Nonempty ∧ By.Nonempty ∧
-      d[φ ∘ UA # φ ∘ UB] * log (Nat.card A * Nat.card B / (Nat.card Ax * Nat.card By))
-        ≤ (H[φ ∘ UA] + H[φ ∘ UB]) * (d[UA # UB] - dᵤ[Ax # By]) := by sorry
+lemma single_fibres {G H Ω Ω': Type u}
+    [AddCommGroup G] [Countable G] [MeasurableSpace G] [MeasurableSingletonClass G]
+    [AddCommGroup H] [Countable H] [MeasurableSpace H] [MeasurableSingletonClass H]
+    [MeasureSpace Ω] [MeasureSpace Ω']
+    [IsProbabilityMeasure (ℙ : Measure Ω)] [IsProbabilityMeasure (ℙ : Measure Ω')]
+    (φ : G →+ H)
+    {A B : Set G} [Finite A] [Finite B] [Nonempty A] [Nonempty B] {UA : Ω → G} {UB: Ω' → G}
+    (hUA': Measurable UA) (hUB': Measurable UB) (hUA: IsUniform A UA) (hUB: IsUniform B UB)
+    (hUA_mem : ∀ ω, UA ω ∈ A) (hUB_mem : ∀ ω, UB ω ∈ B) :
+    ∃ (x y : H) (Ax By: Set G),
+    Ax = A ∩ φ.toFun ⁻¹' {x} ∧ By = B ∩ φ.toFun ⁻¹' {y} ∧ Nonempty Ax ∧ Nonempty By ∧
+    d[φ.toFun ∘ UA # φ.toFun ∘ UB]
+    * log ((Nat.card A) * (Nat.card B) / ((Nat.card Ax) * (Nat.card By))) ≤
+    (H[φ.toFun ∘ UA] + H[φ.toFun ∘ UB]) * (d[UA # UB] - dᵤ[Ax # By]) := by
+  haveI : FiniteRange UA := finiteRange_of_finset UA A.toFinite.toFinset (by simpa)
+  haveI : FiniteRange UB := finiteRange_of_finset UB B.toFinite.toFinset (by simpa)
+  have hUA_coe : IsUniform A.toFinite.toFinset.toSet UA := by rwa [Set.Finite.coe_toFinset]
+  have hUB_coe : IsUniform B.toFinite.toFinset.toSet UB := by rwa [Set.Finite.coe_toFinset]
+
+  let A_ (x : H) : Set G := A ∩ φ.toFun ⁻¹' {x}
+  let B_ (y : H) : Set G := B ∩ φ.toFun ⁻¹' {y}
+  let X : Finset H := FiniteRange.toFinset (φ.toFun ∘ UA)
+  let Y : Finset H := FiniteRange.toFinset (φ.toFun ∘ UB)
+
+  haveI h_Ax (x : X) : Nonempty (A_ x.val) := by
+    obtain ⟨ω, hω⟩ := (FiniteRange.mem_iff _ _).mp x.property
+    use UA ω; exact Set.mem_inter (hUA_mem ω) (by exact hω)
+  haveI h_By (y : Y): Nonempty (B_ y.val) := by
+    obtain ⟨ω, hω⟩ := (FiniteRange.mem_iff _ _).mp y.property
+    use UB ω; exact Set.mem_inter (hUB_mem ω) (by exact hω)
+  have h_AX (a : A) : φ.toFun a.val ∈ X := by
+    obtain ⟨ω, hω⟩ := hUA_coe.nonempty_preimage_of_mem hUA' (A.toFinite.mem_toFinset.mpr a.property)
+    exact (FiniteRange.mem_iff _ (φ.toFun a.val)).mpr ⟨ω, congr_arg _ hω⟩
+  have h_BY (b : B) : φ.toFun b.val ∈ Y := by
+    obtain ⟨ω, hω⟩ := hUB_coe.nonempty_preimage_of_mem hUB' (B.toFinite.mem_toFinset.mpr b.property)
+    exact (FiniteRange.mem_iff _ (φ.toFun b.val)).mpr ⟨ω, congr_arg _ hω⟩
+
+  let φ_AX (a : A) : X := by use φ.toFun a.val; exact h_AX a
+  let φ_BY (b : B) : Y := by use φ.toFun b.val; exact h_BY b
+  have h_φ_AX (x : X) : A_ x.val = φ_AX ⁻¹' {x} := by ext; simp; simp [Subtype.ext_iff]
+  have h_φ_BY (y : Y) : B_ y.val = φ_BY ⁻¹' {y} := by ext; simp; simp [Subtype.ext_iff]
+
+  let p (x : H) (y : H) : ℝ :=
+    (Nat.card (A_ x).Elem) * (Nat.card (B_ y).Elem) / ((Nat.card A.Elem) * (Nat.card B.Elem))
+  have : ∑ x in X, ∑ y in Y, (p x y) * dᵤ[A_ x # B_ y] ≤ d[UA # UB] - d[φ.toFun ∘ UA # φ.toFun ∘ UB]
+  calc
+    _ = d[UA | φ.toFun ∘ UA # UB | φ.toFun ∘ UB] := by
+      rewrite [condRuzsaDist_eq_sum hUA' ((measurable_discrete _).comp hUA')
+        hUB' ((measurable_discrete _).comp hUB')]
+      refine Finset.sum_congr rfl <| fun x hx ↦ Finset.sum_congr rfl <| fun y hy ↦ ?_
+      haveI : Nonempty (A_ x) := h_Ax ⟨x, hx⟩
+      haveI : Nonempty (B_ y) := h_By ⟨y, hy⟩
+      let μx := (ℙ : Measure Ω)[|(φ.toFun ∘ UA) ⁻¹' {x}]
+      let μy := (ℙ : Measure Ω')[|(φ.toFun ∘ UB) ⁻¹' {y}]
+      have h_μ_p : IsProbabilityMeasure μx ∧ IsProbabilityMeasure μy := by
+        constructor <;> apply ProbabilityTheory.cond_isProbabilityMeasure <;> rw [Set.preimage_comp]
+        refine @IsUniform.measure_preimage_ne_zero _ _ _ _ _ _ _ _ _ _ hUA_coe hUA' _ ?_
+        swap; refine @IsUniform.measure_preimage_ne_zero _ _ _ _ _ _ _ _ _ _ hUB_coe hUB' _ ?_
+        all_goals rwa [Set.inter_comm, Set.Finite.coe_toFinset]
+      have h_μ_unif : IsUniform (A_ x) UA μx ∧ IsUniform (B_ y) UB μy := by
+        have : _ ∧ _ := ⟨hUA.restrict hUA' (φ.toFun ⁻¹' {x}), hUB.restrict hUB' (φ.toFun ⁻¹' {y})⟩
+        rwa [Set.inter_comm _ A, Set.inter_comm _ B] at this
+      rewrite [rdist_set_eq_rdist h_μ_p.1 h_μ_p.2 h_μ_unif.1 h_μ_unif.2 hUA' hUB']
+      show _ = (Measure.real _ (UA ⁻¹' (_ ⁻¹' _))) * (Measure.real _ (UB ⁻¹' (_ ⁻¹' _))) * _
+      rewrite [hUA_coe.measureReal_preimage hUA', hUB_coe.measureReal_preimage hUB']
+      simp_rw [IsProbabilityMeasure.measureReal_univ, one_mul]
+      rewrite [mul_div_mul_comm, Set.inter_comm A, Set.inter_comm B]
+      simp only [Set.Finite.coe_toFinset, Set.Finite.mem_toFinset, Finset.mem_val]; rfl
+    _ ≤ d[UA # UB] - d[φ.toFun ∘ UA # φ.toFun ∘ UB] := by
+      rewrite [ZeroHom.toFun_eq_coe, AddMonoidHom.toZeroHom_coe]
+      linarith only [rdist_le_sum_fibre φ hUA' hUB' (μ := ℙ) (μ' := ℙ)]
+  let M := H[φ.toFun ∘ UA] + H[φ.toFun ∘ UB]
+  have hM : M = ∑ x in X, ∑ y in Y, Real.negMulLog (p x y) := by
+    have h_compl (z : H × H) (h_notin : z ∉ X ×ˢ Y) : Real.negMulLog (p z.1 z.2) = 0 := by
+      have h_p_empty {a b : ℝ} : negMulLog ((Nat.card (∅ : Set G)) * a / b) = 0 := by simp
+      unfold_let p; beta_reduce
+      rewrite [Finset.mem_product, not_and_or] at h_notin
+      cases' h_notin with h_notin h_notin
+      have h_empty : A_ z.1 = ∅; rotate_left 2
+      have h_empty : B_ z.2 = ∅; let h_AX := h_BY; rotate_left
+      rw [mul_comm, h_empty, h_p_empty]; rotate_left
+      rw [h_empty, h_p_empty]
+      all_goals {
+        by_contra hc
+        obtain ⟨a, ha⟩ := Set.nonempty_iff_ne_empty'.mpr hc
+        rewrite [← ha.right] at h_notin
+        exact h_notin (h_AX ⟨a, ha.left⟩)
+      }
+    unfold_let M
+    unfold entropy
+    haveI := isProbabilityMeasure_map (μ := ℙ) ((measurable_discrete φ).comp hUA').aemeasurable
+    haveI := isProbabilityMeasure_map (μ := ℙ) ((measurable_discrete φ).comp hUB').aemeasurable
+    rewrite [← Finset.sum_product', ← tsum_eq_sum h_compl, ← measureEntropy_prod]
+    apply tsum_congr; intro; congr
+    rewrite [← Set.singleton_prod_singleton, Measure.smul_apply, Measure.prod_prod,
+      Measure.map_apply ((measurable_discrete _).comp hUA') (MeasurableSet.singleton _),
+      Measure.map_apply ((measurable_discrete _).comp hUB') (MeasurableSet.singleton _),
+      Set.preimage_comp, hUA_coe.measure_preimage hUA',
+      Set.preimage_comp, hUB_coe.measure_preimage hUB']
+    simp? [mul_div_mul_comm, Set.inter_comm, ENNReal.toReal_div]
+      says simp only [ZeroHom.toFun_eq_coe, AddMonoidHom.toZeroHom_coe,
+        measure_univ, inv_one, Set.Finite.coe_toFinset, Set.inter_comm, one_mul,
+        Set.Finite.mem_toFinset, smul_eq_mul, ENNReal.toReal_mul, ENNReal.toReal_div,
+        ENNReal.toReal_nat, mul_div_mul_comm]
+  have h_sum : ∑ x in X, ∑ y in Y,
+      (p x y) * (M * dᵤ[A_ x # B_ y] + d[φ.toFun ∘ UA # φ.toFun ∘ UB] * -Real.log (p x y)) ≤
+      M * d[UA # UB]
+  calc
+    _ = ∑ x in X, ∑ y in Y, (p x y) * M * dᵤ[A_ x # B_ y] + M * d[φ.toFun ∘ UA # φ.toFun ∘ UB] := by
+      simp_rw [hM, Finset.sum_mul, ← Finset.sum_add_distrib]
+      refine Finset.sum_congr rfl <| fun _ _ ↦ Finset.sum_congr rfl <| fun _ _ ↦ ?_
+      simp only [negMulLog, left_distrib, mul_assoc, Finset.sum_mul]
+      exact congrArg (HAdd.hAdd _) (by group)
+    _ = M * ∑ x in X, ∑ y in Y, (p x y) * dᵤ[A_ x # B_ y] + M * d[φ.toFun ∘ UA # φ.toFun ∘ UB] := by
+      simp_rw [Finset.mul_sum]
+      congr; ext; congr; ext; group
+    _ ≤ M * d[UA # UB] := by
+      rewrite [← left_distrib]
+      apply mul_le_mul_of_nonneg_left
+      · linarith
+      · unfold_let M
+        linarith only [entropy_nonneg (φ.toFun ∘ UA) ℙ, entropy_nonneg (φ.toFun ∘ UB) ℙ]
+  have : ∃ x : X, ∃ y : Y,
+      M * dᵤ[A_ x.val # B_ y.val] + d[φ.toFun ∘ UA # φ.toFun ∘ UB] * -Real.log (p x.val y.val) ≤
+      M * d[UA # UB] := by
+    let f (xy : H × H) := (p xy.1 xy.2) * (M * d[UA # UB])
+    let g (xy : H × H) := (p xy.1 xy.2) *
+      (M * dᵤ[A_ xy.1 # B_ xy.2] + d[φ.toFun ∘ UA # φ.toFun ∘ UB] * -Real.log (p xy.1 xy.2))
+    by_contra hc; push_neg at hc
+    replace hc : ∀ xy ∈ X ×ˢ Y, f xy < g xy := by
+      refine fun xy h ↦ mul_lt_mul_of_pos_left ?_ ?_
+      · exact hc ⟨xy.1, (Finset.mem_product.mp h).1⟩ ⟨xy.2, (Finset.mem_product.mp h).2⟩
+      · haveI : Nonempty _ := h_Ax ⟨xy.1, (Finset.mem_product.mp h).1⟩
+        haveI : Nonempty _ := h_By ⟨xy.2, (Finset.mem_product.mp h).2⟩
+        simp only [div_pos, mul_pos, Nat.cast_pos, Nat.card_pos]
+    have h_nonempty : Finset.Nonempty (X ×ˢ Y) := by
+      use ⟨φ.toFun <| UA <| Classical.choice <| ProbabilityMeasure.nonempty ⟨ℙ, inferInstance⟩,
+        φ.toFun <| UB <| Classical.choice <| ProbabilityMeasure.nonempty ⟨ℙ, inferInstance⟩⟩
+      exact Finset.mem_product.mpr ⟨FiniteRange.mem _ _, FiniteRange.mem _ _⟩
+    replace hc := Finset.sum_lt_sum_of_nonempty h_nonempty hc
+    have h_p_one : ∑ x in X ×ˢ Y, p x.1 x.2 = 1 := by
+      simp_rw [Finset.sum_product, mul_div_mul_comm, ← Finset.mul_sum,
+        ← sum_prob_preimage h_φ_AX, sum_prob_preimage h_φ_BY, mul_one]
+    rewrite [← Finset.sum_mul, h_p_one, one_mul, Finset.sum_product] at hc
+    exact not_le_of_gt hc h_sum
+  obtain ⟨x, y, hxy⟩ := this
+  refine ⟨x, y, A_ x.val, B_ y.val, rfl, rfl, h_Ax x, h_By y, ?_⟩
+  rewrite [← inv_div, Real.log_inv]
+  show _ * -log (p x.val y.val) ≤ M * _
+  linarith only [hxy]
 
 section dim
 
@@ -275,6 +603,7 @@ lemma exists_coset_cover (A : Set G) :
   existsi FiniteDimensional.finrank ℤ (⊤ : Submodule ℤ G), ⊤, 0
   refine ⟨rfl, fun a _ ↦ trivial⟩
 
+/-- The dimension of the affine span over `ℤ` of a subset of an additive group. -/
 noncomputable def dimension (A : Set G) : ℕ := Nat.find (exists_coset_cover A)
 
 lemma dimension_le_of_coset_cover (A : Set G) (S : Submodule ℤ G) (v : G)
@@ -445,32 +774,31 @@ lemma single {Ω : Type u} [MeasurableSpace Ω] [DiscreteMeasurableSpace Ω] (μ
   assumption
 
 /-- Given two non-empty finite subsets A, B of a rank n free Z-module G, there exists a subgroup N and points x, y in G/N such that the fibers Ax, By of A, B over x, y respectively are non-empty, one has the inequality
-$$ \log \frac{|A| |B|}{|A_x| |B_y|} ≤ 44 (d[U_A; U_B] - d[U_{A_x}; U_{B_y}])$$
+$$ \log \frac{|A| |B|}{|A_x| |B_y|} ≤ 34 (d[U_A; U_B] - d[U_{A_x}; U_{B_y}])$$
 and one has the dimension bound
 $$ n \log 2 ≤ \log |G/N| + 40 d[U_A; U_B].$$
  -/
-lemma weak_PFR_asymm_prelim {A B : Set G} [Finite A] [Finite B] (hA : A.Nonempty)
-    (hB : B.Nonempty) :
-    ∃ (N : AddSubgroup G) (x y : G ⧸ N) (Ax By : Set G), Ax.Nonempty ∧ By.Nonempty ∧ Ax.Finite ∧
-      By.Finite ∧ Ax = {z:G | z ∈ A ∧ QuotientAddGroup.mk' N z = x } ∧
-        By = {z : G | z ∈ B ∧ QuotientAddGroup.mk' N z = y } ∧
-        log 2 * FiniteDimensional.finrank ℤ G ≤ log (Nat.card (G ⧸ N)) + 40 * dᵤ[ A # B ] ∧ log (Nat.card A) + log (Nat.card B) - log (Nat.card Ax) - log (Nat.card By) ≤ 44 * (dᵤ[ A # B ] - dᵤ[ Ax # By ]) := by
-  have := hA.to_subtype
-  have := hB.to_subtype
+lemma weak_PFR_asymm_prelim (A B : Set G) [Finite A] [Finite B] [hnA : Nonempty A] [hnB : Nonempty B]:
+    ∃ (N : AddSubgroup G) (x y : G ⧸ N) (Ax By : Set G), Nonempty Ax ∧ Nonempty By ∧
+    Set.Finite Ax ∧ Set.Finite By ∧ Ax = {z:G | z ∈ A ∧ QuotientAddGroup.mk' N z = x } ∧
+    By = {z:G | z ∈ B ∧ QuotientAddGroup.mk' N z = y } ∧
+    (log 2) * FiniteDimensional.finrank ℤ G ≤ log (Nat.card (G ⧸ N)) +
+      40 * dᵤ[ A # B ] ∧ log (Nat.card A) + log (Nat.card B) - log (Nat.card Ax) - log (Nat.card By)
+      ≤ 34 * (dᵤ[ A # B ] - dᵤ[ Ax # By ]) := by
   obtain ⟨ h_elem, h_finite, h_card ⟩ := weak_PFR_quotient_prelim (G := G)
   set ψ : G →+ G := zsmulAddGroupHom 2
   set G₂ := AddMonoidHom.range ψ
   set H := G ⧸ G₂
   let φ : G →+ H := QuotientAddGroup.mk' G₂
   let _mH : MeasurableSpace H := ⊤
-  have _msH : MeasurableSingletonClass H := ⟨λ _ ↦ trivial⟩
   have h_fintype : Fintype H := Fintype.ofFinite H
   have h_torsionfree := torsion_free (G := G)
 
-  obtain ⟨ Ω, mΩ, UA, hμ, hUA_mes, hUA_unif, -, hUA_fin ⟩ := exists_isUniform_measureSpace' A
-  obtain ⟨ Ω', mΩ', UB, hμ', hUB_mes, hUB_unif, -, hUB_fin ⟩ := exists_isUniform_measureSpace' B
+  obtain ⟨ Ω, mΩ, UA, hμ, hUA_mes, hUA_unif, hUA_mem, hUA_fin ⟩ := exists_isUniform_measureSpace' A
+  obtain ⟨ Ω', mΩ', UB, hμ', hUB_mes, hUB_unif, hUB_mem, hUB_fin ⟩ :=
+    exists_isUniform_measureSpace' B
 
-  rcases (PFR_projection (φ.toFun ∘ UA) (φ.toFun ∘ UB) ℙ ℙ) with ⟨H', ⟨ hH1, hH2 ⟩ ⟩
+  rcases (PFR_projection (φ.toFun ∘ UA) (φ.toFun ∘ UB) ℙ ℙ (by measurability) (by measurability)) with ⟨H', ⟨ hH1, hH2 ⟩ ⟩
   let N := AddSubgroup.comap φ H'
   set φ' := QuotientAddGroup.mk' N
   have _cGN : Countable (G ⧸ N) := Function.Surjective.countable (QuotientAddGroup.mk'_surjective N)
@@ -480,10 +808,9 @@ lemma weak_PFR_asymm_prelim {A B : Set G} [Finite A] [Finite B] (hA : A.Nonempty
     exact MeasurableSpace.map_def.mpr (measurableSet_discrete _)
 
   rcases third_iso H' with ⟨ e : H ⧸ H' ≃+ G ⧸ N, he ⟩
-  rcases single_fibres φ' hA hB hUA_mes hUB_mes hUA_unif hUB_unif with
+  rcases single_fibres φ' hUA_mes hUB_mes hUA_unif hUB_unif hUA_mem hUB_mem with
     ⟨x, y, Ax, By, hAx, hBy, hnAx, hnBy, hcard_ineq⟩
-  have := hnAx.to_subtype
-  have := hnBy.to_subtype
+
   have Axf : Finite Ax := by rw [hAx]; infer_instance
   have Byf : Finite By := by rw [hBy]; infer_instance
 
@@ -508,12 +835,12 @@ lemma weak_PFR_asymm_prelim {A B : Set G} [Finite A] [Finite B] (hA : A.Nonempty
   use N, x, y, Ax, By
   refine ⟨ hnAx, hnBy, Ax.toFinite, By.toFinite, hAx, hBy, h_card, ?_ ⟩
 
-  replace hH2 : H[φ'.toFun ∘ UA] + H[φ'.toFun ∘ UB] ≤ 44 * d[φ'.toFun ∘ UA # φ'.toFun ∘ UB] := by
+  replace hH2 : H[φ'.toFun ∘ UA] + H[φ'.toFun ∘ UB] ≤ 34 * d[φ'.toFun ∘ UA # φ'.toFun ∘ UB] := by
     set X := ((mk' H').toFun ∘ φ.toFun) ∘ UA
     set Y := ((mk' H').toFun ∘ φ.toFun) ∘ UB
     have hX : Measurable X := Measurable.comp (measurable_discrete _) hUA_mes
     have hY : Measurable Y := Measurable.comp (measurable_discrete _) hUB_mes
-    change H[X] + H[Y] ≤ 44 * d[X # Y] at hH2
+    change H[X] + H[Y] ≤ 34 * d[X # Y] at hH2
 
     have ha : φ'.toFun ∘ UA = e.toFun ∘ X := by ext x; exact (he (UA x)).symm
     have hb : φ'.toFun ∘ UB = e.toFun ∘ Y := by ext x; exact (he (UB x)).symm
@@ -594,7 +921,7 @@ lemma weak_PFR_asymm_prelim {A B : Set G} [Finite A] [Finite B] (hA : A.Nonempty
       convert (four_logs ?_ ?_ ?_ ?_).symm
       all_goals norm_cast; exact Nat.card_pos
     _ ≤ (H[φ'.toFun ∘ UA] + H[φ'.toFun ∘ UB]) * (d[UA # UB] - dᵤ[Ax # By]) := hcard_ineq
-    _ ≤ (44 * d[φ'.toFun ∘ UA # φ'.toFun ∘ UB]) * (d[UA # UB] - dᵤ[Ax # By]) := by
+    _ ≤ (34 * d[φ'.toFun ∘ UA # φ'.toFun ∘ UB]) * (d[UA # UB] - dᵤ[Ax # By]) := by
       apply mul_le_mul_of_nonneg_right hH2
       have := rdist_le_avg_ent (Measurable.comp (measurable_discrete φ'.toFun) hUA_mes) (Measurable.comp (measurable_discrete φ'.toFun) hUB_mes)
       replace this : 0 < H[φ'.toFun ∘ UA] + H[φ'.toFun ∘ UB] := by linarith
@@ -614,15 +941,118 @@ lemma weak_PFR_asymm_prelim {A B : Set G} [Finite A] [Finite B] (hA : A.Nonempty
       rw [hBy]; exact Set.inter_subset_left _ _
       norm_cast
       exact mul_pos Nat.card_pos Nat.card_pos
-    _ = d[φ'.toFun ∘ UA # φ'.toFun ∘ UB] * (44 * (d[UA # UB] - dᵤ[Ax # By])) := by ring
-    _ = d[φ'.toFun ∘ UA # φ'.toFun ∘ UB] * (44 * (dᵤ[A # B] - dᵤ[Ax # By])) := by rw [<- rdist_set_eq_rdist hμ hμ' hUA_unif hUB_unif hUA_mes hUB_mes]
+    _ = d[φ'.toFun ∘ UA # φ'.toFun ∘ UB] * (34 * (d[UA # UB] - dᵤ[Ax # By])) := by ring
+    _ = d[φ'.toFun ∘ UA # φ'.toFun ∘ UB] * (34 * (dᵤ[A # B] - dᵤ[Ax # By])) := by
+      rw [<- rdist_set_eq_rdist hμ hμ' hUA_unif hUB_unif hUA_mes hUB_mes]
   exact (mul_le_mul_left h).mp this
 
 /-- Separating out the conclusion of `weak_PFR_asymm` for convenience of induction arguments.-/
-def WeakPFRAsymmConclusion (A B : Set G) : Prop := ∃ A' B' : Set G, A' ⊆ A ∧ B' ⊆ B ∧ Nonempty A' ∧ Nonempty B' ∧ log (((Nat.card A) * (Nat.card B)) / ((Nat.card A') * (Nat.card B'))) ≤ 44 * dᵤ[A # B] ∧ max (dimension A') (dimension B') ≤ (40 / log 2) * dᵤ[A # B]
+def weak_PFR_asymm_conclusion (A B : Set G) : Prop :=
+  ∃ A' B' : Set G, A' ⊆ A ∧ B' ⊆ B ∧ Nonempty A' ∧ Nonempty B' ∧
+  log (((Nat.card A) * (Nat.card B)) / ((Nat.card A') * (Nat.card B'))) ≤ 34 * dᵤ[A # B] ∧
+  max (dimension A') (dimension B') ≤ (40 / log 2) * dᵤ[A # B]
+
+/-- The property of two sets A,B of a group G not being contained in cosets of the same proper subgroup -/
+def not_in_coset {G: Type u} [AddCommGroup G] (A B : Set G) : Prop := AddSubgroup.closure ((A-A) ∪ (B-B)) = ⊤
+
+/-- The property of a set in a group being a translate of a subset of a subgroup. -/
+def is_shift {G: Type u} [AddCommGroup G] {H: AddSubgroup G} (A : Set G) (A' : Set H) : Prop :=
+  ∃ x, A = (A' : Set G) + {x}
+
+lemma sub_of_shift  {G: Type u} [AddCommGroup G] {H: AddSubgroup G} {A : Set G} {A' : Set H} (hA: is_shift A A') : A - A = (A' - A': Set H) := by
+  rcases hA with ⟨ x, hA ⟩
+  ext z; constructor
+  . intro hz
+    rw [hA, Set.mem_sub] at hz
+    rcases hz with ⟨ a1, a2, ha1, ha2, ha12 ⟩
+    rw [Set.add_singleton, Set.image_add_right, Set.mem_preimage, Set.mem_image] at ha1 ha2
+    rcases ha1 with ⟨ a1', ha1', ha1 ⟩
+    rcases ha2 with ⟨ a2', ha1', ha2 ⟩
+    have : z = (a1' - a2':H) := by push_cast; rw [ha1, ha2, <-ha12]; abel
+    rw [this]
+    convert Set.mem_image_of_mem Subtype.val ?_
+    rw [Set.mem_sub]
+    use a1', a2'
+  intro hz
+  rw [Set.mem_image] at hz
+  rcases hz with ⟨ z', hz, hzz ⟩
+  rw [Set.mem_sub] at hz
+  rcases hz with ⟨ a1, a2, ha1, ha2, ha12 ⟩
+  rw [Set.mem_sub, <-hzz, <-ha12, hA]
+  use a1+x, a2+x
+  simp [ha1, ha2]
+
+lemma card_of_shift  {G: Type u} [AddCommGroup G] {H: AddSubgroup G} {A : Set G} {A' : Set H} (hA: is_shift A A') [Finite A] [Nonempty A] : Finite A' ∧ Nonempty A' ∧ Nat.card A' = Nat.card A := by
+  rcases hA with ⟨ x, hA ⟩
+  set f : H → G := fun a ↦ (a:G) + x
+  have hf : Function.Injective f := by
+    intro y z hyz
+    simp at hyz
+    exact hyz
+  have hA' : A = f '' A' := by
+    rw [hA]
+    ext a
+    simp_rw [Set.add_singleton, Set.mem_image]
+    constructor
+    . rintro ⟨ a', ⟨ b, hb, hb' ⟩, ha ⟩
+      use b; rw [<-hb'] at ha; exact ⟨ hb, ha ⟩
+    rintro ⟨ a', ha, ha' ⟩
+    use a'; refine ⟨?_, ha' ⟩
+    use a'
+  have hA'_card : Nat.card A' = Nat.card A := by
+    rw [hA', Nat.card_image_of_injective hf]
+  have hA'_nonfin : Nonempty A' ∧ Finite A' := by
+    have := Nat.card_pos (α := A)
+    rw [<-hA'_card, Nat.card_pos_iff] at this
+    exact this
+  exact ⟨ hA'_nonfin.2, hA'_nonfin.1, hA'_card ⟩
+
+
+
+/-- Without loss of generality, one can move (up to translation and embedding) any pair A, B of non-empty sets into a subgroup where they are not in a coset. -/
+lemma wlog_not_in_coset {G: Type u} [AddCommGroup G] (A B : Set G) [hA: Nonempty A] [hB: Nonempty B] : ∃ (G': AddSubgroup G) (A' B' : Set G'), is_shift A A' ∧ is_shift B B' ∧ not_in_coset A' B' := by
+  set G' := AddSubgroup.closure ((A-A) ∪ (B-B))
+  obtain ⟨ x ⟩ := hA
+  obtain ⟨ y ⟩ := hB
+  set A' : Set G' := { a : G' | (a:G) + x ∈ A }
+  set B' : Set G' := { b : G' | (b:G) + y ∈ B }
+  use G', A', B'
+  have hA : is_shift A A' := by
+    use x; ext z; simp
+    intro hz
+    apply AddSubgroup.subset_closure
+    rw [Set.mem_union]; left
+    rw [Set.mem_sub]
+    use z, x
+    refine ⟨ hz, Subtype.mem x, sub_eq_add_neg z x ⟩
+  have hB : is_shift B B' := by
+    use y; ext z; simp
+    intro hz
+    apply AddSubgroup.subset_closure
+    rw [Set.mem_union]; right
+    rw [Set.mem_sub]
+    use z, y
+    refine ⟨ hz, Subtype.mem y, sub_eq_add_neg z y ⟩
+
+  refine ⟨ hA, hB, ?_ ⟩
+  unfold not_in_coset
+  rw [AddSubgroup.eq_top_iff']
+  intro z
+  rw [AddSubgroup.mem_closure]
+  intro K hK
+  replace hK := Set.image_mono (f := Subtype.val) hK
+  rw [Set.image_union] at hK
+  change ((A'-A':Set G'):Set G) ∪ ((B'-B':Set G'):Set G) ⊆ (K:Set G') at hK
+  rw [<-sub_of_shift hA, <-sub_of_shift hB, <- AddSubgroup.coeSubtype, <-AddSubgroup.coe_map (AddSubgroup.subtype G') K, <-AddSubgroup.closure_le] at hK
+  change G' ≤ AddSubgroup.map (AddSubgroup.subtype G') K at hK
+  replace hK := hK (SetLike.coe_mem z)
+  simp at hK
+  exact hK
 
 /-- In fact one has equality here, but this is tricker to prove and not needed for the argument. -/
-lemma dimension_of_shift {G : Type u} [AddCommGroup G] [Module.Free ℤ G] [Module.Finite ℤ G] {H : AddSubgroup G} [Module.Free ℤ H] [Module.Finite ℤ H] (A : Set H) (x : G) : dimension ((fun a : H ↦ (a : G) + x) '' A) ≤ dimension A := by
+lemma dimension_of_shift {G: Type u} [AddCommGroup G]
+  {H: AddSubgroup G} (A : Set H) (x : G) :
+  dimension ((fun a:H ↦ (a:G) + x) '' A) ≤ dimension A := by
   classical
   rcases Nat.find_spec (exists_coset_cover A) with ⟨ S, v, hrank, hshift ⟩
   change FiniteDimensional.finrank ℤ S = dimension A at hrank
@@ -638,9 +1068,11 @@ lemma dimension_of_shift {G : Type u} [AddCommGroup G] [Module.Free ℤ G] [Modu
   simp [← hb']
   abel
 
-lemma conclusion_transfers {A B : Set G} [Finite A] [Finite B] [Nonempty A] [Nonempty B] (G': AddSubgroup G) [Module.Finite ℤ G'] [Module.Free ℤ G'] (A' B' : Set G') (hA: IsShift A A') (hB: IsShift B B') [Finite A'] [Finite B'] [Nonempty A'] [Nonempty B'] : WeakPFRAsymmConclusion A' B' → WeakPFRAsymmConclusion A B := by
-  intro this
-  rcases this with ⟨ A'', B'', hA'', hB'', hA''_non, hB''_non, hcard_ineq, hdim_ineq ⟩
+lemma conclusion_transfers {A B : Set G}
+    (G': AddSubgroup G) (A' B' : Set G')
+    (hA : is_shift A A') (hB : is_shift B B') [Finite A'] [Finite B'] [Nonempty A'] [Nonempty B']
+    (h : weak_PFR_asymm_conclusion A' B') : weak_PFR_asymm_conclusion A B := by
+  rcases h with ⟨A'', B'', hA'', hB'', hA''_non, hB''_non, hcard_ineq, hdim_ineq⟩
   rcases hA with ⟨ x, hA ⟩
   set f : G' → G := fun a ↦ (a : G) + x
   have hf : Function.Injective f := by
@@ -703,11 +1135,10 @@ lemma conclusion_transfers {A B : Set G} [Finite A] [Finite B] [Nonempty A] [Non
   norm_cast
   apply max_le_max
   . exact dimension_of_shift A'' x
-  exact dimension_of_shift B'' y
-
+  · exact dimension_of_shift B'' y
 
 /-- If $A,B\subseteq \mathbb{Z}^d$ are finite non-empty sets then there exist non-empty $A'\subseteq A$ and $B'\subseteq B$ such that
-\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_A;U_B]\]
+\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 34 d[U_A;U_B]\]
 such that $\max(\dim A',\dim B')\leq \frac{40}{\log 2} d[U_A;U_B]$. -/
 lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] (hA : A.Nonempty) (hB : B.Nonempty) : WeakPFRAsymmConclusion A B  := by
   let P : ℕ → Prop := fun M ↦ (∀ (G : Type u) (hG_comm : AddCommGroup G) (_hG_free : Module.Free ℤ G) (_hG_fin : Module.Finite ℤ G) (_hG_count : Countable G) (hG_mes : MeasurableSpace G) (_hG_sing: MeasurableSingletonClass G) (A B: Set G) (_hA_fin: Finite A) (_hB_fin: Finite B) (_hA_non: A.Nonempty) (_hB_non: B.Nonempty) (_hM : (Nat.card A) + (Nat.card B) ≤ M), WeakPFRAsymmConclusion A B)
@@ -813,12 +1244,12 @@ lemma weak_PFR_asymm (A B : Set G) [Finite A] [Finite B] (hA : A.Nonempty) (hB :
   exact ⟨ dimension_le_rank A, dimension_le_rank B ⟩
 
 /-- If $A\subseteq \mathbb{Z}^d$ is a finite non-empty set with $d[U_A;U_A]\leq \log K$ then there exists a non-empty $A'\subseteq A$ such that
-$\lvert A'\rvert\geq K^{-22}\lvert A\rvert$
+$\lvert A'\rvert\geq K^{-17}\lvert A\rvert$
 and $\dim A'\leq \frac{40}{\log 2} \log K$. -/
-lemma weak_PFR {A : Set G} [Finite A] (hA : A.Nonempty) {K : ℝ} (hK: 0 < K)
-    (hdist : dᵤ[A # A] ≤ log K) :
-    ∃ A' ⊆ A, Nat.card A' ≥ K^(-22 : ℝ) * Nat.card A ∧ dimension A' ≤ 40 / log 2 * log K := by
-  rcases weak_PFR_asymm A A hA hA with ⟨A', A'', hA', hA'', hA'nonempty, hA''nonempty, hcard, hdim⟩
+lemma weak_PFR {A : Set G} [Finite A]  [Nonempty A]  {K : ℝ} (hK: 0 < K) (hdist: dᵤ[A # A] ≤ log K):
+    ∃ A' : Set G, A' ⊆ A ∧ (Nat.card A') ≥ K^(-17 : ℝ) * (Nat.card A)
+    ∧ (dimension A') ≤ (40 / log 2) * log K := by
+  rcases weak_PFR_asymm A A with ⟨A', A'', hA', hA'', hA'nonempty, hA''nonempty, hcard, hdim⟩
 
   have : ∃ B : Set G, B ⊆ A ∧ (Nat.card B) ≥ (Nat.card A') ∧ (Nat.card B) ≥ (Nat.card A'') ∧ (dimension B) ≤
 max (dimension A') (dimension A'') := by
@@ -851,30 +1282,31 @@ max (dimension A') (dimension A'') := by
         apply log_le_log
         . positivity
         gcongr
-      _ ≤ 44 * dᵤ[A # A] := hcard
-      _ ≤ 44 * log K := mul_le_mul_of_nonneg_left hdist (by linarith)
-      _ = 2 * (22 * log K) := by ring
-      _ = 2 * log (K^22) := by
+      _ ≤ 34 * dᵤ[A # A] := hcard
+      _ ≤ 34 * log K := mul_le_mul_of_nonneg_left hdist (by linarith)
+      _ = 2 * (17 * log K) := by ring
+      _ = 2 * log (K^17) := by
         congr
-        convert (log_pow K 22).symm
-    rw [mul_le_mul_left (by norm_num), log_le_log_iff (by positivity) (by positivity), div_le_iff (by positivity), ← mul_inv_le_iff (by positivity), ← ge_iff_le, mul_comm] at this
+        convert (log_pow K 17).symm
+    rw [mul_le_mul_left (by norm_num), log_le_log_iff (by positivity) (by positivity), div_le_iff (by positivity), <- mul_inv_le_iff (by positivity), <-ge_iff_le, mul_comm] at this
     convert this using 2
-    convert zpow_neg K 22 using 1
+    convert zpow_neg K 17 using 1
     norm_cast
   calc (dimension B : ℝ)
     _ ≤ (((max (dimension A') (dimension A'')) : ℕ) : ℝ) := by norm_cast
     _ ≤ (40 / log 2) * dᵤ[A # A] := hdim
     _ ≤ (40 / log 2) * log K := mul_le_mul_of_nonneg_left hdist (by positivity)
 
-
-/-- Let $A\subseteq \mathbb{Z}^d$ and $\lvert A-A\rvert\leq K\lvert A\rvert$. There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-22}\lvert A\rvert$ and $\dim A' \leq \frac{40}{\log 2} \log K$.-/
-theorem weak_PFR_int {A : Set G} [Finite A] (hA₀ : A.Nonempty) {K : ℝ} (hK: 0 < K)
+/-- Let $A\subseteq \mathbb{Z}^d$ and $\lvert A-A\rvert\leq K\lvert A\rvert$.
+There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-17}\lvert A\rvert$
+and $\dim A' \leq \frac{40}{\log 2} \log K$.-/
+theorem weak_PFR_int {A : Set G} [Finite A] [Nonempty A] {K : ℝ} (hK : 0 < K)
     (hA: Nat.card (A-A) ≤ K * Nat.card A) :
-    ∃ A' ⊆ A, Nat.card A' ≥ K^(-22 : ℝ) * Nat.card A ∧ dimension A' ≤ (40 / log 2) * log K := by
-  have := hA₀.to_subtype
-  apply weak_PFR hA₀ hK ((rdist_set_le A A hA₀ hA₀).trans _)
+    ∃ A' : Set G, A' ⊆ A ∧ Nat.card A' ≥ K ^ (-17 : ℝ) * (Nat.card A) ∧
+      dimension A' ≤ (40 / log 2) * log K := by
+  apply weak_PFR hK ((rdist_set_le A A).trans _)
   suffices log (Nat.card (A-A)) ≤ log K + log (Nat.card A) by linarith
-  rw [<-log_mul (by positivity) _]
+  rw [← log_mul (by positivity) _]
   . apply log_le_log _ hA
     norm_cast
     have : Nonempty (A-A) := by

--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -21,27 +21,27 @@ $$ (\sum_{b \in B} r(b))^2 \leq |B| \sum_{b \in B} r(b)^2.$$
 $$ C_1 = 2^4, C_2 = 1, C_3 = 2^{10}, C_4 = 4.$$
 \end{lemma}
 
-\begin{proof} See \url{https://leanprover.zulipchat.com/user_uploads/3121/D5wRxEww9_Qlmvj8QvdJO7FQ/SimpleBSG.pdf}
+\begin{proof} See \url{https://terrytao.files.wordpress.com/2024/01/simplebsg.pdf}
 \end{proof}
 
 \begin{theorem}[Approximate homomorphism form of PFR]\label{approx-hom-pfr}\lean{approx_hom_pfr}\leanok Let $G,G'$ be finite abelian $2$-groups.
   Let $f: G \to G'$ be a function, and suppose that there are at least $|G|^2 / K$ pairs $(x,y) \in G^2$ such that
 $$ f(x+y) = f(x) + f(y).$$
 Then there exists a homomorphism $\phi: G \to G'$ and a constant $c \in G'$
-such that $f(x) = \phi(x)+c$ for at least $|G| / C_1^{13} C_3^{12}
-K^{24C_4+26 C_2}$ values of $x \in G$.
+such that $f(x) = \phi(x)+c$ for at least $|G| / C_1 C_3^{12}
+K^{24C_4 + 2C_2}$ values of $x \in G$.
 \end{theorem}
 
-\begin{proof}\uses{goursat, cs-bound, bsg, pfr_aux-improv} Consider the graph $A \subset G \times G'$ defined by
+\begin{proof}\uses{goursat, cs-bound, bsg, pfr_aux-improv}\leanok Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have $a+a' \in A$ for at least
 $|A|^2/K$ pairs $(a,a') \in A^2$. By Lemma \ref{cs-bound}, this implies that
 $E(A) \geq |A|^3/K^2$.  Applying Lemma \ref{bsg}, we conclude that there
 exists a subset $A' \subset A$ with $|A'| \geq |A|/C_1 K^{2C_2}$ and $|A'+A'|
-\leq C_1C_3 K^{2(C_2+C_4)} |A'|$. Applying Lemma \ref{pfr_aux-improv}, we may
-find a subspace $H \subset G \times G'$ such that $|H| / |A'| \in [L^{-10},
-L^{10}$ and a subset $c$ of cardinality at most $L^6 |A'|^{1/2} / |H|^{1/2}$
-such that $A' \subseteq c + H$, where $L =  C_1C_3 K^{2(C_2+C_4)}$. If we let
+\leq L|A'|$, where $L = C_3 K^{2C_4}$. Applying Lemma \ref{pfr_aux-improv}, we may
+find a subspace $H \subset G \times G'$
+and a subset $c$ of cardinality at most $L^6 |A'|^{1/2} / |H|^{1/2}$
+such that $A' \subseteq c + H$. If we let
 $H_0,H_1$ be as in Lemma \ref{goursat}, this implies on taking projections
 the projection of $A'$ to $G$ is covered by at most $|c|$ translates of
 $H_0$.  This implies that
@@ -59,6 +59,6 @@ $$
 $$
 
 By the pigeonhole principle, one of these translates must then contain at
-least $|A'|/L^{12} \geq |G| / (C_1C_3 K^{2(C_2+C_4)})^{12} (C_1 K^{2C_2})$
+least $|A'|/L^{12} \geq |G| / (C_3 K^{2C_4})^{12} (C_1 K^{2C_2})$
 elements of $A'$ (and hence of $A$), and the claim follows.
 \end{proof}

--- a/blueprint/src/chapter/distance.tex
+++ b/blueprint/src/chapter/distance.tex
@@ -3,7 +3,7 @@
 In this section $G$ will be a finite additive group.  (May eventually want to generalize to infinite $G$.)
 
 \begin{lemma}[Negation preserves entropy]\label{neg-ent}
-  \lean{entropy_neg}\leanok
+  \lean{ProbabilityTheory.entropy_neg}\leanok
   If $X$ is $G$-valued, then $\bbH[-X]=\bbH[X]$.
 \end{lemma}
 
@@ -12,7 +12,7 @@ In this section $G$ will be a finite additive group.  (May eventually want to ge
 \end{proof}
 
 \begin{lemma}[Shearing preserves entropy]\label{shear-ent}
-  \lean{condEntropy_add_right, condEntropy_of_diff_eq,entropy_of_shear_eq,entropy_of_shear_eq'}\leanok
+  \lean{ProbabilityTheory.condEntropy_add_right, ProbabilityTheory.condEntropy_add_left, ProbabilityTheory.condEntropy_sub_right, ProbabilityTheory.condEntropy_sub_left}\leanok
   If $X,Y$ are $G$-valued, then $\bbH[X \pm Y | Y]=\bbH[X|Y]$ and $\bbH[X \pm Y, Y] = \bbH[X, Y]$.
 \end{lemma}
 
@@ -21,7 +21,7 @@ In this section $G$ will be a finite additive group.  (May eventually want to ge
 \end{proof}
 
 \begin{lemma}[Lower bound of sumset]\label{sumset-lower-gen}
-  \lean{max_entropy_sub_mutualInfo_le_entropy_add,max_entropy_sub_mutualInfo_le_entropy_sub}\leanok
+  \lean{ProbabilityTheory.max_entropy_sub_mutualInfo_le_entropy_add, ProbabilityTheory.max_entropy_sub_mutualInfo_le_entropy_sub}\leanok
   If $X,Y$ are $G$-valued random variables on $\Omega$, we have
 $$ \max(\bbH[X], \bbH[Y]) -  \bbI[X:Y] \leq \bbH[X \pm Y].$$
 \end{lemma}
@@ -36,7 +36,7 @@ and similarly with the roles of $X,Y$ reversed, giving the claim.
 
 \begin{corollary}[Conditional lower bound on sumset]\label{sumset-lower-gen-cond}
   \uses{conditional-mutual-def}
-  \lean{max_condEntropy_sub_condMutualInfo_le_condEntropy_mul, max_condEntropy_sub_condMutualInfo_le_condEntropy_div}\leanok
+  \lean{ProbabilityTheory.max_condEntropy_sub_condMutualInfo_le_condEntropy_mul, ProbabilityTheory.max_condEntropy_sub_condMutualInfo_le_condEntropy_div}\leanok
   If $X,Y$ are $G$-valued random variables on $\Omega$ and $Z$ is another random variable on $\Omega$ then
 \[
   \max(\bbH[X|Z], \bbH[Y|Z]) -  \bbI[X:Y|Z] \leq \bbH[X\pm Y|Z],
@@ -159,13 +159,19 @@ $$  \bbH[X-Y] - \bbH[X], \bbH[X-Y] - \bbH[Y] \leq 2d[X ;Y].$$
 
 
 \begin{lemma}[Projection entropy and distance]\label{dist-projection}\lean{ent_of_proj_le}\leanok
-If $G$ is an additive group and $X$ is a $G$-valued random variable and $H\leq G$ is a finite subgroup then, with $\pi:G\to G/H$ the natural homomorphism we have (if $U_H$ is the  uniform distribution on $H$, independent of $X$)
+If $G$ is an additive group and $X$ is a $G$-valued random variable and $H\leq G$ is a finite subgroup then, with $\pi:G\to G/H$ the natural homomorphism we have (where $U_H$ is uniform on $H$)
 \[\mathbb{H}(\pi(X))\leq 2d[X;U_H].\]
 \end{lemma}
 \begin{proof}
-\uses{ruzsa-diff}
-We have
-\[\mathbb{H}(X+U_H)=\mathbb{H}(\pi(X))+\mathbb{H}(U_H)\]
+\uses{independent-exist, ruzsa-diff, chain-rule, shear-ent, submodularity, jensen-bound}\leanok
+WLOG, we make $X$, $U_H$ independent (Lemma \ref{independent-exist}).
+Now by Lemmas \ref{submodularity}, \ref{shear-ent}, \ref{jensen-bound}
+\begin{align*}
+&\mathbb{H}(X-U_H|\pi(X)) \geq \mathbb{H}(X-U_H|X) &= \mathbb{H}(U_H) \\
+&\mathbb{H}(X-U_H|\pi(X)) \leq \log |H| &= \mathbb{H}(U_H)
+\end{align*}
+By Lemma \ref{chain-rule}
+\[\mathbb{H}(X-U_H)=\mathbb{H}(\pi(X))+\mathbb{H}(X-U_H|\pi(X))=\mathbb{H}(\pi(X))+\mathbb{H}(U_H)\]
 and therefore
 \[d[X;U_H]=\mathbb{H}(\pi(X))+\frac{\mathbb{H}(U_H)-\mathbb{H}(X)}{2}.\]
 Furthermore by Lemma \ref{ruzsa-diff}

--- a/blueprint/src/chapter/entropy.tex
+++ b/blueprint/src/chapter/entropy.tex
@@ -11,7 +11,7 @@ Random variables in this paper are measurable maps $X : \Omega \to S$ from a pro
   with the convention that $0 \log \frac{1}{0} = 0$.
 \end{definition}
 
-\begin{lemma}[Entropy and relabeling]\label{relabeled-entropy}\lean{ProbabilityTheory.entropy_comp_of_injective, entropy_of_comp_eq_of_comp} \uses{entropy-def}\leanok
+\begin{lemma}[Entropy and relabeling]\label{relabeled-entropy}\lean{ProbabilityTheory.entropy_comp_of_injective, ProbabilityTheory.entropy_of_comp_eq_of_comp} \uses{entropy-def}\leanok
   \begin{itemize}
 \item[(i)]   If $X: \Omega \to S$ and $Y: \Omega \to T$ are random variables, and $Y = f(X)$ for some injection $f: S \to T$, then $\bbH[X] = \bbH[Y]$.
 \item[(ii)]   If $X: \Omega \to S$ and $Y: \Omega \to T$ are random variables, and $Y = f(X)$ and $X = g(Y)$ for some functions $f: S \to T$, $g: T \to S$, then $\bbH[X] = \bbH[Y]$.
@@ -23,7 +23,7 @@ Random variables in this paper are measurable maps $X : \Omega \to S$ from a pro
 
 \begin{lemma}[Jensen bound]\label{jensen-bound}
   \uses{entropy-def}
-  \lean{ProbabilityTheory.entropy_le_log_card}
+  \lean{ProbabilityTheory.entropy_le_log_card, ProbabilityTheory.entropy_le_log_card_of_mem}
   \leanok
   If $X$ is an $S$-valued random variable, then $\bbH[X] \leq \log |S|$.
 \end{lemma}
@@ -210,7 +210,7 @@ $$ \bbH[X, Y | Z] = \bbH[Y | Z] + \bbH[X|Y, Z].$$
 \end{proof}
 
 \begin{corollary}[Submodularity]\label{submodularity}
-  \lean{ProbabilityTheory.entropy_submodular}\leanok
+  \lean{ProbabilityTheory.entropy_submodular, ProbabilityTheory.condEntropy_comp_ge}\leanok
   With three random variables $X,Y,Z$, one has $\bbH[X|Y,Z] \leq \bbH[X|Z]$.
 \end{corollary}
 

--- a/blueprint/src/chapter/entropy_pfr.tex
+++ b/blueprint/src/chapter/entropy_pfr.tex
@@ -425,7 +425,7 @@ Moreover, from Definition \ref{eta-def} we have $8 \eta + \eta^2 < 1$. It follow
   Furthermore, both $d[X^0_1;U_H]$ and $d[X^0_2;U_H]$ are at most $6 d[X^0_1;X^0_2]$.
 \end{theorem}
 
-\begin{proof} \uses{de-prop, tau-min, lem:100pc, ruzsa-triangle} \leanok  Let $X_1, X_2$ be the $\tau$-minimizer from Lemma \ref{tau-min}.  From Theorem \ref{de-prop}, $d[X_1;X_2]=0$.  From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau$-minimization we have $\tau[X_1;X_2] \leq \tau[X^0_1;X^0_2]$.  Using this and the Ruzsa triangle inequality we can conclude.
+\begin{proof} \uses{de-prop, tau-min, lem:100pc, ruzsa-triangle} \leanok  Let $X_1, X_2$ be the $\tau$-minimizer from Lemma \ref{tau-min}.  From Theorem \ref{de-prop}, $d[X_1;X_2]=0$.  From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau$-minimization we have $\tau[X_1;X_2] \leq \tau[X^0_2;X^0_1]$.  Using this and the Ruzsa triangle inequality we can conclude.
 \end{proof}
 
 Note: a ``stretch goal'' for this project would be to obtain a `decidable` analogue of this result (see the remark at the end of Section 2 for some related discussion).

--- a/blueprint/src/chapter/improved_exponent.tex
+++ b/blueprint/src/chapter/improved_exponent.tex
@@ -206,7 +206,7 @@ tau-minimizers for $1/8$ satisfying additionally $d[X_1;X_2] = 0$.
 
 \begin{proof} \uses{de-prop-lim-improv, lem:100pc, ruzsa-triangle}\leanok
 Let $X_1, X_2$ be the good $\tau$-minimizer from Theorem \ref{de-prop-lim-improv}. By construction, $d[X_1;X_2]=0$.
-From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau$-minimization we have $\tau[X_1;X_2] \leq \tau[X^0_1;X^0_2]$.  Using this and the Ruzsa triangle inequality we can conclude.
+From Corollary \ref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau$-minimization we have $\tau[X_1;X_2] \leq \tau[X^0_2;X^0_1]$.  Using this and the Ruzsa triangle inequality we can conclude.
 \end{proof}
 
 One can then replace Lemma~\ref{pfr_aux} with

--- a/blueprint/src/chapter/jensen.tex
+++ b/blueprint/src/chapter/jensen.tex
@@ -20,7 +20,7 @@ In this chapter, $h$ denotes the function $h(x) := x \log \frac{1}{x}$ for $x \i
 \end{proof}
 
 \begin{lemma}[Converse Jensen]\label{converse-jensen}
-  \lean{Real.sum_negMulLog_eq}\leanok
+  \lean{Real.sum_negMulLog_eq_iff}\leanok
 If equality holds in the above lemma, then $p_s = \sum_{s \in S} w_s h(p_s)$ whenever $w_s \neq 0$.
 \end{lemma}
 

--- a/blueprint/src/chapter/weak_pfr.tex
+++ b/blueprint/src/chapter/weak_pfr.tex
@@ -50,54 +50,93 @@ and $\phi(2Y)=2\phi(Y)\equiv 0$ so the left-hand side is equal to $d[\phi(X);0]=
 \end{proof}
 
 \begin{lemma}\label{app-ent-pfr}\lean{app_ent_PFR}\leanok
-Let $G=\mathbb{F}_2^n$ and $X,Y$ be $G$-valued random variables such that
-\[\mathbb{H}(X)+\mathbb{H}(Y)> 44d[X;Y].\]
+Let $G=\mathbb{F}_2^n$ and $\alpha\in (0,1)$ and let $X,Y$ be $G$-valued
+random variables such that
+\[\mathbb{H}(X)+\mathbb{H}(Y)> \frac{20}{\alpha} d[X;Y].\]
 There is a non-trivial subgroup $H\leq G$ such that
-\[\log \lvert H\rvert <\mathbb{H}(X)+\mathbb{H}(Y)\] and
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))< \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}\]
+\[\log \lvert H\rvert <\frac{1+\alpha}{2}(\mathbb{H}(X)+\mathbb{H}(Y))\] and
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))< \alpha (\mathbb{H}(X)+\mathbb{H}(Y))\]
 where $\psi:G\to G/H$ is the natural projection homomorphism.
 \end{lemma}
 \begin{proof}
-\uses{entropy-pfr-improv, ruzsa-diff, dist-projection, ruzsa-nonneg}
-By Theorem \ref{entropy-pfr-improv} there exists a subgroup $H$ such that $d[X;U_H]\leq \frac{11}{2} d[X;Y]$ and $d[Y;U_H]\leq \frac{11}{2} d[X;Y]$. Using Lemma \ref{dist-projection} we deduce that $\mathbb{H}(\psi(X))\leq 11 d[X;Y]$ and $\mathbb{H}(\psi(Y))\leq 11d[X;Y]$. The second claim follows adding these inequalities and using the assumption on $\mathbb{H}(X)+\mathbb{H}(Y)$.
+\uses{entropy-pfr-improv, ruzsa-diff, dist-projection, ruzsa-nonneg}\leanok
+By Theorem \ref{entropy-pfr-improv} there exists a subgroup $H$ such that
+$d[X;U_H] + d[Y;U_H] \leq 10 d[X;Y]$. Using Lemma \ref{dist-projection} we
+deduce that $\mathbb{H}(\psi(X)) + \mathbb{H}(\psi(X)) \leq 20 d[X;Y]$. The
+second claim follows adding these inequalities and using the assumption on
+$\mathbb{H}(X)+\mathbb{H}(Y)$.
 
 Furthermore we have by Lemma \ref{ruzsa-diff}
-\[\log \lvert H \rvert-\mathbb{H}(X)\leq 2d[X;U_H]\leq 11d[X;Y]\]
+\[\log \lvert H \rvert-\mathbb{H}(X)\leq 2d[X;U_H]\]
 and similarly for $Y$ and thus
-\[\log \lvert  H\rvert \leq \frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}+12d[X;Y]< \mathbb{H}(X)+\mathbb{H}(Y).\]
-Finally note that if $H$ were trivial then $\psi(X)=X$ and $\psi(Y)=Y$ and hence $\mathbb{H}(X)+\mathbb{H}(Y)=0$, which contradicts Lemma \ref{ruzsa-nonneg}.
+\begin{align*}
+\log \lvert  H\rvert
+&\leq
+\frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}+d[X;U_H] + d[Y;U_H] \leq
+\frac{\mathbb{H}(X)+\mathbb{H}(Y)}{2}+ 10d[X;Y]
+\\& <
+\frac{1+\alpha}{2}(\mathbb{H}(X)+\mathbb{H}(Y)).
+\end{align*}
+Finally note that if $H$
+were trivial then $\psi(X)=X$ and $\psi(Y)=Y$ and hence
+$\mathbb{H}(X)+\mathbb{H}(Y)=0$, which contradicts Lemma \ref{ruzsa-nonneg}.
 \end{proof}
 
 
-\begin{lemma}\label{pfr-projection}\lean{PFR_projection}\leanok
-If $G=\mathbb{F}_2^d$ and $X,Y$ are $G$-valued random variables then there is a subgroup $H\leq \mathbb{F}_2^d$ such that
-\[\log \lvert H\rvert \leq 2(\mathbb{H}(X)+\mathbb{H}(Y))\]
+\begin{lemma}\label{pfr-projection'}\lean{PFR_projection'}\leanok
+If $G=\mathbb{F}_2^d$ and $\alpha\in (0,1)$ and $X,Y$ are $G$-valued random
+variables then there is a subgroup $H\leq \mathbb{F}_2^d$ such that
+\[\log \lvert H\rvert \leq \frac{1+\alpha}{2(1-\alpha)} (\mathbb{H}(X)+\mathbb{H}(Y))\]
 and if $\psi:G \to G/H$ is the natural projection then
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 44 d[\psi(X);\psi(Y)].\]
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq \frac{20}{\alpha} d[\psi(X);\psi(Y)].\]
 \end{lemma}
 \begin{proof}
-\uses{app-ent-pfr}
+\uses{app-ent-pfr}\leanok
 Let $H\leq \mathbb{F}_2^d$ be a maximal subgroup such that
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))> 44d[\psi(X);\psi(Y)]\]
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))> \frac{20}{\alpha} d[\psi(X);\psi(Y)]\]
+and such that there exists $c \ge 0$ with
+\[\log \lvert H\rvert \leq \frac{1+\alpha}{2(1-\alpha)}(1-c)(\mathbb{H}(X)+\mathbb{H}(Y))\]
 and
-\[\log \lvert H\rvert \leq \left(2-2^{2-\lvert H\rvert}\right)(\mathbb{H}(X)+\mathbb{H}(Y))\]
-and
-\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 2^{1-\lvert H\rvert}(\mathbb{H}(X)+\mathbb{H}(Y)).\]
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq c (\mathbb{H}(X)+\mathbb{H}(Y)).\]
 Note that this exists since $H=\{0\}$ is an example of such a subgroup or we are done with this choice of $H$.
 
-We know that $G/H$ has the shape $\mathbb{F}_2^{d'}$ for some $d'$ [exactly how to see this/set up the hypotheses of Lemma \ref{app-ent-pfr} to make this an easy deduction I'll leave to those who know Lean better] and so by Lemma \ref{app-ent-pfr} there exists some non-trivial subgroup $H'\leq G/H$ such that
-\[\log \lvert H'\rvert < \mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\]
+We know that $G/H$ is a $2$-elementary group and so by Lemma
+\ref{app-ent-pfr} there exists some non-trivial subgroup $H'\leq G/H$ such
+that
+\[\log \lvert H'\rvert < \frac{1+\alpha}{2}(\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\]
 and
-\[2(\mathbb{H}(\psi'(X))+\mathbb{H}(\psi'(Y)))< \mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\]
-where $\psi':G/H\to (G/H)/H'$. By group isomorphism theorems we know that there exists some $H''$ with $H\leq H''\leq G$ such that $H'\cong H''/H$ and $\psi'(X)=\psi''(X)$ where $\psi'':G\to G/H''$ is the projection homomorphism.
+\[\mathbb{H}(\psi' \circ\psi(X))+\mathbb{H}(\psi' \circ \psi(Y))< \alpha(\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y)))\]
+where $\psi':G/H\to (G/H)/H'$. By group isomorphism theorems we know that
+there exists some $H''$ with $H\leq H''\leq G$ such that $H'\cong H''/H$ and
+$\psi' \circ \psi(X)=\psi''(X)$ where $\psi'':G\to G/H''$ is the projection
+homomorphism.
 
 Since $H'$ is non-trivial we know that $H$ is a proper subgroup of $H''$. On the other hand we know that
-\[\log \lvert H''\rvert=\log \lvert H'\rvert+\log \lvert H\rvert< (2-2^{1-\lvert H\rvert})(\mathbb{H}(X)+\mathbb{H}(Y)).\]
+\[\log \lvert H''\rvert=\log \lvert H'\rvert+\log \lvert H\rvert< \frac{1+\alpha}{2(1-\alpha)}(1-\alpha c)(\mathbb{H}(X)+\mathbb{H}(Y))\]
 and
-\[\mathbb{H}(\psi''(X))+\mathbb{H}(\psi''(Y))< \frac{\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))}{2}\leq 2^{1-\lvert H'\rvert}(\mathbb{H}(X)+\mathbb{H}(Y)).\]
+\[\mathbb{H}(\psi''(X))+\mathbb{H}(\psi''(Y))< \alpha (\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y)))\leq \alpha c (\mathbb{H}(X)+\mathbb{H}(Y)).\]
 Therefore (using the maximality of $H$) it must be the first condition that fails, whence
-\[\mathbb{H}(\psi''(X))+\mathbb{H}(\psi''(Y))\leq 48d[\psi''(X);\psi''(Y)].\]
+\[\mathbb{H}(\psi''(X))+\mathbb{H}(\psi''(Y))\leq \frac{20}{\alpha}d[\psi''(X);\psi''(Y)].\]
 \end{proof}
+
+We could use the previous lemma for any value of $\alpha \in (0,1)$, which
+would give a whole range of estimates in Theorem~\ref{weak-pfr-int}. For
+definiteness, we specialize only to $\alpha=3/5$, which gives a constant $2$
+in the first bound below.
+
+\begin{lemma}\label{pfr-projection}\lean{PFR_projection}\leanok
+If $G=\mathbb{F}_2^d$ and $\alpha\in (0,1)$ and $X,Y$ are $G$-valued random
+variables then there is a subgroup $H\leq \mathbb{F}_2^d$ such that
+\[\log \lvert H\rvert \leq 2 (\mathbb{H}(X)+\mathbb{H}(Y))\]
+and if $\psi:G \to G/H$ is the natural projection then
+\[\mathbb{H}(\psi(X))+\mathbb{H}(\psi(Y))\leq 34 d[\psi(X);\psi(Y)].\]
+\end{lemma}
+\begin{proof}
+\uses{pfr-projection'}\leanok
+Specialize Lemma~\ref{pfr-projection'} to $\alpha=3/5$. In the second
+inequality, it gives a bound $100/3 < 34$.
+\end{proof}
+
 
 
 \begin{lemma}\label{single-fibres}\lean{single_fibres}\leanok
@@ -105,7 +144,7 @@ Let $\phi:G\to H$ be a homomorphism and $A,B\subseteq G$ be finite subsets. If $
 \[d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq (\mathbb{H}(\phi(U_A))+\mathbb{H}(\phi(U_B)))(d(U_A,U_B)-d(U_{A_x},U_{B_y})).\]
 \end{lemma}
 \begin{proof}
-\uses{fibring-ident}
+\uses{fibring-ident}\leanok
 The random variables $(U_A\mid \phi(U_A)=x)$ and $(U_B\mid \phi(U_B)=y)$ are equal in distribution to $U_{A_x}$ and $U_{B_y}$ respectively (both are uniformly distributed over their respective fibres). It follows from Lemma \ref{fibring-ident} that
 \begin{align*}
 \sum_{x,y\in H}\frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}d[U_{A_x};U_{B_y}]
@@ -113,13 +152,13 @@ The random variables $(U_A\mid \phi(U_A)=x)$ and $(U_B\mid \phi(U_B)=y)$ are equ
 &\leq d[U_A;U_B]-d[\phi(U_A);\phi(U_B)].
 \end{align*}
 Therefore with $M:=\mathbb{H}(\phi(U_A))+\mathbb{H}(\phi(U_B))$ we have
-\[\sum_{x,y\in H}\frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}Md[U_{A_x};U_{B_y}]+Md[\phi(U_A);\phi(U_B)]\leq Md[U_A;U_B].\]
+\[\left(\sum_{x,y\in H}\frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}Md[U_{A_x};U_{B_y}]\right)+Md[\phi(U_A);\phi(U_B)]\leq Md[U_A;U_B].\]
 Since
 \[M=\sum_{x,y\in H}\frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\]
 we have
-\[\sum_{x,y\in H} \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\left(Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\right)\leq  Md[U_A;U_B].\]
+\[\sum_{x,y\in H} \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\left(Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\right)\leq  Md[U_A;U_B].\]
 It follows that there exists some $x,y\in H$ such that $\lvert A_x\rvert,\lvert B_y\rvert\neq 0$ and
-\[Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A\rvert\lvert B\rvert}\leq  Md[U_A;U_B].\]
+\[Md[U_{A_x};U_{B_y}]+d[\phi(U_A);\phi(U_B)]\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq  Md[U_A;U_B].\]
 \end{proof}
 
 
@@ -130,7 +169,7 @@ If $A\subseteq \mathbb{Z}^{d}$ then by $\dim(A)$ we mean the dimension of the sp
 
 \begin{theorem}\label{weak-pfr-asymm}\lean{weak_PFR_asymm}\leanok
 If $A,B\subseteq \mathbb{Z}^d$ are finite non-empty sets then there exist non-empty $A'\subseteq A$ and $B'\subseteq B$ such that
-\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_A;U_B]\]
+\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 34d[U_A;U_B]\]
 such that $\max(\dim A',\dim B')\leq \frac{40}{\log 2} d[U_A;U_B]$.
 \end{theorem}
 \begin{proof}
@@ -142,28 +181,28 @@ Let $\phi:\mathbb{Z}^d\to \mathbb{F}_2^d$ be the natural mod-2 homomorphism. By 
 We now apply Lemma \ref{pfr-projection}, obtaining some subgroup $H\leq \mathbb{F}_2^d$ such that
 \[\log \lvert H\rvert \leq 40d[U_A;U_B]\]
 and
-\[\mathbb{H}(\tilde{\phi}(U_A))+\mathbb{H}(\tilde{\phi}(U_B))\leq 44 d[\tilde{\phi}(U_A);\tilde{\phi}(U_B)]\]
+\[\mathbb{H}(\tilde{\phi}(U_A))+\mathbb{H}(\tilde{\phi}(U_B))\leq 34 d[\tilde{\phi}(U_A);\tilde{\phi}(U_B)]\]
 where $\tilde{\phi}:\mathbb{Z}^d\to \mathbb{F}_2^d/H$ is $\phi$ composed with the projection onto $\mathbb{F}_2^d/H$.
 
 
 By Lemma \ref{single-fibres} there exist $x,y\in \mathbb{F}_2^d/H$ such that, with $A_x=A\cap \tilde{\phi}^{-1}(x)$ and similarly for $B_y$,
-\[\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq 44(d[U_A;U_B]-d[U_{A_x};U_{B_y}]).\]
+\[\log \frac{\lvert A\rvert\lvert B\rvert}{\lvert A_x\rvert\lvert B_y\rvert}\leq 34(d[U_A;U_B]-d[U_{A_x};U_{B_y}]).\]
 Suppose first that $\lvert A_x\rvert+\lvert B_y\rvert=\lvert A\rvert+\lvert B\rvert$. This means that $\tilde{\phi}(A)=\{x\}$ and $\tilde{\phi}(B)=\{y\}$, and hence both $A$ and $B$ are in cosets of $\ker \tilde{\phi}$. Since by assumption $A,B$ are not in cosets of a proper subgroup of $\mathbb{Z}^d$ this means $\ker\tilde{\phi}=\mathbb{Z}^d$, and so (examining the definition of $\tilde{\phi}$) we must have $H=\mathbb{F}_2^d$. Then our bound on $\log\lvert H\rvert$ forces $d\leq \frac{40}{\log 2}d[U_A;U_B]$ and we are done with $A'=A$ and $B'=B$.
 
 Otherwise,
 \[\lvert A_x\rvert+\lvert B_y\rvert <\lvert A\rvert+\lvert B\rvert.\]
 By induction we can find some $A'\subseteq A_x$ and $B'\subseteq B_y$ such that $\dim A',\dim B'\leq \frac{40}{\log 2} d[U_{A_x};U_{B_y}]\leq \frac{40}{\log 2}d[U_A;U_B]$ and
 
-\[\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_{A_x};U_{B_y}].\]
+\[\log \frac{\lvert A_x\rvert\lvert B_y\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 34d[U_{A_x};U_{B_y}].\]
 Adding these inequalities implies
 
-\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 44d[U_A;U_B]\]
+\[\log\frac{\lvert A\rvert\lvert B\rvert}{\lvert A'\rvert\lvert B'\rvert}\leq 34d[U_A;U_B]\]
 as required.
 \end{proof}
 
 \begin{theorem}\label{weak-pfr-symm}\lean{weak_PFR_symm}\leanok
 If $A\subseteq \mathbb{Z}^d$ is a finite non-empty set with $d[U_A;U_A]\leq \log K$ then there exists a non-empty $A'\subseteq A$ such that
-\[\lvert A'\rvert\geq K^{-22}\lvert A\rvert\]
+\[\lvert A'\rvert\geq K^{-17}\lvert A\rvert\]
 and $\dim A'\leq \frac{40}{\log 2} \log K$.
 \end{theorem}
 \begin{proof}
@@ -172,7 +211,9 @@ Immediate from Theorem \ref{weak-pfr-asymm} and rearranging.
 \end{proof}
 
 \begin{theorem}\label{weak-pfr-int}\lean{weak_PFR_int}\leanok
-Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$. There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-22}\lvert A\rvert$ and $\dim A' \leq \frac{40}{\log 2}\log K$.
+Let $A\subseteq \mathbb{Z}^d$ and $\lvert A+A\rvert\leq K\lvert A\rvert$.
+There exists $A'\subseteq A$ such that $\lvert A'\rvert \geq K^{-17}\lvert
+A\rvert$ and $\dim A' \leq \frac{40}{\log 2}\log K$.
 \end{theorem}
 \begin{proof}\leanok
 \uses{weak-pfr-symm,dimension-def}

--- a/examples.lean
+++ b/examples.lean
@@ -30,9 +30,7 @@ example {A : Set G} {K : ℝ} (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K 
 
 /-- The homomorphism version of PFR. -/
 example (f : G → G') (S : Set G') (hS : ∀ x y : G, f (x + y) - f x - f y ∈ S) :
-    ∃ (φ : G →+ G') (T : Set G'), Nat.card T ≤ 4 * (Nat.card S)^22 ∧ ∀ x, f x - φ x ∈ T := by
-  convert homomorphism_pfr f S hS
-  norm_cast
+    ∃ (φ : G →+ G') (T : Set G'), Nat.card T ≤ (Nat.card S)^12 ∧ ∀ x, f x - φ x ∈ T := homomorphism_pfr f S hS
 
 -- Todo: replace the constants C₁, C₂, C₃, C₄ below with actual values
 
@@ -42,11 +40,18 @@ example (f : G → G') (K : ℝ) (hK: K > 0) (hf: Nat.card { x : G × G| f (x.1+
 
 open Classical TensorProduct Real
 
-/-- The dimension of a subset A of a Z-module G is the rank of the set {(1,a): a in A}. -/
-example {G : Type*} [AddCommGroup G] [Module ℤ G] (A : Set G) : dimension A = Set.finrank ℝ ((fun (n : G) => (1 : ℝ) ⊗ₜ n) '' A : Set (ℝ ⊗[ℤ] G)) := by rfl
+/-- The dimension of a subset A of a Z-module G is the minimal rank of a coset of G that covers A. -/
+example {G : Type*} [AddCommGroup G] (A : Set G) :  ∃ (S : Submodule ℤ G) (v : G), FiniteDimensional.finrank ℤ S = dimension A  ∧ ∀ a ∈ A, a - v ∈ S := Nat.find_spec (exists_coset_cover A)
+
+example {G : Type*} [AddCommGroup G] (A : Set G) (d:ℕ) (h: d < dimension A): ¬ ∃ (S : Submodule ℤ G) (v : G), FiniteDimensional.finrank ℤ S = d ∧ ∀ a ∈ A, a - v ∈ S := Nat.find_min (exists_coset_cover A) h
+
+
+#print axioms weak_PFR_int
+
+variable  {G : Type u} [AddCommGroup G] [Module.Free ℤ G] [Module.Finite ℤ G] [Countable G]  [MeasurableSpace G] [MeasurableSingletonClass G]
 
 /-- Weak PFR over the integers -/
-example (A : Set G) [Finite A]  [Nonempty A] (K : ℝ) (hK: 0 < K) (hA: Nat.card (A+A) ≤ K * Nat.card A) : ∃ A' : Set G, A' ⊆ A ∧ (Nat.card A') ≥ K^(-44 : ℝ) * (Nat.card A) ∧ (dimension A') ≤ 60 * log K := weak_PFR_int hK hA
+example (A : Set G) [Finite A]  [Nonempty A] (K : ℝ) (hK: 0 < K) (hA: Nat.card (A-A) ≤ K * Nat.card A) : ∃ A' : Set G, A' ⊆ A ∧ (Nat.card A') ≥ K^(-17 : ℝ) * (Nat.card A) ∧ (dimension A') ≤ (40/log 2) * log K := weak_PFR_int hK hA
 
 end PFR
 


### PR DESCRIPTION
The `Nonempty`/`Set.Nonempty` confusion was probably resolved suboptimally, but the PR builds. It targets the `bump` branch and not `master` because it built on previous work, so merging this will update #171.