### PR TITLE
Fix docstrings for docs website

### DIFF
--- a/PFR/FirstEstimate.lean
+++ b/PFR/FirstEstimate.lean
@@ -86,7 +86,7 @@ lemma condRuzsaDist_of_sums_ge :
         - p.η * (d[p.X₀₂ # X₂ | X₂ + X₁'] - d[p.X₀₂ # X₂]) :=
   condRuzsaDistance_ge_of_min _ h_min hX₁ hX₂ _ _ (by measurability) (by measurability)
 
-/-- $$d[X^0_1; X_1+\tilde X_2] - d[X^0_1; X_1] \leq \tfrac{1}{2} k + \tfrac{1}{4} \bbH[X_2] - \tfrac{1}{4} \bbH[X_1].$$ -/
+/--`d[X₀₁ # X₁ + X₂'] - d[X₀₁ # X₁] ≤ k/2 + H[X₂]/4 - H[X₁]/4`. -/
 lemma diff_rdist_le_1 : d[p.X₀₁ # X₁ + X₂'] - d[p.X₀₁ # X₁] ≤ k/2 + H[X₂]/4 - H[X₁]/4 := by
   have h : IndepFun X₁ X₂' := by simpa using h_indep.indepFun (show (0:Fin 4) ≠ 2 by decide)
   convert condRuzsaDist_diff_le' ℙ p.hmeas1 hX₁ hX₂' h using 4

--- a/PFR/ImprovedPFR.lean
+++ b/PFR/ImprovedPFR.lean
@@ -192,13 +192,11 @@ lemma gen_ineq_aux2 :
     linarith
   _ = _ := by ring
 
-/-- Let $Z_1, Z_2, Z_3, Z_4$ be independent $G$-valued random variables, and let $Y$ be another
-$G$-valued random variable.  Set $S := Z_1+Z_2+Z_3+Z_4$. Then
-$d[Y; Z_1+Z_2|Z_1 + Z_3, S] - d[Y; Z_1]$ is at most
-$$ \tfrac{1}{4} (d[Z_1;Z_2] + 2d[Z_1;Z_3] + d[Z_2;Z_4])$$
-$$+ \tfrac{1}{4}(d[Z_1|Z_1 + Z_3 ; Z_2|Z_2+Z_4] - d[Z_1|Z_1+Z_2 ; Z_3|Z_3+Z_4]])$$
-$$+ \tfrac{1}{8} (\bbH[Z_1+Z_2] - \bbH[Z_3+Z_4] + \bbH[Z_2] - \bbH[Z_3]$$
-$$ + \bbH[Z_2|Z_2+Z_4] - \bbH[Z_1|Z_1+Z_3]).$$
+/-- Let `Z₁, Z₂, Z₃, Z₄` be independent `G`-valued random variables, and let `Y` be another
+`G`-valued random variable.  Set `S := Z₁ + Z₂ + Z₃ + Z₄`. Then
+`(d[Z₁ # Z₂] + 2 * d[Z₁ # Z₃] + d[Z₂ # Z₄]) / 4`
+`+ (d[Z₁ | Z₁ + Z₃ # Z₂ | Z₂ + Z₄] - d[Z₁ | Z₁ + Z₂ # Z₃ | Z₃ + Z₄]) / 4`
+`+ (H[Z₁ + Z₂] - H[Z₃ + Z₄] + H[Z₂] - H[Z₃] + H[Z₂ | Z₂ + Z₄] - H[Z₁ | Z₁ + Z₃]) / 8`.
 -/
 lemma gen_ineq_00 : d[Y # Z₁ + Z₂ | ⟨Z₁ + Z₃, Sum⟩] - d[Y # Z₁] ≤
     (d[Z₁ # Z₂] + 2 * d[Z₁ # Z₃] + d[Z₂ # Z₄]) / 4

--- a/PFR/MoreRuzsaDist.lean
+++ b/PFR/MoreRuzsaDist.lean
@@ -41,8 +41,8 @@ lemma mutual_comp_le (μ : Measure Ω) [IsProbabilityMeasure μ] (hX : Measurabl
   exact condEntropy_comp_ge μ hX hY f
 
 /--
- Let $X,Y$ be random variables. For any functions $f, g$ on the ranges of $X, Y$ respectively, we
- have $\bbI[f(X) : g(Y)] \leq \bbI[X : Y]$.
+Let `X, Y` be random variables. For any functions `f, g` on the ranges of `X, Y` respectively,
+we have `I[f ∘ X : g ∘ Y ; μ] ≤ I[X : Y ; μ]`.
  -/
 lemma mutual_comp_comp_le (μ : Measure Ω) [IsProbabilityMeasure μ] (hX : Measurable X)
     (hY : Measurable Y) (f : S → U) (g : T → V) (hg : Measurable g)
@@ -55,8 +55,8 @@ lemma mutual_comp_comp_le (μ : Measure Ω) [IsProbabilityMeasure μ] (hX : Meas
     _ = I[X : Y ; μ] := mutualInfo_comm hY hX μ
 
 /--
-Let $X,Y,Z$. For any functions $f, g$
-on the ranges of $X, Y$ respectively, we have $\bbI[f(X) : g(Y )|Z] \leq \bbI[X :Y |Z]$.
+Let `X, Y, Z`. For any functions `f, g` on the ranges of `X, Y` respectively,
+we have `I[f ∘ X : g ∘ Y | Z ; μ] ≤ I[X : Y | Z ; μ]`.
 -/
 lemma condMutual_comp_comp_le (μ : Measure Ω) [IsProbabilityMeasure μ] (hX : Measurable X) (hY : Measurable Y) (hZ : Measurable Z)
   (f : S → V) (g : T → W) [FiniteRange X] [FiniteRange Y]:


### PR DESCRIPTION
We have fixed docstrings so that they're displayed correctly in the documentation website.