### PR TITLE
Start on the rho functional

### DIFF
--- a/PFR.lean
+++ b/PFR.lean
@@ -33,6 +33,7 @@ import PFR.Kullback
 import PFR.Main
 import PFR.Mathlib.Algebra.AddTorsor
 import PFR.Mathlib.Algebra.Module.ZMod
+import PFR.Mathlib.Analysis.SpecialFunctions.Log.Basic
 import PFR.Mathlib.Analysis.SpecialFunctions.NegMulLog
 import PFR.Mathlib.Data.Set.Pointwise.SMul
 import PFR.Mathlib.GroupTheory.PGroup
@@ -53,6 +54,7 @@ import PFR.Mathlib.Probability.Independence.FourVariables
 import PFR.Mathlib.Probability.Independence.Kernel
 import PFR.Mathlib.Probability.Kernel.Composition
 import PFR.Mathlib.Probability.Kernel.Disintegration
+import PFR.Mathlib.Probability.UniformOn
 import PFR.Mathlib.SetTheory.Cardinal.Finite
 import PFR.MoreRuzsaDist
 import PFR.MultiTauFunctional

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -486,10 +486,22 @@ variable [MeasurableSingletonClass S]
 lemma condEntropy_eq_sum_sum (hX : Measurable X) {Y : Ω → T} (hY : Measurable Y)
     (μ : Measure Ω) [IsProbabilityMeasure μ] [FiniteRange X] [FiniteRange Y] :
     H[X | Y ; μ]
-      = ∑ y in FiniteRange.toFinset Y, ∑ x in FiniteRange.toFinset X, (μ.map Y {y}).toReal * negMulLog ((μ[|Y ← y]).map X {x}).toReal := by
+      = ∑ y in FiniteRange.toFinset Y, ∑ x in FiniteRange.toFinset X,
+        (μ.map Y {y}).toReal * negMulLog ((μ[|Y ← y]).map X {x}).toReal := by
   rw [condEntropy_eq_sum _ _ _ hY]
   congr with y
   rw [entropy_cond_eq_sum_finiteRange hX, Finset.mul_sum]
+
+omit [MeasurableSingletonClass S] in
+/-- `H[X|Y] = ∑_y ∑_x P[Y=y] P[X=x|Y=y] log ⧸(P[X=x|Y=y])`$.-/
+lemma condEntropy_eq_sum_sum_fintype {Y : Ω → T} (hY : Measurable Y)
+    (μ : Measure Ω) [IsProbabilityMeasure μ] [Fintype S] [Fintype T] :
+    H[X | Y ; μ] = ∑ y, ∑ x,
+        (μ.map Y {y}).toReal * negMulLog ((μ[|Y ← y]).map X {x}).toReal := by
+  rw [condEntropy_eq_sum_fintype _ _ _ hY]
+  congr with y
+  rw [entropy_cond_eq_sum, tsum_fintype, Finset.mul_sum,
+    Measure.map_apply hY (measurableSet_singleton _)]
 
 /-- Same as previous lemma, but with a sum over a product space rather than a double sum. -/
 lemma condEntropy_eq_sum_prod (hX : Measurable X) {Y : Ω → T}

--- a/PFR/ForMathlib/Uniform.lean
+++ b/PFR/ForMathlib/Uniform.lean
@@ -2,6 +2,7 @@ import Mathlib.Probability.IdentDistrib
 import Mathlib.Probability.ConditionalProbability
 import PFR.ForMathlib.MeasureReal
 import PFR.ForMathlib.FiniteRange.Defs
+import PFR.Mathlib.Probability.UniformOn
 
 open Function MeasureTheory Set
 open scoped ENNReal
@@ -14,29 +15,13 @@ variable {Ω : Type uΩ} {S : Type uS} {T : Type uT} [mΩ : MeasurableSpace Ω]
 /-- The assertion that the law of $X$ is the uniform probability measure on a finite set $H$.
 While in applications $H$ will be non-empty finite set, $X$ measurable, and and $μ$ a probability
 measure, it could be technically convenient to have a definition that works even without these
