### PR TITLE
feat: Improve other bounds using PFR 9

### DIFF
--- a/PFR/ApproxHomPFR.lean
+++ b/PFR/ApproxHomPFR.lean
@@ -3,6 +3,7 @@ import Mathlib.Analysis.Normed.Lp.PiLp
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import LeanAPAP.Extras.BSG
 import PFR.HomPFR
+import PFR.RhoFunctional
 
 /-!
 # The approximate homomorphism form of PFR
@@ -28,10 +29,10 @@ variable {G G' : Type*} [AddCommGroup G] [Fintype G] [AddCommGroup G'] [Fintype 
 Let $f : G \to G'$ be a function, and suppose that there are at least
 $|G|^2 / K$ pairs $(x,y) \in G^2$ such that $$ f(x+y) = f(x) + f(y).$$
 Then there exists a homomorphism $\phi : G \to G'$ and a constant $c \in G'$ such that
-$f(x) = \phi(x)+c$ for at least $|G| / (2 ^ {172} * K ^ {146})$ values of $x \in G$. -/
+$f(x) = \phi(x)+c$ for at least $|G| / (2 ^ {144} * K ^ {122})$ values of $x \in G$. -/
 theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK : K > 0)
     (hf : Nat.card G ^ 2 / K ≤ Nat.card {x : G × G | f (x.1 + x.2) = f x.1 + f x.2}) :
-    ∃ (φ : G →+ G') (c : G'), Nat.card {x | f x = φ x + c} ≥ Nat.card G / (2 ^ 172 * K ^ 146) := by
+    ∃ (φ : G →+ G') (c : G'), Nat.card {x | f x = φ x + c} ≥ Nat.card G / (2 ^ 144 * K ^ 122) := by
   let A := (Set.univ.graphOn f).toFinite.toFinset
   have hA : #A = Nat.card G := by rw [Set.Finite.card_toFinset]; simp [← Nat.card_eq_fintype_card]
   have hA_nonempty : A.Nonempty := by simp [-Set.Finite.toFinset_setOf, A]
@@ -64,7 +65,7 @@ theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK : K > 0)
   replace : Nat.card (A'' + A'') ≤ 2 ^ 14 * K ^ 12 * Nat.card A'' := by
     rewrite [← this, hA''_coe]
     simpa [← pow_mul] using hA'2
-  obtain ⟨H, c, hc_card, hH_le, hH_ge, hH_cover⟩ := PFR_conjecture_improv_aux hA''_nonempty this
+  obtain ⟨H, c, hc_card, hH_le, hH_ge, hH_cover⟩ := better_PFR_conjecture_aux hA''_nonempty this
   clear hA'2 hA''_coe hH_le hH_ge
   obtain ⟨H₀, H₁, φ, hH₀H₁, hH₀H₁_card⟩ := goursat H
 
@@ -168,7 +169,7 @@ theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK : K > 0)
     · positivity
     · rewrite [Nat.cast_pos, Finset.card_pos, Set.Finite.toFinset_nonempty _]
       exact h_nonempty
