### PR TITLE
Use capitalised clever references

### DIFF
--- a/blueprint/src/chapter/entropy_pfr.tex
+++ b/blueprint/src/chapter/entropy_pfr.tex
@@ -232,7 +232,7 @@ $$ I_2 \leq 2 \eta k + \frac{2 \eta (2 \eta k - I_1)}{1 - \eta}.$$
   \begin{equation}\label{combined}
   \bbI[X_1+X_2 : X_1 + \tilde X_1 | X_1+X_2+\tilde X_1+\tilde X_2] \leq \eta ( d[X_1; X_1] + d[X_2; X_2] ).
   \end{equation}
-  Together with Lemma~\ref{second-estimate-aux}, this gives the conclusion.
+  Together with \Cref{second-estimate-aux}, this gives the conclusion.
 \end{proof}
 
 

--- a/blueprint/src/chapter/improved_exponent.tex
+++ b/blueprint/src/chapter/improved_exponent.tex
@@ -187,7 +187,7 @@ For $\eta = 1/8$, there exist tau-minimizers $X_1, X_2$ satisfying $d[X_1;X_2] =
 \end{theorem}
 \begin{proof}\uses{de-prop-improv, tau-min}\leanok
 For each $\eta<1/8$, consider minimizers $X_1^\eta$ and $X_2^\eta$ from \Cref{tau-min}.
-By Theorem~\ref{de-prop-improv},
+By \Cref{de-prop-improv},
 they satisfy $d[X_1^\eta; X_2^\eta]=0$. By compactness of the space of probability measures
 on $G$, one may extract a converging subsequence of the distributions of $X_1^\eta$ and $X_2^\eta$
 as $\eta \to 1/8$. By continuity of all the involved quantities, the limit is a pair of
@@ -209,7 +209,7 @@ Let $X_1, X_2$ be the good $\tau$-minimizer from \Cref{de-prop-lim-improv}. By c
 From \Cref{lem:100pc}, $d[X_1;U_H] = d[X_2; U_H] = 0$.  Also from $\tau$-minimization we have $\tau[X_1;X_2] \leq \tau[X^0_2;X^0_1]$.  Using this and the Ruzsa triangle inequality we can conclude.
 \end{proof}
 
-One can then replace Lemma~\ref{pfr_aux} with
+One can then replace \Cref{pfr_aux} with
 
 \begin{lemma}\label{pfr_aux-improv}\lean{PFR_conjecture_improv_aux}\leanok
 If $A \subset {\bf F}_2^n$ is non-empty and
@@ -220,7 +220,7 @@ $$
 \end{lemma}
 
 \begin{proof}\uses{entropy-pfr-improv, unif-exist, uniform-entropy-II, jensen-bound,ruz-dist-def,ruzsa-diff,bound-conc,ruz-cov}\leanok
-By repeating the proof of Lemma~\ref{pfr_aux} and using \Cref{entropy-pfr-improv} one can obtain the claim with $13/2$
+By repeating the proof of \Cref{pfr_aux} and using \Cref{entropy-pfr-improv} one can obtain the claim with $13/2$
 replaced with $6$ and $11$ replaced by $10$.
 \end{proof}
 

--- a/blueprint/src/chapter/pfr.tex
+++ b/blueprint/src/chapter/pfr.tex
@@ -54,7 +54,7 @@ If $A \subset {\bf F}_2^n$ is non-empty and $|A+A| \leq K|A|$, then $A$ can be c
 
 \begin{proof}
   \uses{pfr_aux}\leanok
-  Let $H$ be given by Lemma~\ref{pfr_aux}.
+  Let $H$ be given by \Cref{pfr_aux}.
   If $|H| \leq |A|$ then we are already done thanks to~\eqref{ah}.  If $|H| > |A|$ then we can cover $H$ by at most $2 |H|/|A|$ translates of a subspace $H'$ of $H$ with $|H'| \leq |A|$.  We can thus cover $A$ by at most
   \[2K^{13/2} \frac{|H|^{1/2}}{|A|^{1/2}}\]
   translates of $H'$, and the claim again follows from~\eqref{ah}.

--- a/blueprint/src/chapter/weak_pfr.tex
+++ b/blueprint/src/chapter/weak_pfr.tex
@@ -133,7 +133,7 @@ and if $\psi:G \to G/H$ is the natural projection then
 \end{lemma}
 \begin{proof}
 \uses{pfr-projection'}\leanok
-Specialize Lemma~\ref{pfr-projection'} to $\alpha=3/5$. In the second
+Specialize \Cref{pfr-projection'} to $\alpha=3/5$. In the second
 inequality, it gives a bound $100/3 < 34$.
 \end{proof}
 


### PR DESCRIPTION
Use capitalised clever references on some remaining `Lemma~\ref`.