### PR TITLE
Proof of `mutual_comp_le` & fix blueprint typo

### DIFF
--- a/PFR/MoreRuzsaDist.lean
+++ b/PFR/MoreRuzsaDist.lean
@@ -31,8 +31,14 @@ variable {Ω : Type uΩ} {S : Type uS} {T : Type uT} {U : Type uU} {V : Type uV}
 /--
 Let $X,Y$ be random variables. For any function $f, g$ on the range of $X$, we have $I[f(X) : Y] \leq I[X:Y]$.
 -/
-lemma mutual_comp_le (μ : Measure Ω) [IsProbabilityMeasure μ] (hX : Measurable X) (f : S → U) [FiniteRange X]:
-    I[f ∘ X : Y ; μ] ≤ I[X : Y ; μ] := by sorry
+lemma mutual_comp_le (μ : Measure Ω) [IsProbabilityMeasure μ] (hX : Measurable X)
+    (hY : Measurable Y) (f : S → U) (hf : Measurable f) [FiniteRange X] [FiniteRange Y] :
+    I[f ∘ X : Y ; μ] ≤ I[X : Y ; μ] := by
+  rw [mutualInfo_comm (Measurable.comp hf hX) hY, mutualInfo_comm hX hY,
+    mutualInfo_eq_entropy_sub_condEntropy hY (Measurable.comp hf hX),
+    mutualInfo_eq_entropy_sub_condEntropy hY hX]
+  gcongr
+  exact condEntropy_comp_ge μ hX hY f
 
 /--
  Let $X,Y$ be random variables. For any functions $f, g$ on the ranges of $X, Y$ respectively, we have $\bbI[f(X) : g(Y )] \leq \bbI[X : Y]$.

--- a/blueprint/src/chapter/torsion.tex
+++ b/blueprint/src/chapter/torsion.tex
@@ -15,7 +15,7 @@ thanks to Lemma \ref{relabeled-entropy} and Lemma \ref{chain-rule}, giving the c
 \end{lemma}
 
 \begin{proof}\uses{alternative-mutual, submodularity, relabeled-entropy}
-  By Lemma \ref{alternative-mutual} it suffices to show that $\bbH[Y|X] \geq \bbH[Y|f(X)]$. But this follows from Corollary \ref{submodularity} (and Lemma \ref{relabeled-entropy}).
+  By Lemma \ref{alternative-mutual} it suffices to show that $\bbH[Y|X] \leq \bbH[Y|f(X)]$. But this follows from Corollary \ref{submodularity} (and Lemma \ref{relabeled-entropy}).
 \end{proof}
 
 \begin{lemma}[Unconditional data processing inequality]\label{data-process-unc}\lean{ProbabilityTheory.mutual_comp_comp_le}\leanok Let $X,Y$ be random variables. For any functions $f, g$ on the ranges of $X, Y$ respectively, we have $\bbI[f(X) : g(Y )] \leq \bbI[X : Y]$.


### PR DESCRIPTION
- [x]  Prove `mutual_comp_le`
- [x] Fix typo (i.e. $\mathbb{H}[Y|X] \geq \mathbb{H}[Y|f(X)]$ into $\mathbb{H}[Y|X] \leq \mathbb{H}[Y|f(X)]$) in corresponding blueprint object

We had to add the following hypotheses:
- `Measurable Y`
- `Measurable f`
- `FiniteRange Y`

Co-authored-by: Lorenzo Luccioli <lorenzoluccioli@gmail.com>