-  rw [show 146 = 2 + 144 by norm_num, show 172 = 4 + 168 by norm_num, pow_add, pow_add,
+  rw [show 122 = 2 + 120 by norm_num, show 144 = 4 + 140 by norm_num, pow_add, pow_add,
     mul_mul_mul_comm]
   gcongr
   rewrite [← c.toFinite.toFinset_prod (H₁ : Set G').toFinite, Finset.card_product]
@@ -178,12 +179,12 @@ theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK : K > 0)
   refine (mul_le_mul_of_nonneg_right hc_card (by positivity)).trans ?_
   rewrite [mul_div_left_comm, mul_assoc]
   refine (mul_le_mul_of_nonneg_right hc_card (by positivity)).trans_eq ?_
-  rw [mul_assoc ((_ * _)^6), mul_mul_mul_comm, mul_comm (_ ^ (1/2) * _), mul_comm_div,
+  rw [mul_assoc ((_ * _)^5), mul_mul_mul_comm, mul_comm (_ ^ (1/2) * _), mul_comm_div,
     ← mul_assoc _ (_^_) (_^_), mul_div_assoc, mul_mul_mul_comm _ (_^_) (_^_),
     ← mul_div_assoc, mul_assoc _ (_^(1/2)) (_^(1/2)),
     ← Real.rpow_add (Nat.cast_pos.mpr Nat.card_pos), add_halves, Real.rpow_one,
     ← Real.rpow_add (Nat.cast_pos.mpr Nat.card_pos), add_halves, Real.rpow_neg_one,
-    mul_comm _ (_ / _), mul_assoc (_^6)]
+    mul_comm _ (_ / _), mul_assoc (_^5)]
   conv => { lhs; rhs; rw [← mul_assoc, ← mul_div_assoc, mul_comm_div, mul_div_assoc] }
   rw [div_self <| Nat.cast_ne_zero.mpr (Nat.ne_of_lt Nat.card_pos).symm, mul_one]
   rw [mul_inv_cancel₀ <| Nat.cast_ne_zero.mpr (Nat.ne_of_lt Nat.card_pos).symm, one_mul, ← sq,
@@ -191,4 +192,4 @@ theorem approx_hom_pfr (f : G → G') (K : ℝ) (hK : K > 0)
   have : K ^ (12 : ℕ) = K ^ (12 : ℝ) := (Real.rpow_natCast K 12).symm
   rw [this, ← Real.rpow_mul (by positivity)]
   norm_num
-  exact Real.rpow_natCast K 144
+  exact Real.rpow_natCast K 120

--- a/PFR/HomPFR.lean
+++ b/PFR/HomPFR.lean
@@ -17,7 +17,7 @@ few values.
   abelian 2-groups.
 * `homomorphism_pfr` : If $f : G → G'$ is a map between finite abelian elementary 2-groups such
   that $f(x+y)-f(x)-f(y)$ takes at most $K$ values, then there is a homomorphism $\phi: G \to G'$
-  such that $f(x)-\phi(x)$ takes at most $K^{12}$ values.
+  such that $f(x)-\phi(x)$ takes at most $K^{10}$ values.
 -/
 
 open Set

--- a/PFR/HomPFR.lean
+++ b/PFR/HomPFR.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Set.Card
 import PFR.Mathlib.LinearAlgebra.Basis.VectorSpace
 import PFR.Mathlib.SetTheory.Cardinal.Finite
 import PFR.ImprovedPFR
+import PFR.RhoFunctional
 
 /-!
 # The homomorphism form of PFR
@@ -64,9 +65,9 @@ open Set Fintype
 /-- Let $f: G \to G'$ be a function, and let $S$ denote the set
 $$ S := \{ f(x+y)-f(x)-f(y): x,y \in G \}.$$
 Then there exists a homomorphism $\phi: G \to G'$ such that
-$$ |\{f(x) - \phi(x)\}| \leq |S|^{12}. $$ -/
+$$ |\{f(x) - \phi(x)\}| \leq |S|^{10}. $$ -/
 theorem homomorphism_pfr (f : G → G') (S : Set G') (hS : ∀ x y : G, f (x+y) - (f x) - (f y) ∈ S) :
-  ∃ (φ : G →+ G') (T : Set G'), Nat.card T ≤ Nat.card S ^ 12 ∧ ∀ x : G, (f x) - (φ x) ∈ T := by
+  ∃ (φ : G →+ G') (T : Set G'), Nat.card T ≤ Nat.card S ^ 10 ∧ ∀ x : G, (f x) - (φ x) ∈ T := by
   classical
   have : 0 < Nat.card G := Nat.card_pos
   let A := univ.graphOn f
@@ -88,7 +89,7 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS : ∀ x y : G, f (x+y) 
     norm_cast
     exact (Nat.card_mono (toFinite B) hAB).trans hB_card
   have hA_nonempty : A.Nonempty := by simp [A]
-  obtain ⟨H, c, hcS, -, -, hAcH⟩ := PFR_conjecture_improv_aux hA_nonempty hA_le
+  obtain ⟨H, c, hcS, -, -, hAcH⟩ := better_PFR_conjecture_aux hA_nonempty hA_le
   have : 0 < Nat.card c := by
     have : c.Nonempty := by
       by_contra! H
@@ -139,7 +140,7 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS : ∀ x y : G, f (x+y) 
         congr! 3 with a
         rw [← range, ← range, ← graphOn_univ_eq_range, ← graphOn_univ_eq_range, vadd_graphOn_univ]
   refine ⟨φ, T, ?_, ?_⟩
-  · have : (Nat.card T : ℝ) ≤ (Nat.card S : ℝ) ^ (12 : ℝ) := by calc
+  · have : (Nat.card T : ℝ) ≤ (Nat.card S : ℝ) ^ (10 : ℝ) := by calc
       (Nat.card T : ℝ) ≤ Nat.card (c + {(0 : G)} ×ˢ (H₁ : Set G')) := by
         norm_cast; apply Nat.card_image_le (toFinite _)
       _ ≤ Nat.card c * Nat.card H₁ := by
@@ -148,9 +149,9 @@ theorem homomorphism_pfr (f : G → G') (S : Set G') (hS : ∀ x y : G, f (x+y) 
         rw [Set.card_singleton_prod] ; rfl
       _ ≤ Nat.card c * ((Nat.card H / Nat.card A) * Nat.card c) := by gcongr
       _ = Nat.card c ^ 2 * (Nat.card H / Nat.card A) := by ring
-      _ ≤ (Nat.card S ^ (6 : ℝ) * Nat.card A ^ (1 / 2 : ℝ) * Nat.card H ^ (-1 / 2 : ℝ)) ^ 2
+      _ ≤ (Nat.card S ^ (5 : ℝ) * Nat.card A ^ (1 / 2 : ℝ) * Nat.card H ^ (-1 / 2 : ℝ)) ^ 2
           * (Nat.card H / Nat.card A) := by gcongr
-      _ = (Nat.card S : ℝ) ^ (12 : ℝ) := by
+      _ = (Nat.card S : ℝ) ^ (10 : ℝ) := by
         rw [← Real.rpow_two, div_eq_mul_inv, div_eq_mul_inv, div_eq_mul_inv]
         have : 0 < Nat.card S := by
           have : S.Nonempty := ⟨f (0 + 0) - f 0 - f 0, hS 0 0⟩

--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -28,22 +28,23 @@ $$ C_1 = 2^4, C_2 = 1, C_3 = 2^{10}, C_4 = 5.$$
   Let $f: G \to G'$ be a function, and suppose that there are at least $|G|^2 / K$ pairs $(x,y) \in G^2$ such that
 $$ f(x+y) = f(x) + f(y).$$
 Then there exists a homomorphism $\phi: G \to G'$ and a constant $c \in G'$
-such that $f(x) = \phi(x)+c$ for at least $|G| / (2 ^ {172} * K ^ {146})$ values of $x \in G$.
+such that $f(x) = \phi(x)+c$ for at least $|G| / (2 ^ {144} * K ^ {122})$
+values of $x \in G$.
 \end{theorem}
 
 \begin{proof}\uses{goursat, cs-bound, bsg, pfr_aux-improv}\leanok Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have $a+a' \in A$ for at least
-$|A|^2/K$ pairs $(a,a') \in A^2$. By \Cref{cs-bound}, this implies that
-$E(A) \geq |A|^3/K^2$.  Applying \Cref{bsg}, we conclude that there
-exists a subset $A' \subset A$ with $|A'| \geq |A|/C_1 K^{2C_2}$ and $|A'+A'|
-\leq C_1C_3 K^{2(C_2+C_4)} |A'|$. Applying \Cref{pfr_aux-improv}, we may
-find a subspace $H \subset G \times G'$ such that $|H| / |A'| \in [L^{-10},
-L^{10}$ and a subset $c$ of cardinality at most $L^6 |A'|^{1/2} / |H|^{1/2}$
-such that $A' \subseteq c + H$, where $L =  C_1C_3 K^{2(C_2+C_4)}$. If we let
-$H_0,H_1$ be as in \Cref{goursat}, this implies on taking projections
-the projection of $A'$ to $G$ is covered by at most $|c|$ translates of
-$H_0$.  This implies that
+$|A|^2/K$ pairs $(a,a') \in A^2$. By \Cref{cs-bound}, this implies that $E(A)
+\geq |A|^3/K^2$.  Applying \Cref{bsg}, we conclude that there exists a subset
+$A' \subset A$ with $|A'| \geq |A|/C_1 K^{2C_2}$ and $|A'+A'| \leq C_1C_3
+K^{2(C_2+C_4)} |A'|$. Applying \Cref{pfr-9-aux'}, we may find a subspace $H
+\subset G \times G'$ such that $|H| / |A'| \in [L^{-8}, L^{8}]$ and a subset
+$c$ of cardinality at most $L^5 |A'|^{1/2} / |H|^{1/2}$ such that $A'
+\subseteq c + H$, where $L =  C_1C_3 K^{2(C_2+C_4)}$. If we let $H_0,H_1$ be
+as in \Cref{goursat}, this implies on taking projections the projection of
+$A'$ to $G$ is covered by at most $|c|$ translates of $H_0$.  This implies
+that
 $$ |c| |H_0| \geq |A'|;$$
 since $|H_0| |H_1| = |H|$, we conclude that
 $$ |H_1| \leq |c| |H|/|A'|.$$
@@ -54,10 +55,10 @@ is a homomorphism, each such translate can be written in the form $\{
 (x,\phi(x)+c): x \in G \}$ for some $c \in G'$. The number of translates is
 bounded by
 $$
-|c|^2 \frac{|H|}{|A'|} \leq \left(L^6 \frac{|A'|^{1/2}}{|H|^{1/2}}\right)^2 \frac{|H|}{|A'|} = L^{12}.
+|c|^2 \frac{|H|}{|A'|} \leq \left(L^5 \frac{|A'|^{1/2}}{|H|^{1/2}}\right)^2 \frac{|H|}{|A'|} = L^{10}.
 $$
 
 By the pigeonhole principle, one of these translates must then contain at
-least $|A'|/L^{12} \geq |G| / (C_1C_3 K^{2(C_2+C_4)})^{12} (C_1 K^{2C_2})$
+least $|A'|/L^{10} \geq |G| / (C_1C_3 K^{2(C_2+C_4)})^{10} (C_1 K^{2C_2})$
 elements of $A'$ (and hence of $A$), and the claim follows.
 \end{proof}

--- a/blueprint/src/chapter/further_improvement.tex
+++ b/blueprint/src/chapter/further_improvement.tex
@@ -344,8 +344,9 @@ By \Cref{ruzsa-triangle} and \Cref{ruzsa-nonneg} we have $d[X_1;X_1]=d[X_2;X_2]=
 By \Cref{rho-invariant} we get $\rho(U_{H_1})+\rho(U_{H_2})\le \rho(Y_1) + \rho(Y_2) + 8 d[Y_1;Y_2]$, and thus the claim holds for $H=H_1$ or $H=H_2$.
 \end{proof}
 
-\begin{corollary}\label{pfr-9-aux}\lean{better_PFR_conjecture_aux}\leanok
-If $|A+A| \leq K|A|$, then there exists a subgroup $H$ and $t\in G$ such that $|A \cap (H+t)| \geq K^{-4} \sqrt{|A||V|}$, and $|H|/|A|\in[K^{-8},K^8]$.
+\begin{corollary}\label{pfr-9-aux}\lean{better_PFR_conjecture_aux0}\leanok
+If $|A+A| \leq K|A|$, then there exists a subgroup $H$ and $t\in G$ such that
+$|A \cap (H+t)| \geq K^{-4} \sqrt{|A||H|}$, and $|H|/|A|\in[K^{-8},K^8]$.
 \end{corollary}
 
 \begin{proof}\leanok
@@ -353,10 +354,24 @@ If $|A+A| \leq K|A|$, then there exists a subgroup $H$ and $t\in G$ such that $|
   Apply \Cref{pfr-rho} on $U_A,U_A$ to get a subspace such that $2\rho(U_H)\le 2\rho(U_A)+8d[U_A;U_A]$. Recall that $d[U_A;U_A]\le \log K$ as proved in \Cref{pfr_aux}, and $\rho(U_A)=0$ by \Cref{rho-init}. Therefore $\rho(U_H)\le 4\log(K)$. The claim then follows from \Cref{rho-subgroup}.
 \end{proof}
 
+
+\begin{corollary}\label{pfr-9-aux'}\lean{better_PFR_conjecture_aux}\leanok
+If $|A+A| \leq K|A|$, then there exist a subgroup $H$ and a subset $c$ of $G$
+with $A \subseteq c + H$, such that $|c| \leq K^{5} |A|^{1/2}/|H|^{1/2}$ and
+$|H|/|A|\in[K^{-8},K^8]$.
+\end{corollary}
+
+\begin{proof}\leanok
+  \uses{pfr-9-aux, ruz-cov}
+Apply \Cref{pfr-9-aux} and \Cref{ruz-cov} to get the result, as in the proof
+of \Cref{pfr_aux}.
+\end{proof}
+
+
 \begin{theorem}[PFR with \texorpdfstring{$C=9$}{C=9}]\label{pfr-9}\lean{better_PFR_conjecture}\leanok  If $A \subset {\bf F}_2^n$ is finite non-empty with $|A+A| \leq K|A|$, then there exists a subgroup $H$ of ${\bf F}_2^n$ with $|H| \leq |A|$ such that $A$ can be covered by at most $2K^9$ translates of $H$.
 \end{theorem}
 
 \begin{proof}\leanok
   \uses{pfr-9-aux,ruz-cov}
-Apply \Cref{pfr-9-aux} and \Cref{ruz-cov} to get a variant of \Cref{pfr_aux}. The remaining part is the same as \Cref{pfr}.
+Given \Cref{pfr-9-aux'}, the proof is the same as that of \Cref{pfr}.
 \end{proof}

--- a/blueprint/src/chapter/hom_pfr.tex
+++ b/blueprint/src/chapter/hom_pfr.tex
@@ -19,7 +19,7 @@ In particular, $|H| = |H_0| |H_1|$.
 \begin{theorem}[Homomorphism form of PFR]\label{hom-pfr}\lean{homomorphism_pfr}\leanok  Let $f: G \to G'$ be a function, and let $S$ denote the set
 $$ S := \{ f(x+y)-f(x)-f(y): x,y \in G \}.$$
 Then there exists a homomorphism $\phi: G \to G'$ such that
-$$ |\{ f(x) - \phi(x): x \in G \}| \leq |S|^{12}.$$
+$$ |\{ f(x) - \phi(x): x \in G \}| \leq |S|^{10}.$$
 \end{theorem}
 
 \begin{proof}\uses{goursat, pfr_aux-improv}\leanok
@@ -27,12 +27,11 @@ Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have
 $$ A+A \subset \{ (x,f(x)+s): x \in G, s \in S\}$$
-and hence $|A+A| \leq |S| |A|$.  Applying \Cref{pfr_aux-improv}, we may
-find a subspace $H \subset G \times G'$ such that $|H|/ |A| \in [K^{-10},
-K^{10}]$ and $A$ is covered by $c + H$ with $|c| \le |S|^6|A|^{1/2} /
-|H|^{1/2}$. If we let $H_0, H_1$ be as in \Cref{goursat}, this implies
-on taking projections that $G$ is covered by at most $|c|$ translates of
-$H_0$. This implies that
+and hence $|A+A| \leq |S| |A|$.  Applying \Cref{pfr-9-aux'}, we may find a
+subspace $H \subset G \times G'$ such that $|H|/ |A| \in [|S|^{-8}, |S|^{8}]$
+and $A$ is covered by $c + H$ with $|c| \le |S|^5|A|^{1/2} / |H|^{1/2}$. If
+we let $H_0, H_1$ be as in \Cref{goursat}, this implies on taking projections
+that $G$ is covered by at most $|c|$ translates of $H_0$. This implies that
 $$ |c| |H_0| \geq |G|;$$
 since $|H_0| |H_1| = |H|$, we conclude that
 $$ |H_1| \leq |c| |H|/|G| = |c| |H|/|A|.$$
@@ -41,8 +40,8 @@ by at most $|c| |H_1|$ translates of $\{ (x,\phi(x)): x \in G \}$. As $\phi$
 is a homomorphism, each such translate can be written in the form $\{
 (x,\phi(x)+d): x \in G \}$ for some $d \in G'$. Since
 $$
-|c| |H_1| \le |c|^2 \frac{|H|}{|A|} \le \left(|S|^6 \frac{|A|^{1/2}}{|H|^{1/2}}\right)^2 \frac{|H|}{|A|}
-= |S|^{12},
+|c| |H_1| \le |c|^2 \frac{|H|}{|A|} \le \left(|S|^5 \frac{|A|^{1/2}}{|H|^{1/2}}\right)^2 \frac{|H|}{|A|}
+= |S|^{10},
 $$
 the result follows.
 \end{proof}

--- a/examples.lean
+++ b/examples.lean
@@ -1,6 +1,7 @@
 import PFR.ApproxHomPFR
 import PFR.ImprovedPFR
 import PFR.WeakPFR
+import PFR.RhoFunctional
 
 section PFR
 
@@ -12,7 +13,7 @@ variable {G' : Type*} [AddCommGroup G'] [Module (ZMod 2) G'] [Fintype G']
 
 /-- A self-contained version of the PFR conjecture using only Mathlib definitions. -/
 example {A : Set G} {K : ℝ} (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K * Nat.card A) :
-    ∃ (H : AddSubgroup G) (c : Set G),
+    ∃ (H : Submodule (ZMod 2) G) (c : Set G),
       Nat.card c < 2 * K ^ 12 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
   convert PFR_conjecture h₀A hA
   norm_cast
@@ -21,12 +22,22 @@ example {A : Set G} {K : ℝ} (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K 
 
 /-- The improved version -/
 example {A : Set G} {K : ℝ} (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K * Nat.card A) :
-    ∃ (H : AddSubgroup G) (c : Set G),
+    ∃ (H : Submodule (ZMod 2) G) (c : Set G),
       Nat.card c < 2 * K ^ 11 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
   convert PFR_conjecture_improv h₀A hA
   norm_cast
 
 #print axioms PFR_conjecture_improv
+
+/-- The even more improved version -/
+example {A : Set G} {K : ℝ} (h₀A : A.Nonempty) (hA : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : Submodule (ZMod 2) G) (c : Set G),
+      Nat.card c < 2 * K ^ 9 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  convert better_PFR_conjecture h₀A hA
+  norm_cast
+
+#print axioms better_PFR_conjecture
+
 
 /-- The homomorphism version of PFR. -/
 example (f : G → G') (S : Set G') (hS : ∀ x y : G, f (x + y) - f x - f y ∈ S) :


### PR DESCRIPTION
Improve the homomorphism version and approximate homomorphism version of PFR. It's not obvious if PFR 9 also gives an improvement for weak PFR over Z^d as the proof really uses the entropic control, which is not provided by the Kullback-Leibler divergence argument, so I haven't done anything there.