### PR TITLE
Fix `hyperref` warning

### DIFF
--- a/blueprint/src/chapter/torsion.tex
+++ b/blueprint/src/chapter/torsion.tex
@@ -1,4 +1,4 @@
-\chapter{The $m$-torsion case}
+\chapter{The \texorpdfstring{$m$}{m}-torsion case}
 
 \subsection{Data processing inequality}
 


### PR DESCRIPTION
Fix `hyperref` warnings such as:

```console
Package hyperref Warning: Token not allowed in a PDF string (Unicode):
(hyperref)                removing `math shift' on input line 419.
```

This warning is generated by the `hyperref` package when it encounters a math symbol in a section heading or caption, which is not allowed in a PDF string. It automatically removes the math symbol, but it still generates a warning.

Using `\texorpdfstring{$X$}{X}` prevents the warning.