-hypotheses. (For instance, `isUniform` would be well-defined, but false, for infinite `H`) -/
+hypotheses. (For instance, `isUniform` would be well-defined, but false, for infinite `H`).
+
+This should probably be refactored, requiring instead that `μ.map X = uniformOn H` -- but at the
+time of writing `uniformOn` did not exist in mathlib. -/
 structure IsUniform (H : Set S) (X : Ω → S) (μ : Measure Ω := by volume_tac) : Prop :=
   eq_of_mem : ∀ x y, x ∈ H → y ∈ H → μ (X ⁻¹' {x}) = μ (X ⁻¹' {y})
   measure_preimage_compl : μ (X ⁻¹' Hᶜ) = 0
-
-lemma uniformOn_apply_singleton_of_mem [MeasurableSingletonClass Ω]
-    {A : Set Ω} {x : Ω} (hx : x ∈ A) (h'A : A.Finite) :
-    uniformOn A {x} = 1 / Nat.card A := by
-  have : {x} ∩ A = {x} := by ext y; simp (config := {contextual := true}) [hx]
-  simp only [uniformOn, cond, Measure.smul_apply, MeasurableSet.singleton, Measure.restrict_apply,
-    this, Measure.count_singleton', smul_eq_mul, mul_one, one_div, inv_inj]
-  rw [Measure.count_apply_finite _ h'A, Nat.card_eq_card_finite_toFinset h'A]
-
-lemma uniformOn_apply_singleton_of_nmem [MeasurableSingletonClass Ω]
-    {A : Set Ω} {x : Ω} (hx : x ∉ A) :
-    uniformOn A {x} = 0 := by
-  simp [uniformOn, cond, hx]
-
-theorem uniformOn_apply_eq_zero [MeasurableSingletonClass Ω]
-    {s t : Set Ω} (hst : s ∩ t = ∅) : uniformOn s t = 0 := by
-  rcases Set.finite_or_infinite s with hs | hs
-  · exact (uniformOn_eq_zero_iff hs).mpr hst
-  · simp [uniformOn, cond, Measure.count_apply_infinite hs]
 
 lemma isUniform_uniformOn [MeasurableSingletonClass Ω] {A : Set Ω} :
     IsUniform A id (uniformOn A) := by

--- a/PFR/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/PFR/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -1,6 +1,6 @@
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 @[simp] lemma Real.log_div_self (x : ℝ) : log (x / x) = 0 := by
-    rcases eq_or_ne x 0 with rfl | hx
-    · simp
-    · simp [hx]
+  rcases eq_or_ne x 0 with rfl | hx
+  · simp
+  · simp [hx]

--- a/PFR/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/PFR/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -1,0 +1,6 @@
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+@[simp] lemma Real.log_div_self (x : ℝ) : log (x / x) = 0 := by
+    rcases eq_or_ne x 0 with rfl | hx
+    · simp
+    · simp [hx]

--- a/PFR/Mathlib/MeasureTheory/Measure/Prod.lean
+++ b/PFR/Mathlib/MeasureTheory/Measure/Prod.lean
@@ -30,3 +30,28 @@ lemma prod_of_full_measure_finset {μ : Measure α} {ν : Measure β} [SigmaFini
     ext ⟨s, t⟩; simp; tauto
   rw [this]
   simp [hA, hB]
+
+end MeasureTheory.Measure
+
+open MeasureTheory
+
+/-- To put next to quasiMeasurePreserving_fst -/
+theorem MeasureTheory.measurePreserving_fst {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    {μ : Measure α} {ν : Measure β} [IsProbabilityMeasure ν] :
+    MeasurePreserving Prod.fst (μ.prod ν) μ :=
+  ⟨measurable_fst, by simp⟩
+
+/-- To put next to quasiMeasurePreserving_fst -/
+theorem MeasureTheory.measurePreserving_snd {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    {μ : Measure α} {ν : Measure β} [IsProbabilityMeasure μ] [SFinite ν] :
+    MeasurePreserving Prod.snd (μ.prod ν) ν :=
+  ⟨measurable_snd, by simp⟩
+
+instance {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] {μ : Measure α}
+    [IsZeroOrProbabilityMeasure μ] {ν : Measure β} [IsZeroOrProbabilityMeasure ν] :
+    IsZeroOrProbabilityMeasure (μ.prod ν) := by
+  rcases eq_zero_or_isProbabilityMeasure μ with rfl | hμ
+  · simp; infer_instance
+  rcases eq_zero_or_isProbabilityMeasure ν with rfl | hν
+  · simp; infer_instance
+  infer_instance

--- a/PFR/Mathlib/Probability/IdentDistrib.lean
+++ b/PFR/Mathlib/Probability/IdentDistrib.lean
@@ -98,6 +98,16 @@ lemma IdentDistrib.comp_right {i : δ → β} (hi : MeasurableEmbedding i) (hi' 
     (hg : Measurable g) (hfg : IdentDistrib f g μ ν) : IdentDistrib f (g ∘ i) μ (ν.comap i) :=
   hfg.trans $ identDistrib_comp_right hi hi' hg
 
+lemma _root_.MeasureTheory.MeasurePreserving.identDistrib {α β γ : Type*} {X : β → γ} {f : α → β}
+    [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ] {μ : Measure α}
+    {ν : Measure β} (hf : MeasurePreserving f μ ν) (hX : AEMeasurable X ν) :
+    IdentDistrib X (X ∘ f) ν μ := by
+  have A : AEMeasurable X (Measure.map f μ) := by rwa [hf.map_eq]
+  constructor
+  · exact hX
+  · exact AEMeasurable.comp_aemeasurable A hf.aemeasurable
+  · rw [← AEMeasurable.map_map_of_aemeasurable A hf.aemeasurable, hf.map_eq]
+
 end ProbabilityTheory
 
 open MeasureTheory ProbabilityTheory Function Set

--- a/PFR/Mathlib/Probability/UniformOn.lean
+++ b/PFR/Mathlib/Probability/UniformOn.lean
@@ -1,0 +1,29 @@
+import Mathlib.Probability.UniformOn
+
+
+open MeasureTheory
+
+namespace ProbabilityTheory
+
+variable {Ω : Type*} [MeasurableSpace Ω]
+
+lemma uniformOn_apply_singleton_of_mem [MeasurableSingletonClass Ω]
+    {A : Set Ω} {x : Ω} (hx : x ∈ A) (h'A : A.Finite) :
+    uniformOn A {x} = 1 / Nat.card A := by
+  have : {x} ∩ A = {x} := by ext y; simp (config := {contextual := true}) [hx]
+  simp only [uniformOn, cond, Measure.smul_apply, MeasurableSet.singleton, Measure.restrict_apply,
+    this, Measure.count_singleton', smul_eq_mul, mul_one, one_div, inv_inj]
+  rw [Measure.count_apply_finite _ h'A, Nat.card_eq_card_finite_toFinset h'A]
+
+lemma uniformOn_apply_singleton_of_nmem [MeasurableSingletonClass Ω]
+    {A : Set Ω} {x : Ω} (hx : x ∉ A) :
+    uniformOn A {x} = 0 := by
+  simp [uniformOn, cond, hx]
+
+theorem uniformOn_apply_eq_zero [MeasurableSingletonClass Ω]
+    {s t : Set Ω} (hst : s ∩ t = ∅) : uniformOn s t = 0 := by
+  rcases Set.finite_or_infinite s with hs | hs
+  · exact (uniformOn_eq_zero_iff hs).mpr hst
+  · simp [uniformOn, cond, Measure.count_apply_infinite hs]
+
+end ProbabilityTheory

--- a/PFR/RhoFunctional.lean
+++ b/PFR/RhoFunctional.lean
@@ -477,13 +477,13 @@ noncomputable def condRho {Ω S : Type*}
   ∑' s, (volume (Y ⁻¹' {s})).toReal * @rho G _ _ Ω ⟨ ProbabilityTheory.cond volume (Y⁻¹' {s}) ⟩ X A
 
 /-- Average of rhoMinus along the fibers-/
-noncomputable def condrhoMinus {Ω S : Type*}
+noncomputable def condRhoMinus {Ω S : Type*}
     [MeasureSpace Ω] (X : Ω → G) (Y : Ω → S) (A : Finset G) : ℝ :=
   ∑' s, (volume (Y ⁻¹' {s})).toReal *
     @rhoMinus G _ _ Ω ⟨ProbabilityTheory.cond volume (Y⁻¹' {s}) ⟩ X A
 
 /-- Average of rhoPlus along the fibers-/
-noncomputable def condrhoPlus {Ω S : Type*}
+noncomputable def condRhoPlus {Ω S : Type*}
     [MeasureSpace Ω] (X : Ω → G) (Y : Ω → S) (A : Finset G) : ℝ :=
   ∑' s, (volume (Y ⁻¹' {s})).toReal *
     @rhoPlus G _ _ Ω ⟨ ProbabilityTheory.cond volume (Y⁻¹' {s}) ⟩ X A
@@ -501,13 +501,13 @@ lemma condRho_of_injective {Ω S T : Type*} [MeasureSpace Ω]
   sorry
 
 /-- $$ \rho^-(X|Z) \leq \rho^-(X) + \bbH[X] - \bbH[X|Z]$$ -/
-lemma condrhoMinus_le {Ω S : Type*} [MeasureSpace Ω] [MeasurableSpace S]
+lemma condRhoMinus_le {Ω S : Type*} [MeasureSpace Ω] [MeasurableSpace S]
     (X : Ω → G) (Z : Ω → S) (A : Finset G) :
-    condrhoMinus X Z A ≤ rhoMinus X A + H[ X ] - H[ X | Z ] := by sorry
+    condRhoMinus X Z A ≤ rhoMinus X A + H[ X ] - H[ X | Z ] := by sorry
 
 /-- $$ \rho^+(X|Z) \leq \rho^+(X)$$ -/
-lemma condrhoPlus_le {Ω S : Type*} [MeasureSpace Ω] [MeasurableSpace S]
-    (X : Ω → G) (Z : Ω → S) (A : Finset G) : condrhoPlus X Z A ≤ rhoPlus X A := by sorry
+lemma condRhoPlus_le {Ω S : Type*} [MeasureSpace Ω] [MeasurableSpace S]
+    (X : Ω → G) (Z : Ω → S) (A : Finset G) : condRhoPlus X Z A ≤ rhoPlus X A := by sorry
 
 /-- $$ \rho(X|Z) \leq \rho(X) + \frac{1}{2}( \bbH[X] - \bbH[X|Z] )$$ -/
 lemma condRho_le {Ω S : Type*} [MeasureSpace Ω] [MeasurableSpace S]

--- a/blueprint/src/chapter/further_improvement.tex
+++ b/blueprint/src/chapter/further_improvement.tex
@@ -4,17 +4,17 @@
 
 In the definitions below, $G$ is a set.
 
-\begin{definition}[Kullback--Leibler divergence]\label{kl-div}\lean{KL_div}\leanok If $X,Y$ are two $G$-valued random variables, the Kullback--Leibler divergence is defined as
+\begin{definition}[Kullback--Leibler divergence]\label{kl-div}\lean{KLDiv}\leanok If $X,Y$ are two $G$-valued random variables, the Kullback--Leibler divergence is defined as
   $$ D_{KL}(X\Vert Y) := \sum_x \mathbf{P}(X=x) \log \frac{\mathbf{P}(X=x)}{\mathbf{P}(Y=x)}.$$
 \end{definition}
 
-\begin{lemma}[Kullback--Leibler divergence of copy]\label{kl-div-copy}\lean{KL_div_eq_of_equiv}\leanok  If $X'$ is a copy of $X$, and $Y'$ is a copy of $Y$, then $D_{KL}(X'\Vert Y') = D_{KL}(X\Vert Y)$.
+\begin{lemma}[Kullback--Leibler divergence of copy]\label{kl-div-copy}\lean{KLDiv_eq_of_equiv}\leanok  If $X'$ is a copy of $X$, and $Y'$ is a copy of $Y$, then $D_{KL}(X'\Vert Y') = D_{KL}(X\Vert Y)$.
 \end{lemma}
 
 \begin{proof}\uses{kl-div}\leanok  Clear from definition.
 \end{proof}
 
-\begin{lemma}[Gibbs inequality]\label{Gibbs}\uses{kl-div}\lean{KL_div_nonneg}\leanok  $D_{KL}(X\Vert Y) \geq 0$.
+\begin{lemma}[Gibbs inequality]\label{Gibbs}\uses{kl-div}\lean{KLDiv_nonneg}\leanok  $D_{KL}(X\Vert Y) \geq 0$.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -22,7 +22,7 @@ In the definitions below, $G$ is a set.
   Apply \Cref{log-sum} on the definition.
 \end{proof}
 
-\begin{lemma}[Converse Gibbs inequality]\label{Gibbs-converse}\lean{KL_div_eq_zero_iff_identDistrib}\leanok  If $D_{KL}(X\Vert Y) = 0$, then $Y$ is a copy of $X$.
+\begin{lemma}[Converse Gibbs inequality]\label{Gibbs-converse}\lean{KLDiv_eq_zero_iff_identDistrib}\leanok  If $D_{KL}(X\Vert Y) = 0$, then $Y$ is a copy of $X$.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -30,7 +30,7 @@ In the definitions below, $G$ is a set.
   Apply \Cref{converse-log-sum}.
 \end{proof}
 
-\begin{lemma}[Convexity of Kullback--Leibler]\label{kl-div-convex}\lean{KL_div_of_convex}\leanok  If $S$ is a finite set, $\sum_{s \in S} w_s = 1$ for some non-negative $w_s$, and ${\bf P}(X=x) = \sum_{s\in S} w_s  {\bf P}(X_s=x)$, ${\bf P}(Y=x) = \sum_{s\in S} w_s  {\bf P}(Y_s=x)$ for all $x$, then
+\begin{lemma}[Convexity of Kullback--Leibler]\label{kl-div-convex}\lean{KLDiv_of_convex}\leanok  If $S$ is a finite set, $\sum_{s \in S} w_s = 1$ for some non-negative $w_s$, and ${\bf P}(X=x) = \sum_{s\in S} w_s  {\bf P}(X_s=x)$, ${\bf P}(Y=x) = \sum_{s\in S} w_s  {\bf P}(Y_s=x)$ for all $x$, then
 $$D_{KL}(X\Vert Y) \le \sum_{s\in S} w_s D_{KL}(X_s\Vert Y_s).$$
 \end{lemma}
 
@@ -40,7 +40,7 @@ For each $x$, replace $\log \frac{\mathbf{P}(X_s=x)}{\mathbf{P}(Y_s=x)}$ in the 
 \end{proof}
 
 
-\begin{lemma}[Kullback--Leibler and injections]\label{kl-div-inj}\lean{KL_div_of_comp_inj}\leanok  If $f:G \to H$ is an injection, then $D_{KL}(f(X)\Vert f(Y)) = D_{KL}(X\Vert Y)$.
+\begin{lemma}[Kullback--Leibler and injections]\label{kl-div-inj}\lean{KLDiv_of_comp_inj}\leanok  If $f:G \to H$ is an injection, then $D_{KL}(f(X)\Vert f(Y)) = D_{KL}(X\Vert Y)$.
 \end{lemma}
 
 \begin{proof}\leanok\uses{kl-div} Clear from definition.
@@ -48,7 +48,7 @@ For each $x$, replace $\log \frac{\mathbf{P}(X_s=x)}{\mathbf{P}(Y_s=x)}$ in the 
 
 Now let $G$ be an additive group.
 
-\begin{lemma}[Kullback--Leibler and sums]\label{kl-sums}\lean{KL_div_add_le_KL_div_of_indep}\leanok If $X, Y, Z$ are independent $G$-valued random variables, then
+\begin{lemma}[Kullback--Leibler and sums]\label{kl-sums}\lean{KLDiv_add_le_KLDiv_of_indep}\leanok If $X, Y, Z$ are independent $G$-valued random variables, then
   $$D_{KL}(X+Z\Vert Y+Z) \leq D_{KL}(X\Vert Y).$$
 \end{lemma}
 
@@ -62,7 +62,7 @@ For each $z$, $D_{KL}(X+z\Vert Y+z)=D_{KL}(X\Vert Y)$ by \Cref{kl-div-inj}. Then
 $$ D_{KL}(X|Z \Vert  Y) := \sum_z \mathbf{P}(Z=z) D_{KL}( (X|Z=z) \Vert  Y).$$
 \end{definition}
 
-\begin{lemma}[Kullback--Leibler and conditioning]\label{kl-cond}\lean{condKL_div_eq}\leanok If $X, Y$ are independent $G$-valued random variables, and $Z$ is another random variable defined on the same sample space as $X$, then
+\begin{lemma}[Kullback--Leibler and conditioning]\label{kl-cond}\lean{condKLDiv_eq}\leanok If $X, Y$ are independent $G$-valued random variables, and $Z$ is another random variable defined on the same sample space as $X$, then
   $$D_{KL}((X|Z)\Vert Y) = D_{KL}(X\Vert Y) + \bbH[X] - \bbH[X|Z].$$
 \end{lemma}
 
@@ -70,7 +70,7 @@ $$ D_{KL}(X|Z \Vert  Y) := \sum_z \mathbf{P}(Z=z) D_{KL}( (X|Z=z) \Vert  Y).$$
   \uses{ckl-div} Compare the terms correspond to each $x\in G$ on both sides.
 \end{proof}
 
-\begin{lemma}[Conditional Gibbs inequality]\label{Conditional-Gibbs}\lean{condKL_div_nonneg}\leanok  $D_{KL}((X|W)\Vert Y) \geq 0$.
+\begin{lemma}[Conditional Gibbs inequality]\label{Conditional-Gibbs}\lean{condKLDiv_nonneg}\leanok  $D_{KL}((X|W)\Vert Y) \geq 0$.
 \end{lemma}
 
 \begin{proof}\uses{Gibbs, ckl-div}  Clear from Definition \ref{ckl-div} and Lemma \ref{Gibbs}.
@@ -80,19 +80,19 @@ $$ D_{KL}(X|Z \Vert  Y) := \sum_z \mathbf{P}(Z=z) D_{KL}( (X|Z=z) \Vert  Y).$$
 
 Let $G$ be an additive group, and let $A$ be a non-empty subset of $G$.
 
-\begin{definition}[Rho minus]\label{rhominus-def}\lean{rho_minus}\leanok  For any $G$-valued random variable $X$, we define $\rho^-(X)$ to be the infimum of $D_{KL}(X \Vert  U_A + T)$, where $U_A$ is uniform on $A$ and $T$ ranges over $G$-valued random variables independent of $U_A$.
+\begin{definition}[Rho minus]\label{rhominus-def}\lean{rhoMinus}\leanok  For any $G$-valued random variable $X$, we define $\rho^-(X)$ to be the infimum of $D_{KL}(X \Vert  U_A + T)$, where $U_A$ is uniform on $A$ and $T$ ranges over $G$-valued random variables independent of $U_A$.
 \end{definition}
 
-\begin{definition}[Rho plus]\label{rhoplus-def}\lean{rho_plus}\uses{rhominus-def}\leanok  For any $G$-valued random variable $X$, we define $\rho^+(X) := \rho^-(X) + \bbH(X) - \bbH(U_A)$.
+\begin{definition}[Rho plus]\label{rhoplus-def}\lean{rhoPlus}\uses{rhominus-def}\leanok  For any $G$-valued random variable $X$, we define $\rho^+(X) := \rho^-(X) + \bbH(X) - \bbH(U_A)$.
 \end{definition}
 
-\begin{lemma}[Rho minus non-negative]\label{rhominus-nonneg}\label{rho_minus_nonneg}\uses{rhominus-def}\leanok  We have $\rho^-(X) \geq 0$.
+\begin{lemma}[Rho minus non-negative]\label{rhominus-nonneg}\label{rhoMinus_nonneg}\uses{rhominus-def}\leanok  We have $\rho^-(X) \geq 0$.
 \end{lemma}
 
 \begin{proof}\uses{Conditional-Gibbs} Clear from Lemma \ref{Conditional-Gibbs}.
 \end{proof}
 
-\begin{lemma}[Rho minus of subgroup]\label{rhominus-subgroup}\lean{rho_minus_of_subgroup}\uses{rhominus-def}\leanok If $H$ is a finite subgroup of $G$, then $\rho^-(U_H) = \log |A| - \log \max_t |A \cap (H+t)|$.
+\begin{lemma}[Rho minus of subgroup]\label{rhominus-subgroup}\lean{rhoMinus_of_subgroup}\uses{rhominus-def}\leanok If $H$ is a finite subgroup of $G$, then $\rho^-(U_H) = \log |A| - \log \max_t |A \cap (H+t)|$.
 \end{lemma}
 
 \begin{proof}
@@ -104,7 +104,7 @@ Let $G$ be an additive group, and let $A$ be a non-empty subset of $G$.
   To get the equality, let $t^*:=\arg\max_t |A \cap (H+t)|$ and observe that $$\rho^-(U_H)\le D_{KL}(U_H \Vert  U_A+(U_H-t^*))= \log |A| - \log \max_t|A \cap (H+t)|.$$
 \end{proof}
 
-\begin{corollary}[Rho plus of subgroup]\label{rhoplus-subgroup}\lean{rho_plus_of_subgroup}\uses{rhoplus-def}\leanok If $H$ is a finite subgroup of $G$, then $\rho^+(U_H) = \log |H| - \log \max_t |A \cap (H+t)|$.
+\begin{corollary}[Rho plus of subgroup]\label{rhoplus-subgroup}\lean{rhoPlus_of_subgroup}\uses{rhoplus-def}\leanok If $H$ is a finite subgroup of $G$, then $\rho^+(U_H) = \log |H| - \log \max_t |A \cap (H+t)|$.
 \end{corollary}
 
 \begin{proof}\uses{rhominus-subgroup} Straightforward by definition and \Cref{rhominus-subgroup}.
@@ -138,7 +138,7 @@ Let $G$ be an additive group, and let $A$ be a non-empty subset of $G$.
 \begin{proof}  Clear from definition.
 \end{proof}
 
-\begin{lemma}[Rho and sums]\label{rho-sums}\lean{rho_minus_of_sum, rho_plus_of_sum, rho_of_sum}\leanok  If $X,Y$ are independent, one has
+\begin{lemma}[Rho and sums]\label{rho-sums}\lean{rhoMinus_of_sum, rhoPlus_of_sum, rho_of_sum}\leanok  If $X,Y$ are independent, one has
   $$ \rho^-(X+Y) \leq \rho^-(X)$$
   $$ \rho^+(X+Y) \leq \rho^+(X) + \bbH[X+Y] - \bbH[X]$$
 and
@@ -170,7 +170,7 @@ The first inequality follows from \Cref{kl-sums}. The second and third inequalit
   Clear from the definition.
 \end{proof}
 
-\begin{lemma}[Rho and conditioning]\label{rho-cond}\lean{condRho_minus_le, condRho_plus_le, condRho_le}\leanok  If $X,Z$ are defined on the same space, one has
+\begin{lemma}[Rho and conditioning]\label{rho-cond}\lean{condrhoMinus_le, condrhoPlus_le, condRho_le}\leanok  If $X,Z$ are defined on the same space, one has
   $$ \rho^-(X|Z) \leq \rho^-(X) + \bbH[X] - \bbH[X|Z]$$
   $$ \rho^+(X|Z) \leq \rho^+(X)$$
 and

--- a/blueprint/src/chapter/further_improvement.tex
+++ b/blueprint/src/chapter/further_improvement.tex
@@ -173,7 +173,7 @@ The first inequality follows from \Cref{kl-sums}. The second and third inequalit
   Clear from the definition.
 \end{proof}
 
-\begin{lemma}[Rho and conditioning]\label{rho-cond}\lean{condrhoMinus_le, condrhoPlus_le, condRho_le}\leanok  If $X,Z$ are defined on the same space, one has
+\begin{lemma}[Rho and conditioning]\label{rho-cond}\lean{condRhoMinus_le, condRhoPlus_le, condRho_le}\leanok  If $X,Z$ are defined on the same space, one has
   $$ \rho^-(X|Z) \leq \rho^-(X) + \bbH[X] - \bbH[X|Z]$$
   $$ \rho^+(X|Z) \leq \rho^+(X)$$
 and

--- a/blueprint/src/chapter/further_improvement.tex
+++ b/blueprint/src/chapter/further_improvement.tex
@@ -52,7 +52,7 @@ Now let $G$ be an additive group.
   $$D_{KL}(X+Z\Vert Y+Z) \leq D_{KL}(X\Vert Y).$$
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
   \uses{kl-div-inj,kl-div-convex}
 For each $z$, $D_{KL}(X+z\Vert Y+z)=D_{KL}(X\Vert Y)$ by \Cref{kl-div-inj}. Then apply \Cref{kl-div-convex} with $w_z=\mathbf{P}(Z=z)$.
 \end{proof}
@@ -66,14 +66,14 @@ $$ D_{KL}(X|Z \Vert  Y) := \sum_z \mathbf{P}(Z=z) D_{KL}( (X|Z=z) \Vert  Y).$$
   $$D_{KL}((X|Z)\Vert Y) = D_{KL}(X\Vert Y) + \bbH[X] - \bbH[X|Z].$$
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
   \uses{ckl-div} Compare the terms correspond to each $x\in G$ on both sides.
 \end{proof}
 
 \begin{lemma}[Conditional Gibbs inequality]\label{Conditional-Gibbs}\lean{condKLDiv_nonneg}\leanok  $D_{KL}((X|W)\Vert Y) \geq 0$.
 \end{lemma}
 
-\begin{proof}\uses{Gibbs, ckl-div}  Clear from Definition \ref{ckl-div} and Lemma \ref{Gibbs}.
+\begin{proof}\leanok \uses{Gibbs, ckl-div}  Clear from Definition \ref{ckl-div} and Lemma \ref{Gibbs}.
 \end{proof}
 
 \section{Rho functionals}
@@ -89,13 +89,13 @@ Let $G$ be an additive group, and let $A$ be a non-empty subset of $G$.
 \begin{lemma}[Rho minus non-negative]\label{rhominus-nonneg}\label{rhoMinus_nonneg}\uses{rhominus-def}\leanok  We have $\rho^-(X) \geq 0$.
 \end{lemma}
 
-\begin{proof}\uses{Conditional-Gibbs} Clear from Lemma \ref{Conditional-Gibbs}.
+\begin{proof}\leanok \uses{Conditional-Gibbs} Clear from Lemma \ref{Conditional-Gibbs}.
 \end{proof}
 
 \begin{lemma}[Rho minus of subgroup]\label{rhominus-subgroup}\lean{rhoMinus_of_subgroup}\uses{rhominus-def}\leanok If $H$ is a finite subgroup of $G$, then $\rho^-(U_H) = \log |A| - \log \max_t |A \cap (H+t)|$.
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
   \uses{log-sum}
   For every $G$-valued random variable $T$ that is independent of $Y$,
   $$D_{KL}(U_H \Vert U_A+T) = \sum_{h\in H} \frac{1}{|H|}\log\frac{1/|H|}{\mathbf{P}[U_A+T=h]}\ge -\log(\mathbf{P}[U_A+T\in H]),$$
@@ -107,7 +107,7 @@ Let $G$ be an additive group, and let $A$ be a non-empty subset of $G$.
 \begin{corollary}[Rho plus of subgroup]\label{rhoplus-subgroup}\lean{rhoPlus_of_subgroup}\uses{rhoplus-def}\leanok If $H$ is a finite subgroup of $G$, then $\rho^+(U_H) = \log |H| - \log \max_t |A \cap (H+t)|$.
 \end{corollary}
 
-\begin{proof}\uses{rhominus-subgroup} Straightforward by definition and \Cref{rhominus-subgroup}.
+\begin{proof}\leanok \uses{rhominus-subgroup} Straightforward by definition and \Cref{rhominus-subgroup}.
 \end{proof}
 
 \begin{definition}[Rho functional]\label{rho-def}\lean{rho}\uses{rhoplus-def}\leanok  We define $\rho(X) := (\rho^+(X) + \rho^-(X))/2$.
@@ -116,13 +116,16 @@ Let $G$ be an additive group, and let $A$ be a non-empty subset of $G$.
 \begin{lemma}\label{rho-init}\label{rho_of_uniform}\uses{rho-def}\leanok  We have $\rho(U_A) = 0$.
 \end{lemma}
 
-\begin{proof}\uses{rhominus-nonneg} $\rho^-(U_A)\le 0$ by the choice $T=0$. The claim then follows from \Cref{rhominus-nonneg}.
+\begin{proof}\leanok \uses{rhominus-nonneg} $\rho^-(U_A)\le 0$ by the choice $T=0$. The claim then follows from \Cref{rhominus-nonneg}.
 \end{proof}
 
-\begin{lemma}[Rho of subgroup]\label{rho-subgroup}\uses{rho-def}\lean{rho_of_subgroup}\leanok  If $H$ is a finite subgroup of $G$, and $\rho(U_H) \leq r$, then there exists $t$ such that $|A \cap (H+t)| \geq 2^{-r} \sqrt{|A||H|}$, and $|H|/|A|\in[2^{-2r},2^{2r}]$.
+\begin{lemma}[Rho of subgroup]\label{rho-subgroup}\uses{rho-def}\lean{rho_of_subgroup}\leanok
+If $H$ is a finite subgroup of $G$, and $\rho(U_H) \leq r$, then there exists
+$t$ such that $|A \cap (H+t)| \geq e^{-r} \sqrt{|A||H|}$, and
+$|H|/|A|\in[e^{-2r},e^{2r}]$.
 \end{lemma}
 
-\begin{proof}\uses{rhominus-subgroup, rhoplus-subgroup} The first claim is a direct corollary of \Cref{rhominus-subgroup} and \Cref{rhoplus-subgroup}. To see the second claim, observe that \Cref{rhominus-nonneg} and \Cref{rhoplus-subgroup} imply $\rho^-(U_H),\rho^+(U_H)\ge 0$. Therefore $$|H(U_A)-H(U_H)|=|\rho^+(U_H)-\rho^-(U_H)|\le \rho^-(U_H)+\rho^+(U_H)= 2\rho(U_H)\le 2r,$$
+\begin{proof}\leanok\uses{rhominus-subgroup, rhoplus-subgroup} The first claim is a direct corollary of \Cref{rhominus-subgroup} and \Cref{rhoplus-subgroup}. To see the second claim, observe that \Cref{rhominus-nonneg} and \Cref{rhoplus-subgroup} imply $\rho^-(U_H),\rho^+(U_H)\ge 0$. Therefore $$|H(U_A)-H(U_H)|=|\rho^+(U_H)-\rho^-(U_H)|\le \rho^-(U_H)+\rho^+(U_H)= 2\rho(U_H)\le 2r,$$
   which implies the second claim.
 \end{proof}
 


### PR DESCRIPTION
We finish the file on KL divergence, and prove the first lemmas on the rho functional. I changed a little bit the implementation of rhoMinus, expressing it in terms of measures on the group to avoid universe issues (but then I proved a lemma showing that it satisfies the right inequality for random variables, whatever their universe). More importantly, I introduced an absolute continuity assumption in the definition of rhoMinus, because otherwise KLDiv is badly behaved, because we have chosen a real-valued version while the divergence should be infinite when the random variables are not absolutely continuous. 

There is a design balance here: either use the natural KLDiv, valued in [0, \infty], but then computations become a mess because you need to check all the time if the quantities are finite or infinite. Or use the version valued in [0, \infty), but add assumptions in the lemmas to make sure that we never hit the bad case. Since there are quite a lot of computations in the project, I think the versions with values in [0, \infty] would be a bad idea, so I chose the other one with the side conditions.