### PR TITLE
Fix macOS issue with latin modern math font

### DIFF
--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -16,11 +16,11 @@
 \usepackage{mathtools}
 \usepackage[warnings-off={mathtools-colon,mathtools-overbracket}]{unicode-math}
 \usepackage{fontspec}
-\setmathfont{Latin Modern Math}
+\setmathfont{latinmodern-math.otf}
 \setmathfont[range=\varnothing]{Asana-Math.otf}
 \setmathfont[range=\pitchfork]{Asana-Math.otf}
 \setmathfont[range=\intprod]{Asana-Math.otf}
-\setmathfont[range=\int]{Latin Modern Math}
+\setmathfont[range=\int]{latinmodern-math.otf}
 
 \usepackage[nameinlink, capitalize]{cleveref}
 


### PR DESCRIPTION
Trivial fix substituting with `\setmainfont{latinmodern-math.otf}`.

I expect this change to make it compatible to all operating systems and models (e.g. Mac Intel, Mac M1/2/3) so that more contributors could locally compile the PDF if they need.

For more details see [here](https://github.com/ImperialCollegeLondon/FLT/issues/37) and [here](https://github.com/ImperialCollegeLondon/FLT/pull/45). 