### PR TITLE
Generalise `condIndep_copies`

### DIFF
--- a/PFR/Mathlib/Probability/ConditionalProbability.lean
+++ b/PFR/Mathlib/Probability/ConditionalProbability.lean
@@ -1,5 +1,33 @@
+import Mathlib.Probability.ConditionalProbability
+import PFR.ForMathlib.FiniteRange
+
 /-!
 ## TODO
-
 Less explicit arguments to `cond_eq_zero_of_meas_eq_zero`
 -/
+
+namespace ProbabilityTheory
+open MeasureTheory Set
+open scoped BigOperators
+
+variable {Ω α : Type*} {m : MeasurableSpace Ω} (μ : Measure Ω)
+ [MeasurableSpace α] [MeasurableSingletonClass α]
+
+/-- The **law of total probability** for a random variable taking finitely many values: a measure
+`μ` can be expressed as a linear combination of its conditional measures `μ[|X ← x]` on fibers of a
+random variable `X` valued in a fintype. -/
+lemma sum_meas_smul_cond_fiber' {X : Ω → α} (hX : Measurable X) [finX : FiniteRange X]
+    (μ : Measure Ω) [IsFiniteMeasure μ] :
+    ∑ x ∈ finX.toFinset, μ (X ⁻¹' {x}) • μ[|X ← x] = μ := by
+  ext E hE
+  calc
+    _ = ∑ x ∈ finX.toFinset, μ (X ⁻¹' {x} ∩ E) := by
+      simp only [Measure.coe_finset_sum, Measure.coe_smul, Finset.sum_apply,
+        Pi.smul_apply, smul_eq_mul]
+      simp_rw [mul_comm (μ _), cond_mul_eq_inter _ (hX (.singleton _))]
+    _ = _ := by
+      have : ⋃ x ∈ finX.toFinset, X ⁻¹' {x} ∩ E = E := by ext _; simp
+      rw [← measure_biUnion_finset _ fun _ _ ↦ (hX (.singleton _)).inter hE, this]
+      aesop (add simp [PairwiseDisjoint, Set.Pairwise, Function.onFun, disjoint_left])
+
+end ProbabilityTheory

--- a/PFR/Mathlib/Probability/ConditionalProbability.lean
+++ b/PFR/Mathlib/Probability/ConditionalProbability.lean
@@ -10,6 +10,8 @@ namespace ProbabilityTheory
 open MeasureTheory Set
 open scoped BigOperators
 
+/- [TODO]: `sum_meas_smul_cond_fiber'` should substitute `sum_meas_smul_cond_fiber` in Mathlib once
+the definition of `FiniteRange` is in Mathlib.-/
 variable {Ω α : Type*} {m : MeasurableSpace Ω} (μ : Measure Ω)
  [MeasurableSpace α] [MeasurableSingletonClass α]
 

--- a/PFR/Mathlib/Probability/IdentDistrib.lean
+++ b/PFR/Mathlib/Probability/IdentDistrib.lean
@@ -149,10 +149,10 @@ lemma identDistrib_ulift_self {X : Ω → α} (hX : Measurable X) :
 
 /-- To show identical distribution of two random variables on a mixture of probability measures, it suffices to do so on each non-trivial component. -/
 -- in fact this is an if and only if
-lemma identDistrib_of_sum {X : Ω → α} {Y : Ω' → α} [Fintype T] {μ : T → Measure Ω}
-    {μ' : T → Measure Ω'} {w : T → ENNReal} (hX : Measurable X) (hY : Measurable Y)
+lemma identDistrib_of_sum {X : Ω → α} {Y : Ω' → α} {μ : T → Measure Ω}
+    {μ' : T → Measure Ω'} {w : T → ENNReal} (s : Finset T) (hX : Measurable X) (hY : Measurable Y)
     (h_ident : ∀ y, w y ≠ 0 → IdentDistrib X Y (μ y) (μ' y)) :
-    IdentDistrib X Y (∑ y : T, (w y) • (μ y)) (∑ y : T, (w y) • (μ' y)) where
+    IdentDistrib X Y (∑ y ∈ s, (w y) • (μ y)) (∑ y ∈ s, (w y) • (μ' y)) where
   aemeasurable_fst := hX.aemeasurable
   aemeasurable_snd := hY.aemeasurable
   map_eq := by

--- a/PFR/Mathlib/Probability/Independence/Conditional.lean
+++ b/PFR/Mathlib/Probability/Independence/Conditional.lean
@@ -207,8 +207,8 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
       have h3 : (m y) ((Prod.snd⁻¹' {y}) ∩ E) = (m y) E := by
         apply measure_congr
         apply inter_ae_eq_right_of_ae_eq_univ
-        rw [(show (Prod.snd⁻¹' {y})ᶜ = Prod.snd⁻¹' ({y}ᶜ) by rfl), ← map_apply measurable_snd (by simp)]
         simp only [ae_eq_univ]
+        rw [(show (Prod.snd⁻¹' {y})ᶜ = Prod.snd⁻¹' ({y}ᶜ) by rfl), ← map_apply measurable_snd (by simp)]
         simp [m]
       have h3' {x : β} (hx : x ≠ y) : (m x) ((Prod.snd⁻¹' {y}) ∩ E) = 0 := by
         apply measure_inter_null_of_null_left E

--- a/PFR/Mathlib/Probability/Independence/Conditional.lean
+++ b/PFR/Mathlib/Probability/Independence/Conditional.lean
@@ -177,7 +177,8 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
     congr 1
     have : IsProbabilityMeasure (m' y) := h5 hy
     simp
-  . rw [condIndepFun_iff, ae_iff_of_countable]
+  .
+    -- rw [condIndepFun_iff, ae_iff_of_countable]
     have h1 : ν.map Prod.snd = μ.map Y := by
       rw [← sum_meas_smul_cond_fiber hY μ, ← Measure.mapₗ_apply_of_measurable measurable_snd, ← Measure.mapₗ_apply_of_measurable hY]
       simp only [_root_.map_sum, LinearMapClass.map_smul, ν]

--- a/PFR/Mathlib/Probability/Independence/Conditional.lean
+++ b/PFR/Mathlib/Probability/Independence/Conditional.lean
@@ -137,19 +137,16 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
   let m' := fun (y : β) ↦ ((μ[|Y ← y]).map X)
   let m := fun (y : β) ↦ ((m' y).prod (m' y)).prod (Measure.dirac y)
   let ν : Measure ((α × α) × β) := ∑ y ∈ finY.toFinset, ((μ (Y ⁻¹' {y})) • (m y))
-
   have h3' (y : β) : { ω : Ω | Y ω = y } ∈ ae (μ[|Y ← y]) := by
     rw [mem_ae_iff, ← cond_inter_self]
     . have : (Y ⁻¹' {y}) ∩ { ω : Ω | Y ω = y }ᶜ = ∅ := by
         ext _; simp
       simp [this]
     exact hY $ measurableSet_singleton y
-
   have h3 (y : β) : IdentDistrib (fun ω ↦ (X ω, y)) (⟨X, Y⟩) (μ[|Y ← y]) (μ[|Y ← y]) := by
     apply IdentDistrib.of_ae_eq (hX.prod_mk measurable_const).aemeasurable
     apply Filter.eventuallyEq_of_mem (h3' y)
     intro ω; simp only [mem_setOf_eq, Prod.mk.injEq, true_and]; exact fun a ↦ id a.symm
-
   have h4 (y : β) : { ω : (α × α) × β| ω.2 = y } ∈ ae (m y) := by
     rw [mem_ae_iff]
     have : { ω : (α × α) × β | ω.2 = y}ᶜ = Prod.snd⁻¹' {y}ᶜ := by
@@ -157,7 +154,6 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
       rfl
     rw [this, ← Measure.map_apply measurable_snd (MeasurableSet.singleton y).compl]
     simp [m]
-
   have h5 {y : β} (hy : μ (Y ⁻¹' {y}) ≠ 0) : IsProbabilityMeasure (m' y) := by
     have : IsProbabilityMeasure (μ[|Y ← y]) := cond_isProbabilityMeasure μ hy
     exact isProbabilityMeasure_map hX.aemeasurable
@@ -177,7 +173,6 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
     apply Measure.map_congr
     apply Filter.eventuallyEq_of_mem (h3' y)
     intro ω; simp; exact fun a ↦ id a.symm
-
   refine ⟨(α × α) × β, by infer_instance, fun ω ↦ ω.1.1, fun ω ↦ ω.1.2, fun ω ↦ ω.2, ν, ?_,
     measurable_fst.comp measurable_fst, measurable_snd.comp measurable_fst,
     measurable_snd, ?_, ?_, ?_⟩
@@ -196,10 +191,7 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
     congr 1
     have : IsProbabilityMeasure (m' y) := h5 hy
     simp
-  .
-
-    rw [condIndepFun_iff, ae_iff_of_countable]
-    -- apply Filter.eventually_of_forall
+  · rw [condIndepFun_iff, ae_iff_of_countable]
     intro y hy
     have hy' : ν (Prod.snd⁻¹' {y}) = μ (Y ⁻¹' {y}) := by
       rw [← map_apply measurable_snd (by simp), ← map_apply hY $ measurableSet_singleton y, h1]
@@ -207,7 +199,6 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
     have hy'' : μ (Y ⁻¹' {y}) ≠ 0 := by
       convert hy
       exact (map_apply hY $ measurableSet_discrete _).symm
-
     have h2 : ν[| Prod.snd⁻¹' {y}] = m y := by
       rw [Measure.ext_iff]
       intro E _
@@ -230,7 +221,6 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
         rw [h3' hx]
         simp
       · convert FiniteRange.range Y ▸ Set.preimage_singleton_nonempty.mp (nonempty_of_measure_ne_zero hy'')
-
     rw [h2, indepFun_iff_map_prod_eq_prod_map_map]
     . let f : (α × α) × β → α × α := Prod.fst
       show ((m y).map f) = ((m y).map (Prod.fst ∘ f)).prod ((m y).map (Prod.snd ∘ f))
@@ -240,41 +230,38 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
       simp
     . exact (measurable_fst.comp measurable_fst).aemeasurable
     exact (measurable_snd.comp measurable_fst).aemeasurable
-  . sorry
-    -- rw [← sum_meas_smul_cond_fiber' hY μ]
-    -- refine identDistrib_of_sum ?_ ?_ ?_
-    -- -- ((measurable_fst.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY)
-    -- intro y hy
-    -- have h1 : IdentDistrib (fun ω ↦ (ω.1.1, ω.2)) (fun ω ↦ (ω.1.1, y)) (m y) (m y) := by
-    --   apply IdentDistrib.of_ae_eq ((measurable_fst.comp measurable_fst).prod_mk measurable_snd).aemeasurable
-    --   apply Filter.eventuallyEq_of_mem (h4 y)
-    --   intro _; simp
-    -- have h2 : IdentDistrib (fun ω ↦ (ω.1.1, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
-    --   let f := fun (x : α) ↦ (x, y)
-    --   show IdentDistrib (f ∘ (Prod.fst ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
-    --   apply IdentDistrib.comp _ measurable_prod_mk_right
-    --   apply (identDistrib_comp_fst measurable_fst _ _).trans
-    --   have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
-    --   apply (identDistrib_comp_fst measurable_id _ _).trans
-    --   apply identDistrib_map hX measurable_id
-    -- exact (h1.trans h2).trans (h3 y)
+  . rw [← sum_meas_smul_cond_fiber' hY μ]
+    refine identDistrib_of_sum _ ((measurable_fst.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY) ?_
+    intro y hy
+    have h1 : IdentDistrib (fun ω ↦ (ω.1.1, ω.2)) (fun ω ↦ (ω.1.1, y)) (m y) (m y) := by
+      apply IdentDistrib.of_ae_eq ((measurable_fst.comp measurable_fst).prod_mk measurable_snd).aemeasurable
+      apply Filter.eventuallyEq_of_mem (h4 y)
+      intro _; simp
+    have h2 : IdentDistrib (fun ω ↦ (ω.1.1, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
+      let f := fun (x : α) ↦ (x, y)
+      show IdentDistrib (f ∘ (Prod.fst ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
+      apply IdentDistrib.comp _ measurable_prod_mk_right
+      apply (identDistrib_comp_fst measurable_fst _ _).trans
+      have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
+      apply (identDistrib_comp_fst measurable_id _ _).trans
+      apply identDistrib_map hX measurable_id
+    exact (h1.trans h2).trans (h3 y)
   rw [← sum_meas_smul_cond_fiber' hY μ]
-  -- apply identDistrib_of_sum ((measurable_snd.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY)
-  -- intro y hy
-  -- have h1 : IdentDistrib (fun ω ↦ (ω.1.2, ω.2)) (fun ω ↦ (ω.1.2, y)) (m y) (m y) := by
-  --   apply IdentDistrib.of_ae_eq ((measurable_snd.comp measurable_fst).prod_mk measurable_snd).aemeasurable
-  --   apply Filter.eventuallyEq_of_mem (h4 y)
-  --   intro _; simp
-  -- have h2 : IdentDistrib (fun ω ↦ (ω.1.2, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
-  --   let f := fun (x : α) ↦ (x, y)
-  --   show IdentDistrib (f ∘ (Prod.snd ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
-  --   apply IdentDistrib.comp _ measurable_prod_mk_right
-  --   apply (identDistrib_comp_fst measurable_snd _ _).trans
-  --   have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
-  --   apply (identDistrib_comp_snd measurable_id _ _).trans
-  --   apply identDistrib_map hX measurable_id
-  -- exact (h1.trans h2).trans (h3 y)
-  sorry
+  apply identDistrib_of_sum _ ((measurable_snd.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY)
+  intro y hy
+  have h1 : IdentDistrib (fun ω ↦ (ω.1.2, ω.2)) (fun ω ↦ (ω.1.2, y)) (m y) (m y) := by
+    apply IdentDistrib.of_ae_eq ((measurable_snd.comp measurable_fst).prod_mk measurable_snd).aemeasurable
+    apply Filter.eventuallyEq_of_mem (h4 y)
+    intro _; simp
+  have h2 : IdentDistrib (fun ω ↦ (ω.1.2, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
+    let f := fun (x : α) ↦ (x, y)
+    show IdentDistrib (f ∘ (Prod.snd ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
+    apply IdentDistrib.comp _ measurable_prod_mk_right
+    apply (identDistrib_comp_fst measurable_snd _ _).trans
+    have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
+    apply (identDistrib_comp_snd measurable_id _ _).trans
+    apply identDistrib_map hX measurable_id
+  exact (h1.trans h2).trans (h3 y)
 
 /-- For `X, Y` random variables, there exist conditionally independent trials `X₁, X₂, Y'`. -/
 lemma condIndep_copies' (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY : Measurable Y)

--- a/PFR/Mathlib/Probability/Independence/Conditional.lean
+++ b/PFR/Mathlib/Probability/Independence/Conditional.lean
@@ -240,39 +240,41 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
       simp
     . exact (measurable_fst.comp measurable_fst).aemeasurable
     exact (measurable_snd.comp measurable_fst).aemeasurable
-  . rw [← sum_meas_smul_cond_fiber' hY μ]
-    refine identDistrib_of_sum ?_ ?_ ?_
-    -- ((measurable_fst.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY)
-    intro y hy
-    have h1 : IdentDistrib (fun ω ↦ (ω.1.1, ω.2)) (fun ω ↦ (ω.1.1, y)) (m y) (m y) := by
-      apply IdentDistrib.of_ae_eq ((measurable_fst.comp measurable_fst).prod_mk measurable_snd).aemeasurable
-      apply Filter.eventuallyEq_of_mem (h4 y)
-      intro _; simp
-    have h2 : IdentDistrib (fun ω ↦ (ω.1.1, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
-      let f := fun (x : α) ↦ (x, y)
-      show IdentDistrib (f ∘ (Prod.fst ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
-      apply IdentDistrib.comp _ measurable_prod_mk_right
-      apply (identDistrib_comp_fst measurable_fst _ _).trans
-      have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
-      apply (identDistrib_comp_fst measurable_id _ _).trans
-      apply identDistrib_map hX measurable_id
-    exact (h1.trans h2).trans (h3 y)
+  . sorry
+    -- rw [← sum_meas_smul_cond_fiber' hY μ]
+    -- refine identDistrib_of_sum ?_ ?_ ?_
+    -- -- ((measurable_fst.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY)
+    -- intro y hy
+    -- have h1 : IdentDistrib (fun ω ↦ (ω.1.1, ω.2)) (fun ω ↦ (ω.1.1, y)) (m y) (m y) := by
+    --   apply IdentDistrib.of_ae_eq ((measurable_fst.comp measurable_fst).prod_mk measurable_snd).aemeasurable
+    --   apply Filter.eventuallyEq_of_mem (h4 y)
+    --   intro _; simp
+    -- have h2 : IdentDistrib (fun ω ↦ (ω.1.1, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
+    --   let f := fun (x : α) ↦ (x, y)
+    --   show IdentDistrib (f ∘ (Prod.fst ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
+    --   apply IdentDistrib.comp _ measurable_prod_mk_right
+    --   apply (identDistrib_comp_fst measurable_fst _ _).trans
+    --   have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
+    --   apply (identDistrib_comp_fst measurable_id _ _).trans
+    --   apply identDistrib_map hX measurable_id
+    -- exact (h1.trans h2).trans (h3 y)
   rw [← sum_meas_smul_cond_fiber' hY μ]
-  apply identDistrib_of_sum ((measurable_snd.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY)
-  intro y hy
-  have h1 : IdentDistrib (fun ω ↦ (ω.1.2, ω.2)) (fun ω ↦ (ω.1.2, y)) (m y) (m y) := by
-    apply IdentDistrib.of_ae_eq ((measurable_snd.comp measurable_fst).prod_mk measurable_snd).aemeasurable
-    apply Filter.eventuallyEq_of_mem (h4 y)
-    intro _; simp
-  have h2 : IdentDistrib (fun ω ↦ (ω.1.2, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
-    let f := fun (x : α) ↦ (x, y)
-    show IdentDistrib (f ∘ (Prod.snd ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
-    apply IdentDistrib.comp _ measurable_prod_mk_right
-    apply (identDistrib_comp_fst measurable_snd _ _).trans
-    have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
-    apply (identDistrib_comp_snd measurable_id _ _).trans
-    apply identDistrib_map hX measurable_id
-  exact (h1.trans h2).trans (h3 y)
+  -- apply identDistrib_of_sum ((measurable_snd.comp measurable_fst).prod_mk measurable_snd) (hX.prod_mk hY)
+  -- intro y hy
+  -- have h1 : IdentDistrib (fun ω ↦ (ω.1.2, ω.2)) (fun ω ↦ (ω.1.2, y)) (m y) (m y) := by
+  --   apply IdentDistrib.of_ae_eq ((measurable_snd.comp measurable_fst).prod_mk measurable_snd).aemeasurable
+  --   apply Filter.eventuallyEq_of_mem (h4 y)
+  --   intro _; simp
+  -- have h2 : IdentDistrib (fun ω ↦ (ω.1.2, y)) (fun ω ↦ (X ω, y)) (m y) (μ[|Y ← y]) := by
+  --   let f := fun (x : α) ↦ (x, y)
+  --   show IdentDistrib (f ∘ (Prod.snd ∘ Prod.fst)) (f ∘ X) (m y) (μ[|Y ← y])
+  --   apply IdentDistrib.comp _ measurable_prod_mk_right
+  --   apply (identDistrib_comp_fst measurable_snd _ _).trans
+  --   have : IsProbabilityMeasure ((μ[|Y ← y]).map X) := h5 hy
+  --   apply (identDistrib_comp_snd measurable_id _ _).trans
+  --   apply identDistrib_map hX measurable_id
+  -- exact (h1.trans h2).trans (h3 y)
+  sorry
 
 /-- For `X, Y` random variables, there exist conditionally independent trials `X₁, X₂, Y'`. -/
 lemma condIndep_copies' (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY : Measurable Y)

--- a/PFR/Mathlib/Probability/Independence/Conditional.lean
+++ b/PFR/Mathlib/Probability/Independence/Conditional.lean
@@ -159,14 +159,17 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
     have : IsProbabilityMeasure (μ[|Y ← y]) := cond_isProbabilityMeasure μ hy
     exact isProbabilityMeasure_map hX.aemeasurable
 
-  refine ⟨(α × α) × β, by infer_instance, fun ω ↦ ω.1.1, fun ω ↦ ω.1.2, fun ω ↦ ω.2, ν, ?_, measurable_fst.comp measurable_fst, measurable_snd.comp measurable_fst, measurable_snd, ?_, ?_, ?_⟩
+  refine ⟨(α × α) × β, by infer_instance, fun ω ↦ ω.1.1, fun ω ↦ ω.1.2, fun ω ↦ ω.2, ν, ?_,
+    measurable_fst.comp measurable_fst, measurable_snd.comp measurable_fst,
+    measurable_snd, ?_, ?_, ?_⟩
   . constructor
     simp only [coe_finset_sum, smul_toOuterMeasure, OuterMeasure.coe_smul, Finset.sum_apply,
       Pi.smul_apply, smul_eq_mul, ν]
     have : ∑ y ∈ finY.toFinset, μ (Y ⁻¹' {y}) * 1 = 1 := by
       simp only [mul_one]
-      rw [sum_measure_preimage_singleton] <;>
-        simp [hY $ measurableSet_discrete _, measure_ne_top]
+      rw [sum_measure_preimage_singleton]
+      · rw [← FiniteRange.range Y, preimage_range, measure_univ]
+      · exact fun y _ ↦ hY <| measurableSet_singleton y
     rw [← this]
     congr with y
     rcases eq_or_ne (μ (Y ⁻¹' {y})) 0 with hy | hy
@@ -174,7 +177,7 @@ lemma condIndep_copies (X : Ω → α) (Y : Ω → β) (hX : Measurable X) (hY :
     congr 1
     have : IsProbabilityMeasure (m' y) := h5 hy
     simp
-  . rw [condIndepFun_iff, ae_iff_of_countable ]
+  . rw [condIndepFun_iff, ae_iff_of_countable]
     have h1 : ν.map Prod.snd = μ.map Y := by
       rw [← sum_meas_smul_cond_fiber hY μ, ← Measure.mapₗ_apply_of_measurable measurable_snd, ← Measure.mapₗ_apply_of_measurable hY]
       simp only [_root_.map_sum, LinearMapClass.map_smul, ν]


### PR DESCRIPTION
- [x] Add `sum_meas_smul_cond_fiber'` generalising `sum_meas_smul_cond_fiber` relaxing the hypothesis `[DiscreteMeasurableSpace]` to `[MeasurableSingletonClass α]`. `sum_meas_smul_cond_fiber` should be changed in Mathlib
- [x] Generalise `identDistrib_of_sum` 
- [x] Generalise `condIndep_copies` relaxing the hypothesis `[Fintype β]` to `[FiniteRange Y]`. 
- [x] Golf proof of `condIndep_copies ` 