### PR TITLE
bump mathlib

### DIFF
--- a/PFR/BoundingMutual.lean
+++ b/PFR/BoundingMutual.lean
@@ -25,8 +25,12 @@ $$ {\mathcal I} := \bbI[ \bigl(\sum_{i=1}^m X_{i,j}\bigr)_{j =1}^{m}
  $$
  Then ${\mathcal I} \leq 4 m^2 \eta k.$
 -/
-lemma mutual_information_le {G Ωₒ : Type u} [MeasureableFinGroup G] [MeasureSpace Ωₒ] (p : multiRefPackage G Ωₒ) (Ω : Type u) [hΩ: MeasureSpace Ω] (X : ∀ i, Ω → G) (h_indep:
-  iIndepFun (fun _ ↦ by infer_instance) X)
-  (h_min : multiTauMinimizes p (fun _ ↦ Ω) (fun _ ↦ hΩ) X) (Ω' : Type*) [MeasureSpace Ω'] (X': Fin p.m × Fin p.m → Ω' → G) (h_indep': iIndepFun (fun _ ↦ by infer_instance) X') (hperm:
-  ∀ j, ∃ e : Fin p.m ≃ Fin p.m, IdentDistrib (fun ω ↦ (fun i ↦ X' (i, j) ω) ) (fun ω ↦ (fun i ↦ X (e i) ω))) :
-  I[ fun ω ↦ ( fun j ↦ ∑ i, X' (i, j) ω) : fun ω ↦ ( fun i ↦ ∑ j, X' (i, j) ω) | fun ω ↦ ∑ i, ∑ j, X' (i, j) ω ] ≤ 4 * p.m^2 * p.η * D[ X; (fun _ ↦ hΩ)] := sorry
+lemma mutual_information_le {G Ωₒ : Type u} [MeasureableFinGroup G] [MeasureSpace Ωₒ]
+  (p : multiRefPackage G Ωₒ) (Ω : Type u) [hΩ: MeasureSpace Ω] (X : ∀ i, Ω → G)
+  (h_indep : iIndepFun X)
+  (h_min : multiTauMinimizes p (fun _ ↦ Ω) (fun _ ↦ hΩ) X) (Ω' : Type*) [MeasureSpace Ω']
+  (X' : Fin p.m × Fin p.m → Ω' → G) (h_indep': iIndepFun X')
+  (hperm : ∀ j, ∃ e : Fin p.m ≃ Fin p.m, IdentDistrib (fun ω ↦ (fun i ↦ X' (i, j) ω))
+    (fun ω ↦ (fun i ↦ X (e i) ω))) :
+  I[ fun ω ↦ ( fun j ↦ ∑ i, X' (i, j) ω) : fun ω ↦ ( fun i ↦ ∑ j, X' (i, j) ω) |
+    fun ω ↦ ∑ i, ∑ j, X' (i, j) ω ] ≤ 4 * p.m^2 * p.η * D[ X; (fun _ ↦ hΩ)] := sorry

--- a/PFR/Endgame.lean
+++ b/PFR/Endgame.lean
@@ -45,7 +45,7 @@ variable (X₁ X₂ X₁' X₂' : Ω → G)
 
 variable (h₁ : IdentDistrib X₁ X₁') (h₂ : IdentDistrib X₂ X₂')
 
-variable (h_indep : iIndepFun (fun _i => hG) ![X₁, X₂, X₁', X₂'])
+variable (h_indep : iIndepFun ![X₁, X₂, X₁', X₂'])
 
 variable (h_min : tau_minimizes p X₁ X₂)
 
@@ -81,7 +81,7 @@ private lemma hmeas2 {G : Type*} [AddCommGroup G] [Fintype G] [hG : MeasurableSp
 include h_indep hX₁ hX₂ hX₁' hX₂' h₁ in
 /-- The quantity `I_3 = I[V:W|S]` is equal to `I_2`. -/
 lemma I₃_eq [IsProbabilityMeasure (ℙ : Measure Ω)] : I[V : W | S] = I₂ := by
-  have h_indep2 : iIndepFun (fun _ ↦ hG) ![X₁', X₂, X₁, X₂'] := by
+  have h_indep2 : iIndepFun ![X₁', X₂, X₁, X₂'] := by
     exact h_indep.reindex_four_cbad
   have hident : IdentDistrib (fun a (i : Fin 4) => ![X₁, X₂, X₁', X₂'] i a)
     (fun a (j : Fin 4) => ![X₁', X₂, X₁, X₂'] j a) := by
@@ -160,7 +160,7 @@ lemma hU [IsProbabilityMeasure (ℙ : Measure Ω)] : H[U] = H[X₁' + X₂'] :=
 variable {X₁ X₂ X₁' X₂'} in
 include h_indep hX₁ hX₂ hX₁' hX₂' in
 lemma independenceCondition1 :
-    iIndepFun (fun _ ↦ hG) ![X₁, X₂, X₁' + X₂'] :=
+    iIndepFun ![X₁, X₂, X₁' + X₂'] :=
   h_indep.apply_two_last hX₁ hX₂ hX₁' hX₂' measurable_add
 
 include h₁ h₂ h_indep in
@@ -172,31 +172,31 @@ lemma hV [IsProbabilityMeasure (ℙ : Measure Ω)] : H[V] = H[X₁ + X₂'] :=
 include h_indep hX₁ hX₂ hX₁' hX₂' in
 variable {X₁ X₂ X₁' X₂'} in
 lemma independenceCondition2 :
-    iIndepFun (fun _ ↦ hG) ![X₂, X₁, X₁' + X₂'] :=
+    iIndepFun ![X₂, X₁, X₁' + X₂'] :=
   independenceCondition1 hX₂ hX₁ hX₁' hX₂' h_indep.reindex_four_bacd
 
 include h_indep hX₁ hX₂ hX₁' hX₂' in
 variable {X₁ X₂ X₁' X₂'} in
 lemma independenceCondition3 :
-    iIndepFun (fun _ ↦ hG) ![X₁', X₂, X₁ + X₂'] :=
+    iIndepFun ![X₁', X₂, X₁ + X₂'] :=
   independenceCondition1 hX₁' hX₂ hX₁ hX₂' h_indep.reindex_four_cbad
 
 include h_indep hX₁ hX₂ hX₁' hX₂' in
 variable {X₁ X₂ X₁' X₂'} in
 lemma independenceCondition4 :
-    iIndepFun (fun _ ↦ hG) ![X₂, X₁', X₁ + X₂'] :=
+    iIndepFun ![X₂, X₁', X₁ + X₂'] :=
   independenceCondition1 hX₂ hX₁' hX₁ hX₂' h_indep.reindex_four_bcad
 
 include h_indep hX₁ hX₂ hX₁' hX₂' in
 variable {X₁ X₂ X₁' X₂'} in
 lemma independenceCondition5 :
-    iIndepFun (fun _ ↦ hG) ![X₁, X₁', X₂ + X₂'] :=
+    iIndepFun ![X₁, X₁', X₂ + X₂'] :=
   independenceCondition1 hX₁ hX₁' hX₂ hX₂' h_indep.reindex_four_acbd
 
 include h_indep hX₁ hX₂ hX₁' hX₂' in
 variable {X₁ X₂ X₁' X₂'} in
 lemma independenceCondition6 :
-    iIndepFun (fun _ ↦ hG) ![X₂, X₂', X₁' + X₁] :=
+    iIndepFun ![X₂, X₂', X₁' + X₁] :=
   independenceCondition1 hX₂ hX₂' hX₁' hX₁ h_indep.reindex_four_bdca
 
 set_option maxHeartbeats 400000 in
@@ -303,7 +303,7 @@ lemma sum_dist_diff_le [IsProbabilityMeasure (ℙ : Measure Ω)] [Module (ZMod 2
         add_le_add (add_le_add step₁ step₂) step₃
     _ = 3 * H[S ; ℙ] - 3/2 * H[X₁ ; ℙ] -3/2 * H[X₂ ; ℙ] := by ring
 
-  have h_indep' : iIndepFun (fun _i => hG) ![X₁, X₂, X₂', X₁'] := by
+  have h_indep' : iIndepFun ![X₁, X₂, X₂', X₁'] := by
     refine .of_precomp (Equiv.swap (2 : Fin 4) 3).surjective ?_
     convert h_indep using 1
     ext x
@@ -500,7 +500,7 @@ theorem tau_strictly_decreases_aux
     (show Measurable W by fun_prop) (show Measurable S by fun_prop)
   have h1 := sum_condMutual_le p X₁ X₂ X₁' X₂' hX₁ hX₂ hX₁' hX₂' h₁ h₂ h_indep h_min
   have h2 := sum_dist_diff_le p X₁ X₂ X₁' X₂' hX₁ hX₂ hX₁' hX₂' h₁ h₂ h_indep h_min
-  have h_indep' : iIndepFun (fun _i => hG) ![X₁, X₂, X₂', X₁'] := by
+  have h_indep' : iIndepFun ![X₁, X₂, X₂', X₁'] := by
     let σ : Fin 4 ≃ Fin 4 :=
     { toFun := ![0, 1, 3, 2]
       invFun := ![0, 1, 3, 2]

--- a/PFR/Examples.lean
+++ b/PFR/Examples.lean
@@ -173,7 +173,7 @@ example (h1 : IdentDistrib X X') (h2 : IdentDistrib Y Y') : d[X # Y] = d[X' # Y'
 example : d[X # Z] ≤ d[X # Y] + d[Y # Z] := rdist_triangle hX hY hZ
 
 /-- The Kaimanovich-Vershik-Madiman inequality -/
-example (h : iIndepFun (fun _ ↦ hG) ![X, Y, Z]) : H[X + Y + Z] - H[X + Y] ≤ H[Y + Z] - H[Y] :=
+example (h : iIndepFun ![X, Y, Z]) : H[X + Y + Z] - H[X + Y] ≤ H[Y + Z] - H[Y] :=
   kaimanovich_vershik h hX hY hZ
 
 /-- The entropic Balog--Szemeredi--Gowers inequality -/

--- a/PFR/Fibring.lean
+++ b/PFR/Fibring.lean
@@ -87,7 +87,7 @@ variable {G : Type*} [AddCommGroup G] [Fintype G] [hG : MeasurableSpace G]
 variable {Ω : Type*} [mΩ : MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
 
 /-- The conditional Ruzsa Distance step of `sum_of_rdist_eq` -/
-lemma sum_of_rdist_eq_step_condRuzsaDist {Y : Fin 4 → Ω → G} (h_indep : iIndepFun (fun _ : Fin 4 ↦ hG) Y μ)
+lemma sum_of_rdist_eq_step_condRuzsaDist {Y : Fin 4 → Ω → G} (h_indep : iIndepFun Y μ)
   (h_meas : ∀ i, Measurable (Y i)) :
     d[⟨Y 0, Y 2⟩ | Y 0 - Y 2 ; μ # ⟨Y 1, Y 3⟩ | Y 1 - Y 3 ; μ] = d[Y 0 | Y 0 - Y 2 ; μ # Y 1 | Y 1 - Y 3 ; μ] := by
   let Y' : Fin 4 → Ω → G
@@ -149,7 +149,7 @@ lemma sum_of_rdist_eq_step_condMutualInfo {Y : Fin 4 → Ω → G}
 $$d[Y_1-Y_3; Y_2-Y_4] + d[Y_1|Y_1-Y_3; Y_2|Y_2-Y_4] $$
 $$ + I[Y_1-Y_2 : Y_2 - Y_4 | Y_1-Y_2-Y_3+Y_4] = d[Y_1; Y_2] + d[Y_3; Y_4].$$
 -/
-lemma sum_of_rdist_eq (Y : Fin 4 → Ω → G) (h_indep : iIndepFun (fun _ : Fin 4 ↦ hG) Y μ)
+lemma sum_of_rdist_eq (Y : Fin 4 → Ω → G) (h_indep : iIndepFun Y μ)
   (h_meas : ∀ i, Measurable (Y i)) :
     d[Y 0; μ # Y 1; μ] + d[Y 2; μ # Y 3; μ]
       = d[(Y 0) - (Y 2); μ # (Y 1) - (Y 3); μ]
@@ -187,7 +187,7 @@ $$d[Y_1+Y_3; Y_2+Y_4] + d[Y_1|Y_1+Y_3; Y_2|Y_2+Y_4] $$
 $$ + I[Y_1+Y_2 : Y_2 + Y_4 | Y_1+Y_2+Y_3+Y_4] = d[Y_1; Y_2] + d[Y_3; Y_4].$$
 -/
 lemma sum_of_rdist_eq_char_2
-  [Module (ZMod 2) G] (Y : Fin 4 → Ω → G) (h_indep : iIndepFun (fun _ : Fin 4 ↦ hG) Y μ)
+  [Module (ZMod 2) G] (Y : Fin 4 → Ω → G) (h_indep : iIndepFun Y μ)
   (h_meas : ∀ i, Measurable (Y i)) :
     d[Y 0; μ # Y 1; μ] + d[Y 2; μ # Y 3; μ]
       = d[(Y 0) + (Y 2); μ # (Y 1) + (Y 3); μ]
@@ -196,7 +196,7 @@ lemma sum_of_rdist_eq_char_2
   simpa [ZModModule.sub_eq_add] using sum_of_rdist_eq Y h_indep h_meas
 
 lemma sum_of_rdist_eq_char_2' [Module (ZMod 2) G] (X Y X' Y' : Ω → G)
-  (h_indep : iIndepFun (fun _ : Fin 4 ↦ hG) ![X, Y, X', Y'] μ)
+  (h_indep : iIndepFun ![X, Y, X', Y'] μ)
   (hX : Measurable X) (hY : Measurable Y) (hX' : Measurable X') (hY' : Measurable Y') :
   d[X ; μ # Y ; μ] + d[X' ; μ # Y' ; μ]
     = d[X + X' ; μ # Y + Y' ; μ] + d[X | X + X' ; μ # Y | Y + Y' ; μ]

--- a/PFR/FirstEstimate.lean
+++ b/PFR/FirstEstimate.lean
@@ -34,7 +34,7 @@ variable (X₁ X₂ X₁' X₂' : Ω → G)
   (hX₁ : Measurable X₁) (hX₂ : Measurable X₂) (hX₁' : Measurable X₁') (hX₂' : Measurable X₂')
 
 variable (h₁ : IdentDistrib X₁ X₁') (h₂ : IdentDistrib X₂ X₂')
-variable (h_indep : iIndepFun (fun _i => hG) ![X₁, X₂, X₂', X₁'])
+variable (h_indep : iIndepFun ![X₁, X₂, X₂', X₁'])
 variable (h_min : tau_minimizes p X₁ X₂)
 
 /-- `k := d[X₁ # X₂]`, the Ruzsa distance `rdist` between X₁ and X₂. -/

--- a/PFR/ForMathlib/Entropy/Group.lean
+++ b/PFR/ForMathlib/Entropy/Group.lean
@@ -243,7 +243,7 @@ lemma max_entropy_le_entropy_div (hX : Measurable X) (hY : Measurable Y) (h : In
 lemma max_entropy_le_entropy_prod {G : Type*} [Countable G] [hG : MeasurableSpace G]
     [MeasurableSingletonClass G] [CommGroup G] [MeasurableMul₂ G]
     {I : Type*} {s : Finset I} {i₀ : I} (hi₀ : i₀ ∈ s) {X : I → Ω → G} [∀ i, FiniteRange (X i)]
-    (hX : (i : I) → Measurable (X i)) (h_indep : iIndepFun (fun (_ : I) => hG) X μ) :
+    (hX : (i : I) → Measurable (X i)) (h_indep : iIndepFun X μ) :
     H[X i₀ ; μ] ≤ H[∏ i ∈ s, X i ; μ] := by
   have hs : s.Nonempty := ⟨i₀, hi₀⟩
   induction' hs using Finset.Nonempty.cons_induction with i j s Hnot _ Hind

--- a/PFR/ForMathlib/Entropy/RuzsaDist.lean
+++ b/PFR/ForMathlib/Entropy/RuzsaDist.lean
@@ -172,7 +172,7 @@ lemma ProbabilityTheory.IndepFun.rdist_eq [IsFiniteMeasure μ]
 /-- `d[X ; Y] ≤ H[X]/2 + H[Y]/2`. -/
 lemma rdist_le_avg_ent {X : Ω → G} {Y : Ω' → G} [FiniteRange X] [FiniteRange Y] (hX : Measurable X)
     (hY : Measurable Y) (μ : Measure Ω := by volume_tac) (μ' : Measure Ω' := by volume_tac)
-  [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] :
+    [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] :
     d[X ; μ # Y ; μ'] ≤ (H[X ; μ] + H[Y ; μ'])/2 := by
   rcases ProbabilityTheory.independent_copies_finiteRange hX hY μ μ'
     with ⟨ν, X', Y', hprob, hX', hY', h_indep, hidentX, hidentY, hfinX, hfinY⟩
@@ -186,7 +186,7 @@ lemma rdist_le_avg_ent {X : Ω → G} {Y : Ω' → G} [FiniteRange X] [FiniteRan
 /-- Applying an injective homomorphism does not affect Ruzsa distance. -/
 lemma rdist_of_inj {H : Type*} [hH : MeasurableSpace H] [MeasurableSingletonClass H]
   [AddCommGroup H] [Countable H] (hX : Measurable X) (hY : Measurable Y)
-  (φ : G →+ H) (hφ : Injective φ) [IsProbabilityMeasure μ] [IsProbabilityMeasure μ' ]:
+  (φ : G →+ H) (hφ : Injective φ) [IsProbabilityMeasure μ] [IsProbabilityMeasure μ'] :
     d[φ ∘ X ; μ # φ ∘ Y ; μ'] = d[X ; μ # Y ; μ'] := by
     rw [rdist_def, rdist_def]
     congr 2
@@ -1109,7 +1109,7 @@ lemma condRuzsaDist'_of_inj_map' [Module (ZMod 2) G] [IsProbabilityMeasure μ]
   simp [μ']
 
 /-- The **Kaimanovich-Vershik inequality**. `H[X + Y + Z] - H[X + Y] ≤ H[Y + Z] - H[Y]`. -/
-lemma kaimanovich_vershik {X Y Z : Ω → G} (h : iIndepFun (fun _ ↦ hG) ![X, Y, Z] μ)
+lemma kaimanovich_vershik {X Y Z : Ω → G} (h : iIndepFun ![X, Y, Z] μ)
     (hX : Measurable X) (hY : Measurable Y) (hZ : Measurable Z)
     [FiniteRange X] [FiniteRange Z] [FiniteRange Y] :
     H[X + Y + Z ; μ] - H[X + Y ; μ] ≤ H[Y + Z ; μ] - H[Y ; μ] := by
@@ -1141,7 +1141,7 @@ lemma kaimanovich_vershik {X Y Z : Ω → G} (h : iIndepFun (fun _ ↦ hG) ![X, 
     exact h.indepFun_add_right this 2 0 1 (by decide) (by decide)
 
 /-- A version of the **Kaimanovich-Vershik inequality** with some variables negated. -/
-lemma kaimanovich_vershik' {X Y Z : Ω → G} (h : iIndepFun (fun _ ↦ hG) ![X, Y, Z] μ)
+lemma kaimanovich_vershik' {X Y Z : Ω → G} (h : iIndepFun ![X, Y, Z] μ)
     (hX : Measurable X) (hY : Measurable Y) (hZ : Measurable Z)
     [FiniteRange X] [FiniteRange Z] [FiniteRange Y] :
     H[X - (Y + Z) ; μ] - H[X - Y ; μ] ≤ H[Y + Z ; μ] - H[Y ; μ] := by
@@ -1429,7 +1429,7 @@ variable (μ) in
 lemma condRuzsaDist_diff_ofsum_le [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
     {X : Ω → G} {Y Z Z' : Ω' → G}
     (hX : Measurable X) (hY : Measurable Y) (hZ : Measurable Z) (hZ' : Measurable Z')
-    (h : iIndepFun (fun _ ↦ hG) ![Y, Z, Z'] μ')
+    (h : iIndepFun ![Y, Z, Z'] μ')
     [FiniteRange X] [FiniteRange Z] [FiniteRange Y] [FiniteRange Z'] :
     d[X ; μ # Y + Z | Y + Z + Z'; μ'] - d[X ; μ # Y; μ'] ≤
     (H[Y + Z + Z'; μ'] + H[Y + Z; μ'] - H[Y ; μ'] - H[Z' ; μ'])/2 := by

--- a/PFR/ForMathlib/FiniteRange/IdentDistrib.lean
+++ b/PFR/ForMathlib/FiniteRange/IdentDistrib.lean
@@ -84,7 +84,7 @@ lemma independent_copies3_nondep_finiteRange {α : Type u}
     ∃ (A : Type (max u_1 u_2 u_3)) (_ : MeasurableSpace A) (μA : Measure A)
       (X₁' X₂' X₃' : A → α),
     IsProbabilityMeasure μA ∧
-    iIndepFun (fun _ ↦ mS) ![X₁', X₂', X₃'] μA ∧
+    iIndepFun ![X₁', X₂', X₃'] μA ∧
       Measurable X₁' ∧ Measurable X₂' ∧ Measurable X₃' ∧
       IdentDistrib X₁' X₁ μA μ₁ ∧ IdentDistrib X₂' X₂ μA μ₂ ∧ IdentDistrib X₃' X₃ μA μ₃ ∧
       FiniteRange X₁' ∧ FiniteRange X₂' ∧ FiniteRange X₃' := by
@@ -121,7 +121,7 @@ lemma independent_copies4_nondep_finiteRange {α : Type u}
     ∃ (A : Type (max u_1 u_2 u_3 u_4)) (_ : MeasurableSpace A) (μA : Measure A)
       (X₁' X₂' X₃' X₄' : A → α),
     IsProbabilityMeasure μA ∧
-    iIndepFun (fun _ ↦ mS) ![X₁', X₂', X₃', X₄'] μA ∧
+    iIndepFun ![X₁', X₂', X₃', X₄'] μA ∧
       Measurable X₁' ∧ Measurable X₂' ∧ Measurable X₃' ∧ Measurable X₄'
       ∧ IdentDistrib X₁' X₁ μA μ₁ ∧ IdentDistrib X₂' X₂ μA μ₂ ∧ IdentDistrib X₃' X₃ μA μ₃
       ∧ IdentDistrib X₄' X₄ μA μ₄ ∧ FiniteRange X₁' ∧ FiniteRange X₂'

--- a/PFR/ForMathlib/FourVariables.lean
+++ b/PFR/ForMathlib/FourVariables.lean
@@ -8,15 +8,15 @@ namespace ProbabilityTheory.iIndepFun
 variable {Ω : Type*} [MeasureSpace Ω]
   {G : Type*} [hG : MeasurableSpace G]
 
-variable {Z₁ Z₂ Z₃ Z₄ : Ω → G} (h_indep : iIndepFun (fun _i => hG) ![Z₁, Z₂, Z₃, Z₄])
+variable {Z₁ Z₂ Z₃ Z₄ : Ω → G} (h_indep : iIndepFun ![Z₁, Z₂, Z₃, Z₄])
 
 include h_indep
 
 lemma reindex_four_abcd :
-    iIndepFun (fun _ => hG) ![Z₁, Z₂, Z₃, Z₄] := h_indep
+    iIndepFun ![Z₁, Z₂, Z₃, Z₄] := h_indep
 
 lemma reindex_four_abdc :
-    iIndepFun (fun _ => hG) ![Z₁, Z₂, Z₄, Z₃] := by
+    iIndepFun ![Z₁, Z₂, Z₄, Z₃] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![0, 1, 3, 2]
     invFun := ![0, 1, 3, 2]
@@ -28,7 +28,7 @@ lemma reindex_four_abdc :
   fin_cases i <;> rfl
 
 lemma reindex_four_acbd :
-    iIndepFun (fun _ => hG) ![Z₁, Z₃, Z₂, Z₄] := by
+    iIndepFun ![Z₁, Z₃, Z₂, Z₄] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![0, 2, 1, 3]
     invFun := ![0, 2, 1, 3]
@@ -40,7 +40,7 @@ lemma reindex_four_acbd :
   fin_cases i <;> rfl
 
 lemma reindex_four_acdb :
-    iIndepFun (fun _ => hG) ![Z₁, Z₃, Z₄, Z₂] := by
+    iIndepFun ![Z₁, Z₃, Z₄, Z₂] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![0, 2, 3, 1]
     invFun := ![0, 3, 1, 2]
@@ -52,7 +52,7 @@ lemma reindex_four_acdb :
   fin_cases i <;> rfl
 
 lemma reindex_four_adbc :
-    iIndepFun (fun _ => hG) ![Z₁, Z₄, Z₂, Z₃] := by
+    iIndepFun ![Z₁, Z₄, Z₂, Z₃] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![0, 3, 1, 2]
     invFun := ![0, 2, 3, 1]
@@ -64,7 +64,7 @@ lemma reindex_four_adbc :
   fin_cases i <;> rfl
 
 lemma reindex_four_adcb :
-    iIndepFun (fun _ => hG) ![Z₁, Z₄, Z₃, Z₂] := by
+    iIndepFun ![Z₁, Z₄, Z₃, Z₂] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![0, 3, 2, 1]
     invFun := ![0, 3, 2, 1]
@@ -76,7 +76,7 @@ lemma reindex_four_adcb :
   fin_cases i <;> rfl
 
 lemma reindex_four_bacd :
-    iIndepFun (fun _ => hG) ![Z₂, Z₁, Z₃, Z₄] := by
+    iIndepFun ![Z₂, Z₁, Z₃, Z₄] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![1, 0, 2, 3]
     invFun := ![1, 0, 2, 3]
@@ -88,7 +88,7 @@ lemma reindex_four_bacd :
   fin_cases i <;> rfl
 
 lemma reindex_four_badc :
-    iIndepFun (fun _ => hG) ![Z₂, Z₁, Z₄, Z₃] := by
+    iIndepFun ![Z₂, Z₁, Z₄, Z₃] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![1, 0, 3, 2]
     invFun := ![1, 0, 3, 2]
@@ -100,7 +100,7 @@ lemma reindex_four_badc :
   fin_cases i <;> rfl
 
 lemma reindex_four_bcad :
-    iIndepFun (fun _ => hG) ![Z₂, Z₃, Z₁, Z₄] := by
+    iIndepFun ![Z₂, Z₃, Z₁, Z₄] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![1, 2, 0, 3]
     invFun := ![2, 0, 1, 3]
@@ -112,7 +112,7 @@ lemma reindex_four_bcad :
   fin_cases i <;> rfl
 
 lemma reindex_four_bcda :
-    iIndepFun (fun _ => hG) ![Z₂, Z₃, Z₄, Z₁] := by
+    iIndepFun ![Z₂, Z₃, Z₄, Z₁] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![1, 2, 3, 0]
     invFun := ![3, 0, 1, 2]
@@ -124,7 +124,7 @@ lemma reindex_four_bcda :
   fin_cases i <;> rfl
 
 lemma reindex_four_bdac :
-    iIndepFun (fun _ => hG) ![Z₂, Z₄, Z₁, Z₃] := by
+    iIndepFun ![Z₂, Z₄, Z₁, Z₃] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![1, 3, 0, 2]
     invFun := ![2, 0, 3, 1]
@@ -136,7 +136,7 @@ lemma reindex_four_bdac :
   fin_cases i <;> rfl
 
 lemma reindex_four_bdca :
-    iIndepFun (fun _ => hG) ![Z₂, Z₄, Z₃, Z₁] := by
+    iIndepFun ![Z₂, Z₄, Z₃, Z₁] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![1, 3, 2, 0]
     invFun := ![3, 0, 2, 1]
@@ -148,7 +148,7 @@ lemma reindex_four_bdca :
   fin_cases i <;> rfl
 
 lemma reindex_four_cadb :
-    iIndepFun (fun _ => hG) ![Z₃, Z₁, Z₄, Z₂] := by
+    iIndepFun ![Z₃, Z₁, Z₄, Z₂] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![2, 0, 3, 1]
     invFun := ![1, 3, 0, 2]
@@ -160,7 +160,7 @@ lemma reindex_four_cadb :
   fin_cases i <;> rfl
 
 lemma reindex_four_cabd :
-    iIndepFun (fun _ => hG) ![Z₃, Z₁, Z₂, Z₄] := by
+    iIndepFun ![Z₃, Z₁, Z₂, Z₄] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![2, 0, 1, 3]
     invFun := ![1, 2, 0, 3]
@@ -172,7 +172,7 @@ lemma reindex_four_cabd :
   fin_cases i <;> rfl
 
 lemma reindex_four_cbad :
-    iIndepFun (fun _ => hG) ![Z₃, Z₂, Z₁, Z₄] := by
+    iIndepFun ![Z₃, Z₂, Z₁, Z₄] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![2, 1, 0, 3]
     invFun := ![2, 1, 0, 3]
@@ -184,7 +184,7 @@ lemma reindex_four_cbad :
   fin_cases i <;> rfl
 
 lemma reindex_four_dabc :
-    iIndepFun (fun _ => hG) ![Z₄, Z₁, Z₂, Z₃] := by
+    iIndepFun ![Z₄, Z₁, Z₂, Z₃] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![3, 0, 1, 2]
     invFun := ![1, 2, 3, 0]
@@ -196,7 +196,7 @@ lemma reindex_four_dabc :
   fin_cases i <;> rfl
 
 lemma reindex_four_dacb :
-    iIndepFun (fun _ => hG) ![Z₄, Z₁, Z₃, Z₂] := by
+    iIndepFun ![Z₄, Z₁, Z₃, Z₂] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![3, 0, 2, 1]
     invFun := ![1, 3, 2, 0]
@@ -208,7 +208,7 @@ lemma reindex_four_dacb :
   fin_cases i <;> rfl
 
 lemma reindex_four_dbac :
-    iIndepFun (fun _ => hG) ![Z₄, Z₂, Z₁, Z₃] := by
+    iIndepFun ![Z₄, Z₂, Z₁, Z₃] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![3, 1, 0, 2]
     invFun := ![2, 1, 3, 0]
@@ -220,7 +220,7 @@ lemma reindex_four_dbac :
   fin_cases i <;> rfl
 
 lemma reindex_four_dbca :
-    iIndepFun (fun _ => hG) ![Z₄, Z₂, Z₃, Z₁] := by
+    iIndepFun ![Z₄, Z₂, Z₃, Z₁] := by
   let σ : Fin 4 ≃ Fin 4 :=
   { toFun := ![3, 1, 2, 0]
     invFun := ![3, 1, 2, 0]
@@ -254,7 +254,7 @@ attribute [local instance] fintype_kappa in
 lemma apply_two_last
     (hZ₁ : Measurable Z₁) (hZ₂ : Measurable Z₂) (hZ₃ : Measurable Z₃) (hZ₄ : Measurable Z₄)
     {phi : G → G → G} (hphi : Measurable phi.uncurry) :
-    iIndepFun (fun _ ↦ hG) ![Z₁, Z₂, (fun ω ↦ phi (Z₃ ω) (Z₄ ω))] := by
+    iIndepFun ![Z₁, Z₂, (fun ω ↦ phi (Z₃ ω) (Z₄ ω))] := by
   -- deduce from the assumption the independence of `Z₁`, `Z₂` and `(Z₃, Z₄)`.
   have T := (h_indep.precomp κ_equiv.injective).pi' (m := fun _ _ ↦ hG) ?_; swap
   · rintro ⟨i, j⟩; fin_cases i <;> fin_cases j <;> assumption

--- a/PFR/ForMathlib/ThreeVariables.lean
+++ b/PFR/ForMathlib/ThreeVariables.lean
@@ -9,15 +9,15 @@ namespace ProbabilityTheory.iIndepFun
 variable {Ω : Type*} [MeasureSpace Ω]
   {G : Type*} [hG : MeasurableSpace G]
 
-variable {Z₁ Z₂ Z₃ : Ω → G} (h_indep : iIndepFun (fun _i => hG) ![Z₁, Z₂, Z₃])
+variable {Z₁ Z₂ Z₃ : Ω → G} (h_indep : iIndepFun ![Z₁, Z₂, Z₃])
 
 include h_indep
 
 lemma reindex_three_abc :
-    iIndepFun (fun _ => hG) ![Z₁, Z₂, Z₃] := h_indep
+    iIndepFun ![Z₁, Z₂, Z₃] := h_indep
 
 lemma reindex_three_acb :
-    iIndepFun (fun _ => hG) ![Z₁, Z₃, Z₂] := by
+    iIndepFun ![Z₁, Z₃, Z₂] := by
   let σ : Fin 3 ≃ Fin 3 :=
   { toFun := ![0, 2, 1]
     invFun := ![0, 2, 1]
@@ -29,7 +29,7 @@ lemma reindex_three_acb :
   fin_cases i <;> rfl
 
 lemma reindex_three_bac :
-    iIndepFun (fun _ => hG) ![Z₂, Z₁, Z₃] := by
+    iIndepFun ![Z₂, Z₁, Z₃] := by
   let σ : Fin 3 ≃ Fin 3 :=
   { toFun := ![1, 0, 2]
     invFun := ![1, 0, 2]
@@ -41,7 +41,7 @@ lemma reindex_three_bac :
   fin_cases i <;> rfl
 
 lemma reindex_three_bca :
-    iIndepFun (fun _ => hG) ![Z₂, Z₃, Z₁] := by
+    iIndepFun ![Z₂, Z₃, Z₁] := by
   let σ : Fin 3 ≃ Fin 3 :=
   { toFun := ![1, 2, 0]
     invFun := ![2, 0, 1]
@@ -53,7 +53,7 @@ lemma reindex_three_bca :
   fin_cases i <;> rfl
 
 lemma reindex_three_cab :
-    iIndepFun (fun _ => hG) ![Z₃, Z₁, Z₂] := by
+    iIndepFun ![Z₃, Z₁, Z₂] := by
   let σ : Fin 3 ≃ Fin 3 :=
   { toFun := ![2, 0, 1]
     invFun := ![1, 2, 0]
@@ -65,7 +65,7 @@ lemma reindex_three_cab :
   fin_cases i <;> rfl
 
 lemma reindex_three_cba :
-    iIndepFun (fun _ => hG) ![Z₃, Z₂, Z₁] := by
+    iIndepFun ![Z₃, Z₂, Z₁] := by
   let σ : Fin 3 ≃ Fin 3 :=
   { toFun := ![2, 1, 0]
     invFun := ![2, 1, 0]

--- a/PFR/ImprovedPFR.lean
+++ b/PFR/ImprovedPFR.lean
@@ -24,7 +24,7 @@ variable (Y : Ω₀ → G) (hY : Measurable Y)
 variable (Z₁ Z₂ Z₃ Z₄ : Ω → G)
   (hZ₁ : Measurable Z₁) (hZ₂ : Measurable Z₂) (hZ₃ : Measurable Z₃) (hZ₄ : Measurable Z₄)
 
-variable (h_indep : iIndepFun (fun _i => hG) ![Z₁, Z₂, Z₃, Z₄])
+variable (h_indep : iIndepFun ![Z₁, Z₂, Z₃, Z₄])
 
 local notation3 "Sum" => Z₁ + Z₂ + Z₃ + Z₄
 
@@ -268,7 +268,7 @@ variable {X₁ X₂ X₁' X₂' : Ω → G}
 
 variable (h₁ : IdentDistrib X₁ X₁') (h₂ : IdentDistrib X₂ X₂')
 
-variable (h_indep : iIndepFun (fun _i => hG) ![X₁, X₂, X₂', X₁'])
+variable (h_indep : iIndepFun ![X₁, X₂, X₂', X₁'])
 
 variable (h_min : tau_minimizes p X₁ X₂)
 

--- a/PFR/Mathlib/Probability/IdentDistrib.lean
+++ b/PFR/Mathlib/Probability/IdentDistrib.lean
@@ -252,8 +252,7 @@ lemma independent_copies' {I : Type u} [Fintype I] {α : I → Type u'}
     [mΩ : ∀ i : I, MeasurableSpace (Ω i)] (X : ∀ i : I, Ω i → α i) (hX : ∀ i : I, Measurable (X i))
     (μ : ∀ i : I, Measure (Ω i)) [∀ i, IsProbabilityMeasure (μ i)] :
     ∃ (A : Type (max u v)) (_ : MeasurableSpace A) (μA : Measure A) (X' : ∀ i, A → α i),
-    IsProbabilityMeasure μA ∧
-    iIndepFun mS X' μA ∧
+    IsProbabilityMeasure μA ∧ iIndepFun X' μA ∧
     ∀ i : I, Measurable (X' i) ∧ IdentDistrib (X' i) (X i) μA (μ i) := by
   refine ⟨Π i, Ω i, inferInstance, .pi μ, fun i ↦ X i ∘ eval i, inferInstance, ?_, fun i ↦ ⟨?_, ?_⟩⟩
   · rw [iIndepFun_iff]
@@ -276,8 +275,7 @@ lemma independent_copies3_nondep {α : Type u}
     (μ₁ : Measure Ω₁) (μ₂ : Measure Ω₂) (μ₃ : Measure Ω₃)
     [hμ₁ : IsProbabilityMeasure μ₁] [hμ₂ : IsProbabilityMeasure μ₂] [hμ₃ : IsProbabilityMeasure μ₃] :
     ∃ (A : Type (max u_1 u_2 u_3)) (_ : MeasurableSpace A) (μA : Measure A) (X₁' X₂' X₃' : A → α),
-      IsProbabilityMeasure μA ∧
-      iIndepFun (fun _ ↦ mS) ![X₁', X₂', X₃'] μA ∧
+      IsProbabilityMeasure μA ∧ iIndepFun ![X₁', X₂', X₃'] μA ∧
       Measurable X₁' ∧ Measurable X₂' ∧ Measurable X₃' ∧
       IdentDistrib X₁' X₁ μA μ₁ ∧ IdentDistrib X₂' X₂ μA μ₂ ∧ IdentDistrib X₃' X₃ μA μ₃ := by
   let Ω₁' : Type (max u_1 u_2 u_3) := ULift.{max u_2 u_3} Ω₁
@@ -324,8 +322,7 @@ lemma independent_copies4_nondep {α : Type u}
     [hμ₃ : IsProbabilityMeasure μ₃] [hμ₄ : IsProbabilityMeasure μ₄] :
     ∃ (A : Type (max u_1 u_2 u_3 u_4)) (_ : MeasurableSpace A) (μA : Measure A)
       (X₁' X₂' X₃' X₄' : A → α),
-    IsProbabilityMeasure μA ∧
-    iIndepFun (fun _ ↦ mS) ![X₁', X₂', X₃', X₄'] μA ∧
+    IsProbabilityMeasure μA ∧ iIndepFun ![X₁', X₂', X₃', X₄'] μA ∧
     Measurable X₁' ∧ Measurable X₂' ∧ Measurable X₃' ∧ Measurable X₄' ∧
     IdentDistrib X₁' X₁ μA μ₁ ∧ IdentDistrib X₂' X₂ μA μ₂ ∧
     IdentDistrib X₃' X₃ μA μ₃ ∧ IdentDistrib X₄' X₄ μA μ₄ := by

--- a/PFR/Mathlib/Probability/Independence/Basic.lean
+++ b/PFR/Mathlib/Probability/Independence/Basic.lean
@@ -20,7 +20,7 @@ variable {Ω ι ι' : Type*} [MeasurableSpace Ω] {α β : ι → Type*}
 
 variable (i : ι) [Inv (α i)] [MeasurableInv (α i)] [DecidableEq ι] in
 @[to_additive]
-lemma iIndepFun.inv (h : iIndepFun n f μ) : iIndepFun n (update f i (f i)⁻¹) μ := by
+lemma iIndepFun.inv (h : iIndepFun f μ) : iIndepFun (update f i (f i)⁻¹) μ := by
   convert h.comp (update (fun _ ↦ id) i (·⁻¹)) _ with j
   · by_cases hj : j = i
     · subst hj; ext x; simp
@@ -35,8 +35,8 @@ finite index sets, then the tuples formed by `f i` for `i ∈ S j` are mutually 
 when seen as a family indexed by `J`. -/
 lemma iIndepFun.finsets {f : ∀ i, Ω → β i} {J : Type*} [Fintype J]
     (S : J → Finset ι) (h_disjoint : Set.PairwiseDisjoint Set.univ S)
-    (hf_Indep : iIndepFun m f μ) (hf_meas : ∀ i, Measurable (f i)) :
-    iIndepFun (fun _ ↦ pi) (fun (j : J) ↦ fun a (i : S j) ↦ f i a) μ :=
+    (hf_Indep : iIndepFun f μ) (hf_meas : ∀ i, Measurable (f i)) :
+    iIndepFun (fun (j : J) ↦ fun a (i : S j) ↦ f i a) μ :=
   Kernel.iIndepFun.finsets S h_disjoint hf_Indep hf_meas
 
 /-- If `f` is a family of mutually independent random variables, `(S j)ⱼ` are pairwise disjoint
@@ -45,10 +45,10 @@ measurable space `γ j`, then the family of random variables formed by `φ j (f 
 indexed by `J` is iIndep. -/
 lemma iIndepFun.finsets_comp {f : ∀ i, Ω → β i} {J : Type*} [Fintype J]
     (S : J → Finset ι) (h_disjoint : Set.PairwiseDisjoint Set.univ S)
-    (hf_Indep : iIndepFun m f μ) (hf_meas : ∀ i, Measurable (f i))
+    (hf_Indep : iIndepFun f μ) (hf_meas : ∀ i, Measurable (f i))
     {γ : J → Type*} {mγ : ∀ j, MeasurableSpace (γ j)}
     (φ : (j : J) → ((i : S j) → β i) → γ j) (hφ : ∀ j, Measurable (φ j)) :
-    iIndepFun mγ (fun (j : J) ↦ fun a ↦ φ j (fun (i : S j) ↦ f i a)) μ :=
+    iIndepFun (fun (j : J) ↦ fun a ↦ φ j (fun (i : S j) ↦ f i a)) μ :=
   Kernel.iIndepFun.finsets_comp S h_disjoint hf_Indep hf_meas γ φ hφ
 
 end iIndepFun
@@ -102,7 +102,7 @@ lemma IndepFun.comp_right {i : Ω' → Ω} (hi : MeasurableEmbedding i) (hi' : �
 -- Same as `iIndepFun_iff` except that the function `f'` returns measurable sets even on junk values
 lemma iIndepFun_iff' [MeasurableSpace Ω] {β : ι → Type*}
     (m : ∀ i, MeasurableSpace (β i)) (f : ∀ i, Ω → β i) (μ : Measure Ω) :
-    iIndepFun m f μ ↔ ∀ (s : Finset ι) ⦃f' : ι → Set Ω⦄
+    iIndepFun f μ ↔ ∀ (s : Finset ι) ⦃f' : ι → Set Ω⦄
       (_hf' : ∀ i, MeasurableSet[(m i).comap (f i)] (f' i)),
       μ (⋂ i ∈ s, f' i) = ∏ i ∈ s, μ (f' i) := by
   classical
@@ -137,7 +137,7 @@ theorem indepFun_iff_map_prod_eq_prod_map_map'
 theorem iIndepFun_iff_pi_map_eq_map {ι : Type*} {β : ι → Type*} [Fintype ι]
     (f : ∀ x : ι, Ω → β x) [m : ∀ x : ι, MeasurableSpace (β x)]
     [IsProbabilityMeasure μ] (hf : ∀ (x : ι), Measurable (f x)) :
-    iIndepFun m f μ ↔ Measure.pi (fun i ↦ μ.map (f i)) = μ.map (fun ω i ↦ f i ω) := by
+    iIndepFun f μ ↔ Measure.pi (fun i ↦ μ.map (f i)) = μ.map (fun ω i ↦ f i ω) := by
   classical
   rw [iIndepFun_iff_measure_inter_preimage_eq_mul]
   have h₀ {h : ∀ i, Set (β i)} (hm : ∀ (i : ι), MeasurableSet (h i)) :
@@ -200,8 +200,8 @@ variable {ι : Type*} {κ : ι → Type*} [∀ i, Fintype (κ i)]
 `i ↦ (f i j)ⱼ` is independent. -/
 lemma iIndepFun.pi
     (f_meas : ∀ i j, Measurable (f i j))
-    (hf : iIndepFun (fun ij : Σ i, κ i ↦ m ij.1 ij.2) (fun ij : Σ i, κ i ↦ f ij.1 ij.2) μ) :
-    iIndepFun (fun _ ↦ MeasurableSpace.pi) (fun i ω j ↦ f i j ω) μ := by
+    (hf : iIndepFun (fun ij : Σ i, κ i ↦ f ij.1 ij.2) μ) :
+    iIndepFun (fun i ω j ↦ f i j ω) μ := by
   let F i ω j := f i j ω
   let M (i : ι):= MeasurableSpace.pi (m := m i)
   let πβ (i : ι) := Set.pi Set.univ '' Set.pi Set.univ fun j => { s | MeasurableSet[m i j] s }
@@ -261,17 +261,17 @@ lemma iIndepFun.pi
 `i ↦ (f i j)ⱼ` is independent. -/
 lemma iIndepFun.pi' {f : ∀ ij : (Σ i, κ i), Ω → α ij.1 ij.2 }
     (f_meas : ∀ i, Measurable (f i))
-    (hf : iIndepFun (fun ij : Σ i, κ i ↦ m ij.1 ij.2) f μ) :
-    iIndepFun (fun _i ↦ MeasurableSpace.pi) (fun i ω ↦ (fun j ↦ f ⟨i, j⟩ ω)) μ :=
+    (hf : iIndepFun f μ) :
+    iIndepFun (fun i ω ↦ (fun j ↦ f ⟨i, j⟩ ω)) μ :=
   iIndepFun.pi (fun _ _ ↦ f_meas _) hf
 
 variable {ι ι' : Type*} {α : ι → Type*}
     {n : (i : ι) → MeasurableSpace (α i)} {f : (i : ι) → Ω → α i}
 
 lemma iIndepFun.prod {hf : ∀ (i : ι), Measurable (f i)} {ST : ι' → Finset ι}
-    (hS : Pairwise (Disjoint on ST)) (h : iIndepFun n f μ) :
+    (hS : Pairwise (Disjoint on ST)) (h : iIndepFun f μ) :
     let β := fun k ↦ Π i : ST k, α i
-    iIndepFun (β := β) (fun _ ↦ MeasurableSpace.pi) (fun (k : ι') (x : Ω) (i : ST k) ↦ f i x) μ := by
+    iIndepFun (β := β) (fun (k : ι') (x : Ω) (i : ST k) ↦ f i x) μ := by
   let g : (i : ι') × ST i → ι := Subtype.val ∘' (Sigma.snd (α := ι'))
   have hg : Injective g := by
     intro x y hxy
@@ -307,7 +307,7 @@ theorem EventuallyEq.finite_iInter {ι : Type*} {α : Type u_2} {l : Filter α} 
 /-- TODO: a kernel version of this theorem-/
 theorem iIndepFun.ae_eq {ι : Type*} {β : ι → Type*}
     {m : ∀ i, MeasurableSpace (β i)} {f g : ∀ i, Ω → β i}
-    (hf_Indep : iIndepFun m f μ) (hfg : ∀ i, f i =ᵐ[μ] g i) : iIndepFun m g μ := by
+    (hf_Indep : iIndepFun f μ) (hfg : ∀ i, f i =ᵐ[μ] g i) : iIndepFun g μ := by
   rw [iIndepFun_iff_iIndep, iIndep_iff] at hf_Indep ⊢
   intro s E H
   have (i : ι) : ∃ E' : Set Ω, i ∈ s → MeasurableSet[MeasurableSpace.comap (f i) (m i)] E' ∧ E' =ᵐ[μ] E i := by

--- a/PFR/Mathlib/Probability/Independence/Kernel.lean
+++ b/PFR/Mathlib/Probability/Independence/Kernel.lean
@@ -18,8 +18,8 @@ finite index sets, then the tuples formed by `f i` for `i ∈ S j` are mutually 
 when seen as a family indexed by `J`. -/
 lemma iIndepFun.finsets {J : Type*} [Fintype J]
     (S : J → Finset ι) (h_disjoint : Set.PairwiseDisjoint Set.univ S)
-    (hf_Indep : iIndepFun m f κ μ) (hf_meas : ∀ i, Measurable (f i)) :
-    iIndepFun (fun _ ↦ pi) (fun (j : J) ↦ fun a (i : S j) ↦ f i a) κ μ := by
+    (hf_Indep : iIndepFun f κ μ) (hf_meas : ∀ i, Measurable (f i)) :
+    iIndepFun (fun (j : J) ↦ fun a (i : S j) ↦ f i a) κ μ := by
   set F := fun (j : J) ↦ fun a (i : S j) ↦ f i a
   let M (j : J) := pi (m := fun (i : S j) ↦ m i)
   let πβ (j : J) := Set.pi Set.univ '' Set.pi Set.univ fun (i : S j) => { s | MeasurableSet[m i] s }
@@ -154,10 +154,10 @@ measurable space `γ j`, then the family of random variables formed by `φ j (f 
 indexed by `J` is iIndep. -/
 lemma iIndepFun.finsets_comp {J : Type*} [Fintype J]
     (S : J → Finset ι) (h_disjoint : Set.PairwiseDisjoint Set.univ S)
-    (hf_Indep : iIndepFun m f κ μ) (hf_meas : ∀ i, Measurable (f i))
+    (hf_Indep : iIndepFun f κ μ) (hf_meas : ∀ i, Measurable (f i))
     (γ : J → Type*) {mγ : ∀ j, MeasurableSpace (γ j)}
     (φ : (j : J) → ((i : S j) → β i) → γ j) (hφ : ∀ j, Measurable (φ j)) :
-    iIndepFun mγ (fun (j : J) ↦ fun a ↦ φ j (fun (i : S j) ↦ f i a)) κ μ :=
+    iIndepFun (fun (j : J) ↦ fun a ↦ φ j (fun (i : S j) ↦ f i a)) κ μ :=
   (Kernel.iIndepFun.finsets S h_disjoint hf_Indep hf_meas).comp φ hφ
 
 end iIndepFun

--- a/PFR/MoreRuzsaDist.lean
+++ b/PFR/MoreRuzsaDist.lean
@@ -356,7 +356,7 @@ The spelling here is tentative.
 Feel free to modify it to make the proof easier, or the application easier. -/
 lemma kvm_ineq_I {I : Type*} {i₀ : I} {s : Finset I} (hs : ¬ i₀ ∈ s)
     {Y : I → Ω → G} [∀ i, FiniteRange (Y i)] (hY : (i : I) → Measurable (Y i))
-    (h_indep : iIndepFun (fun (_ : I) => hG) Y μ) :
+    (h_indep : iIndepFun Y μ) :
     H[Y i₀ + ∑ i ∈ s, Y i ; μ] - H[Y i₀ ; μ] ≤ ∑ i ∈ s, (H[Y i₀ + Y i ; μ] - H[Y i₀ ; μ]) := by
   classical
   induction s using Finset.induction_on with
@@ -379,7 +379,7 @@ lemma kvm_ineq_I {I : Type*} {i₀ : I} {s : Finset I} (hs : ¬ i₀ ∈ s)
       | 1 => fun Ys ↦ Ys ⟨i₀, by simp [S]⟩
       | 2 => fun Ys ↦ Ys ⟨i, by simp [S]⟩
     have hφ : (j : J) → Measurable (φ j) := fun j ↦ .of_discrete
-    have h_ind : iIndepFun (fun _ ↦ hG) ![∑ j ∈ s, Y j, Y i₀, Y i] μ := by
+    have h_ind : iIndepFun ![∑ j ∈ s, Y j, Y i₀, Y i] μ := by
       convert iIndepFun.finsets_comp S h_dis h_indep hY φ hφ with j x
       fin_cases j <;> simp [φ, (s.sum_attach _).symm]
     have measSum : Measurable (∑ j ∈ s, Y j) := by
@@ -397,7 +397,7 @@ lemma kvm_ineq_I {I : Type*} {i₀ : I} {s : Finset I} (hs : ¬ i₀ ∈ s)
 then `d[Y i₀; μ # ∑ i ∈ s, Y i; μ] ≤ 2 * ∑ i ∈ s, d[Y i₀; μ # Y i; μ]`.-/
 lemma kvm_ineq_II {I : Type*} {i₀ : I} {s : Finset I} (hs : ¬ i₀ ∈ s)
     (hs' : Finset.Nonempty s) {Y : I → Ω → G} [∀ i, FiniteRange (Y i)]
-    (hY : (i : I) → Measurable (Y i)) (h_indep : iIndepFun (fun (_ : I) => hG) Y μ) :
+    (hY : (i : I) → Measurable (Y i)) (h_indep : iIndepFun Y μ) :
     d[Y i₀; μ # ∑ i ∈ s, Y i; μ] ≤ 2 * ∑ i ∈ s, d[Y i₀; μ # Y i; μ] := by
   classical
   have : IsProbabilityMeasure μ := h_indep.isProbabilityMeasure
@@ -474,7 +474,7 @@ lemma kvm_ineq_II {I : Type*} {i₀ : I} {s : Finset I} (hs : ¬ i₀ ∈ s)
 
 lemma kvm_ineq_III_aux {X Y Z : Ω → G} [FiniteRange X] [FiniteRange Y]
     [FiniteRange Z] (hX : Measurable X) (hY : Measurable Y) (hZ : Measurable Z)
-    (h_indep : iIndepFun (fun _ ↦ hG) ![X, Y, Z] μ) :
+    (h_indep : iIndepFun ![X, Y, Z] μ) :
     d[X; μ # Y + Z; μ] ≤ d[X; μ # Y; μ] + (2 : ℝ)⁻¹ * (H[Y + Z; μ] - H[Y; μ]) := by
   have : IsProbabilityMeasure μ := h_indep.isProbabilityMeasure
   have h_indep1 : IndepFun X (Y + Z) μ := by
@@ -493,7 +493,7 @@ then `d[Y i₀, ∑ i, Y i] ≤ d[Y i₀, Y i₁] + 2⁻¹ * (H[∑ i, Y i] - H[
 lemma kvm_ineq_III {I : Type*} {i₀ i₁ : I} {s : Finset I}
     (hs₀ : ¬ i₀ ∈ s) (hs₁ : ¬ i₁ ∈ s) (h01 : i₀ ≠ i₁)
     (Y : I → Ω → G) [∀ i, FiniteRange (Y i)]
-    (hY : ∀ i, Measurable (Y i)) (h_indep : iIndepFun (fun _ ↦ hG) Y μ) :
+    (hY : ∀ i, Measurable (Y i)) (h_indep : iIndepFun Y μ) :
     d[Y i₀; μ # Y i₁ + ∑ i ∈ s, Y i; μ]
       ≤ d[Y i₀; μ # Y i₁; μ] + (2 : ℝ)⁻¹ * (H[Y i₁ + ∑ i ∈ s, Y i; μ] - H[Y i₁; μ]) := by
   let J := Fin 3
@@ -510,7 +510,7 @@ lemma kvm_ineq_III {I : Type*} {i₀ i₁ : I} {s : Finset I}
     | 1 => fun Ys ↦ Ys ⟨i₁, by simp [S]⟩
     | 2 => fun Ys ↦ ∑ i : s, Ys ⟨i.1, i.2⟩
   have hφ : (j : J) → Measurable (φ j) := fun j ↦ .of_discrete
-  have h_indep' : iIndepFun (fun _ ↦ hG) ![Y i₀, Y i₁, ∑ i ∈ s, Y i] μ := by
+  have h_indep' : iIndepFun ![Y i₀, Y i₁, ∑ i ∈ s, Y i] μ := by
     convert iIndepFun.finsets_comp S h_dis h_indep hY φ hφ with j x
     fin_cases j <;> simp [φ, (s.sum_attach _).symm]
   exact kvm_ineq_III_aux (hY i₀) (hY i₁) (by fun_prop) h_indep'
@@ -522,7 +522,7 @@ open Classical in
 function, then `H[∑ j, Y j] ≤ H[∑ i, X i] + ∑ j, H[Y j - X f(j)] - H[X_{f(j)}]`.-/
 lemma ent_of_sum_le_ent_of_sum [IsProbabilityMeasure μ] {I : Type*} {s t : Finset I} (hdisj : Disjoint s t)
     (hs : Finset.Nonempty s) (ht : Finset.Nonempty t) (X : I → Ω → G) (hX : (i : I) → Measurable (X i))
-    (hX' : (i : I) → FiniteRange (X i)) (h_indep : iIndepFun (fun (i : I) ↦ hG) X μ) (f : I → I)
+    (hX' : (i : I) → FiniteRange (X i)) (h_indep : iIndepFun X μ) (f : I → I)
     (hf : Finset.image f t ⊆ s) :
     H[∑ i ∈ t, X i; μ] ≤ H[∑ i ∈ s, X i; μ] + ∑ i ∈ t, (H[X i - X (f i); μ] - H[X (f i); μ]) := by
   sorry
@@ -531,7 +531,7 @@ lemma ent_of_sum_le_ent_of_sum [IsProbabilityMeasure μ] {I : Type*} {s t : Fins
 and let `a` be an integer. Then `H[X - (a+1)Y] ≤ H[X - aY] + H[X - Y - X'] - H[X]` -/
 lemma ent_of_sub_smul {Y : Ω → G} {X' : Ω → G} [FiniteRange X] [FiniteRange Y] [FiniteRange X']
     [IsProbabilityMeasure μ] (hX : Measurable X) (hY : Measurable Y) (hX' : Measurable X')
-    (h_indep : iIndepFun (fun _ ↦ hG) ![X, Y, X'] μ) (hident : IdentDistrib X X' μ μ) {a : ℤ} :
+    (h_indep : iIndepFun ![X, Y, X'] μ) (hident : IdentDistrib X X' μ μ) {a : ℤ} :
     H[X - (a+1) • Y; μ] ≤ H[X - a • Y; μ] + H[X - Y - X'; μ] - H[X; μ] := by
   rw [add_smul, one_smul, add_comm, sub_add_eq_sub_sub]
   have iX'Y : IndepFun X' Y μ := h_indep.indepFun (show 2 ≠ 1 by simp)
@@ -557,7 +557,7 @@ lemma ent_of_sub_smul {Y : Ω → G} {X' : Ω → G} [FiniteRange X] [FiniteRang
 and let `a` be an integer. Then `H[X - (a-1)Y] ≤ H[X - aY] + H[X - Y - X'] - H[X]` -/
 lemma ent_of_sub_smul' {Y : Ω → G} {X' : Ω → G} [FiniteRange X] [FiniteRange Y] [FiniteRange X']
     [IsProbabilityMeasure μ] (hX : Measurable X) (hY : Measurable Y) (hX': Measurable X')
-    (h_indep : iIndepFun (fun _ ↦ hG) ![X, Y, X'] μ) (hident : IdentDistrib X X' μ μ) {a : ℤ} :
+    (h_indep : iIndepFun ![X, Y, X'] μ) (hident : IdentDistrib X X' μ μ) {a : ℤ} :
     H[X - (a-1) • Y; μ] ≤ H[X - a • Y; μ] + H[X - Y - X'; μ] - H[X; μ] := by
   rw [sub_smul, one_smul, sub_eq_add_neg, neg_sub, add_sub]
   have iX'Y : IndepFun X' Y μ := h_indep.indepFun (show 2 ≠ 1 by simp)
@@ -605,7 +605,7 @@ lemma ent_of_sub_smul_le {Y : Ω → G} [IsProbabilityMeasure μ] [Fintype G]
   have iX₁Y : IndepFun X₁' Y' μ' := h_indep'.indepFun (show 0 ≠ 1 by simp)
   have iYX₂ : IndepFun Y' X₂' μ' := h_indep'.indepFun (show 1 ≠ 2 by simp)
   have iX₂nY : IndepFun X₂' (-Y') μ' := iYX₂.symm.comp measurable_id measurable_neg
-  have inX₁YX₂ : iIndepFun (fun _ ↦ hG) ![-X₁', Y', X₂'] μ' := by
+  have inX₁YX₂ : iIndepFun ![-X₁', Y', X₂'] μ' := by
     convert h_indep'.comp ![-id, id, id] (by fun_prop) with i
     match i with | 0 => rfl | 1 => rfl | 2 => rfl
   have idX₁X₂' : IdentDistrib X₁' X₂' μ' μ' := idX₁.trans idX₂.symm
@@ -732,14 +732,15 @@ variable [MeasurableSingletonClass G] [Countable G]
 
 /-- If `X_i` are independent, then `D[X_{[m]}] = H[∑_{i=1}^m X_i] - \frac{1}{m} \sum_{i=1}^m H[X_i]`. -/
 lemma multiDist_indep {m : ℕ} {Ω : Type*} (hΩ : MeasureSpace Ω) (X : Fin m → Ω → G)
-    (h_indep : iIndepFun (fun _ ↦ hG) X) :
+    (h_indep : iIndepFun X) :
     D[X ; fun _ ↦ hΩ] = H[∑ i, X i] - (∑ i, H[X i]) / m := by sorry
 
 lemma multiDist_nonneg_of_indep [Fintype G] {m : ℕ} {Ω : Type*} (hΩ : MeasureSpace Ω)
-    (hprob : IsProbabilityMeasure (ℙ : Measure Ω)) (X : Fin m → Ω → G) (hX : ∀ i, Measurable (X i))
-    (h_indep : iIndepFun (fun _ => inferInstance) X ℙ) :
+    (X : Fin m → Ω → G) (hX : ∀ i, Measurable (X i))
+    (h_indep : iIndepFun X ℙ) :
     0 ≤ D[X ; fun _ ↦ hΩ] := by
   rw [multiDist_indep hΩ X h_indep]
+  have : IsProbabilityMeasure (ℙ : Measure Ω) := h_indep.isProbabilityMeasure
   by_cases hm : m = 0
   · subst hm
     simp only [Finset.univ_eq_empty, Finset.sum_empty, CharP.cast_eq_zero, div_zero, sub_zero,
@@ -762,7 +763,7 @@ lemma multiDist_nonneg [Fintype G] {m : ℕ} {Ω : Fin m → Type*} (hΩ : ∀ i
     0 ≤ D[X ; hΩ] := by
   obtain ⟨A, mA, μA, Y, isProb, h_indep, hY⟩ :=
     ProbabilityTheory.independent_copies' X hX (fun i => ℙ)
-  convert multiDist_nonneg_of_indep ⟨μA⟩ isProb Y (fun i => (hY i).1) h_indep using 1
+  convert multiDist_nonneg_of_indep ⟨μA⟩ Y (fun i => (hY i).1) h_indep using 1
   apply multiDist_copy
   exact fun i => (hY i).2.symm
 
@@ -845,7 +846,7 @@ lemma multidist_ruzsa_III {m:ℕ} (hm: m ≥ 2) {Ω: Fin m → Type*} (hΩ : ∀
 /-- Let `m ≥ 2`, and let `X_[m]` be a tuple of `G`-valued random
 variables. Let `W := ∑ X_i`. Then `d[W;-W] ≤ 2 D[X_i]`. -/
 lemma multidist_ruzsa_IV {m:ℕ} (hm: m ≥ 2) {Ω : Type*} (hΩ : MeasureSpace Ω) (X : Fin m → Ω → G)
-    (h_indep : iIndepFun (fun _ ↦ hG) X) : d[∑ i, X i # ∑ i, X i] ≤ 2 * D[X; fun _ ↦ hΩ] := by sorry
+    (h_indep : iIndepFun X) : d[∑ i, X i # ∑ i, X i] ≤ 2 * D[X; fun _ ↦ hΩ] := by sorry
 
 /-- If `D[X_[m]]=0`, then for each `i ∈ I` there is a finite subgroup `H_i ≤ G` such that
 `d[X_i; U_{H_i}] = 0`. -/
@@ -963,7 +964,7 @@ private lemma ident_of_cond_of_indep
     {S : Type*} [Fintype S] [hS : MeasurableSpace S] [MeasurableSingletonClass S]
     {X : Fin m → Ω → G} (hX : (i:Fin m) → Measurable (X i))
     {Y : Fin m → Ω → S} (hY : (i:Fin m) → Measurable (Y i))
-    (h_indep : ProbabilityTheory.iIndepFun (fun _ ↦ hG.prod hS) (fun i ↦ ⟨X i, Y i⟩))
+    (h_indep : ProbabilityTheory.iIndepFun (fun i ↦ ⟨X i, Y i⟩))
     (y : Fin m → S) (i : Fin m) (hy: ∀ i, ℙ (Y i ⁻¹' {y i}) ≠ 0) :
     IdentDistrib (X i) (X i) (cond ℙ (Y i ⁻¹' {y i})) (cond ℙ (⋂ i, Y i ⁻¹' {y i})) where
   aemeasurable_fst := Measurable.aemeasurable (hX i)
@@ -1000,7 +1001,7 @@ lemma condMultiDist_eq {m : ℕ}
     {S : Type*} [Fintype S] [hS : MeasurableSpace S] [MeasurableSingletonClass S]
     {X : Fin m → Ω → G} (hX : ∀ i, Measurable (X i))
     {Y : Fin m → Ω → S} (hY : ∀ i, Measurable (Y i))
-    (h_indep: iIndepFun (fun _ ↦ hG.prod hS) (fun i ↦ ⟨X i, Y i⟩)) :
+    (h_indep: iIndepFun (fun i ↦ ⟨X i, Y i⟩)) :
     D[X | Y ; fun _ ↦ hΩ] =
       H[fun ω ↦ ∑ i, X i ω | fun ω ↦ (fun i ↦ Y i ω)] - (∑ i, H[X i | Y i])/m := by
   have : IsProbabilityMeasure (ℙ : Measure Ω) := h_indep.isProbabilityMeasure
@@ -1083,7 +1084,7 @@ lemma condMultiDist_eq' {m : ℕ} {Ω : Type*} [hΩ : MeasureSpace Ω]
     {S : Type*} [Fintype S] [hS : MeasurableSpace S] [MeasurableSingletonClass S]
     {X : Fin m → Ω → G} (hX : ∀ i, Measurable (X i)) {Y : Fin m → Ω → S}
     (hY : ∀ i, Measurable (Y i))
-    (h_indep : iIndepFun (fun _ ↦ hG.prod hS) (fun i ↦ ⟨X i, Y i⟩)) :
+    (h_indep : iIndepFun (fun i ↦ ⟨X i, Y i⟩)) :
     D[X | Y ; fun _ ↦ hΩ] =
       ∑ y : Fin m → S, (ℙ (⋂ i, (Y i) ⁻¹' {y i})).toReal
         * D[X; fun _ ↦ ⟨cond ℙ (⋂ i, Y i ⁻¹' {y i})⟩] := by
@@ -1112,7 +1113,7 @@ lemma multiDist_chainRule {G H : Type*} [hG : MeasurableSpace G] [MeasurableSing
     [MeasurableSingletonClass H] [AddCommGroup H]
     [Fintype H] (π : G →+ H) {m : ℕ} {Ω : Type*} (hΩ : MeasureSpace Ω)
     {X : Fin m → Ω → G} (hmes : ∀ i, Measurable (X i))
-    (h_indep : iIndepFun (fun _ ↦ hG) X) :
+    (h_indep : iIndepFun X) :
     D[X; fun _ ↦ hΩ] = D[X | fun i ↦ π ∘ X i; fun _ ↦ hΩ]
       + D[fun i ↦ π ∘ X i; fun _ ↦ hΩ]
       + I[∑ i, X i : fun ω ↦ (fun i ↦ π (X i ω)) | π ∘ (∑ i, X i)] := by
@@ -1161,7 +1162,7 @@ lemma multiDist_chainRule {G H : Type*} [hG : MeasurableSpace G] [MeasurableSing
     . intro i
       exact Measurable.comp .of_discrete (hmes i)
     set g : G → G × H := fun x ↦ ⟨x, π x⟩
-    change iIndepFun _ (fun i ↦ g ∘ X i) ℙ
+    change iIndepFun (fun i ↦ g ∘ X i) ℙ
     exact h_indep.comp _ fun _ ↦ .of_discrete
 
   have eq5: D[fun i ↦ π ∘ X i; fun _ ↦ hΩ] = H[π ∘ S] - avg_HpiX := by
@@ -1194,7 +1195,7 @@ lemma cond_multiDist_chainRule {G H : Type*} [hG : MeasurableSpace G] [Measurabl
     {m : ℕ} {Ω : Type*} [hΩ : MeasureSpace Ω]
     {X : Fin m → Ω → G} (hX : ∀ i, Measurable (X i))
     {Y : Fin m → Ω → S} (hY : ∀ i, Measurable (Y i))
-    (h_indep : iIndepFun (fun _ ↦ (hG.prod hS)) (fun i ↦ ⟨X i, Y i⟩)) :
+    (h_indep : iIndepFun (fun i ↦ ⟨X i, Y i⟩)) :
     D[X | Y; fun _ ↦ hΩ] = D[X | fun i ↦ ⟨π ∘ X i, Y i⟩; fun _ ↦ hΩ]
       + D[fun i ↦ π ∘ X i | Y; fun _ ↦ hΩ]
       + I[∑ i, X i : fun ω ↦ (fun i ↦ π (X i ω)) |
@@ -1228,12 +1229,12 @@ lemma cond_multiDist_chainRule {G H : Type*} [hG : MeasurableSpace G] [Measurabl
         convert Finset.measurable_sum (f := X) Finset.univ _ with ω
         . exact Fintype.sum_apply ω X
         exact (fun i _ ↦ hX i)
-      have hpi_indep : iIndepFun (fun _ ↦ hH.prod hS) (fun i ↦ ⟨π ∘ X i, Y i⟩) ℙ := by
+      have hpi_indep : iIndepFun (fun i ↦ ⟨π ∘ X i, Y i⟩) ℙ := by
         set g : G × S → H × S := fun p ↦ ⟨π p.1, p.2⟩
         convert iIndepFun.comp h_indep (fun _ ↦ g) _
         intro i
         exact .of_discrete
-      have hpi_indep' : iIndepFun (fun x ↦ hG.prod Prod.instMeasurableSpace) (fun i ↦ ⟨X i, ⟨π ∘ X i, Y i⟩⟩) ℙ := by
+      have hpi_indep' : iIndepFun (fun i ↦ ⟨X i, ⟨π ∘ X i, Y i⟩⟩) ℙ := by
         set g : G × S → G × (H × S) := fun p ↦ ⟨p.1, ⟨π p.1, p.2⟩⟩
         convert iIndepFun.comp h_indep (fun _ ↦ g) _
         intro i
@@ -1361,7 +1362,7 @@ lemma iter_multiDist_chainRule {m : ℕ}
     {φ : ∀ i : Fin m, G (i.succ) →+ G i.castSucc} {π : ∀ d, G m →+ G d}
     (hcomp: ∀ i : Fin m, π i.castSucc = (φ i) ∘ (π i.succ))
     {Ω : Type*} [hΩ : MeasureSpace Ω] {X : Fin m → Ω → (G m)}
-    (hX: ∀ i, Measurable (X i)) (h_indep : iIndepFun (fun _ ↦ (hG m)) X) (n : Fin (m + 1)) :
+    (hX : ∀ i, Measurable (X i)) (h_indep : iIndepFun X) (n : Fin (m + 1)) :
     D[X | fun i ↦ (π 0) ∘ X i; fun _ ↦ hΩ] = D[X | fun i ↦ (π n) ∘ X i; fun _ ↦ hΩ]
       + ∑ d ∈ Finset.Iio n, (D[fun i ↦ (π (d+1)) ∘ X i | fun i ↦ (π d) ∘ X i; fun _ ↦ hΩ]
       + I[∑ i, X i : fun ω ↦ (fun i ↦ (π (d+1)) (X i ω)) |
@@ -1429,7 +1430,7 @@ lemma iter_multiDist_chainRule' {m : ℕ} (hm : m > 0)
     [hGcount : ∀ i, Fintype (G i)] {φ : ∀ i : Fin m, G (i.succ) →+ G i.castSucc}
     {π : ∀ d, G m →+ G d} (hπ0 : π 0 = 0) (hcomp : ∀ i : Fin m, π i.castSucc = (φ i) ∘ (π i.succ))
     {Ω : Type*} [hΩ : MeasureSpace Ω] {X : Fin m → Ω → (G m)}
-    (hX : ∀ i, Measurable (X i)) (h_indep : iIndepFun (fun _ ↦ (hG m)) X) :
+    (hX : ∀ i, Measurable (X i)) (h_indep : iIndepFun X) :
     D[X; fun _ ↦ hΩ] ≥
       ∑ d : Fin m, D[fun i ↦ (π (d.succ)) ∘ X i | fun i ↦ (π d.castSucc) ∘ X i; fun _ ↦ hΩ]
       + I[∑ i : Fin m, X i : fun ω i ↦ (π 1) (X i ω)| ⇑(π 1) ∘ ∑ i : Fin m, X i] := by
@@ -1486,7 +1487,7 @@ is less than
 `+ D[(X_{i,m})_{i=1}^m] - D[(∑ j, X_{i,j})_{i=1}^m],`
 where all the multidistances here involve the indexing set `{1, ..., m}`. -/
 lemma cor_multiDist_chainRule [Fintype G] {m:ℕ} (hm: m ≥ 1) {Ω : Type*} (hΩ : MeasureSpace Ω)
-    (X : Fin (m + 1) × Fin (m + 1) → Ω → G) (h_indep : iIndepFun (fun _ ↦ hG) X) :
+    (X : Fin (m + 1) × Fin (m + 1) → Ω → G) (h_indep : iIndepFun X) :
     I[fun ω ↦ (fun j ↦ ∑ i, X (i, j) ω) : fun ω ↦ (fun i ↦ ∑ j, X (i, j) ω) | ∑ p, X p]
       ≤ ∑ j, (D[fun i ↦ X (i, j); fun _ ↦ hΩ] - D[fun i ↦ X (i, j) |
         fun i ↦ ∑ k ∈ Finset.Ici j, X (i, k); fun _ ↦ hΩ]) + D[fun i ↦ X (i, m); fun _ ↦ hΩ]

--- a/PFR/RhoFunctional.lean
+++ b/PFR/RhoFunctional.lean
@@ -789,14 +789,14 @@ lemma rhoMinus_of_sum [IsZeroOrProbabilityMeasure μ]
     apply IdentDistrib.add hXX'.symm hYY'.symm h_indep
     exact h_indep'.indepFun zero_ne_one
   have hX'TUY' : IndepFun (⟨X', T + U⟩) Y' ℙ := by
-    have I : iIndepFun (fun x ↦ hGm) ![X', Y', T + U] m :=
+    have I : iIndepFun ![X', Y', T + U] m :=
       ProbabilityTheory.iIndepFun.apply_two_last h_indep' hX' hY' hT hU
         (phi := fun a b ↦ a + b) (by fun_prop)
     exact (I.reindex_three_bac.pair_last_of_three hY' hX' (by fun_prop)).symm
   have I₁ : ρ⁻[X + Y ; μ # A] ≤ KL[X + Y ; μ # (T + Y') + U ; ℙ] := by
     apply rhoMinus_le (by fun_prop) hA _ (by fun_prop) (by fun_prop)
-    · have : iIndepFun (fun x ↦ hGm) ![U, X', T, Y'] := h_indep'.reindex_four_dacb
-      have : iIndepFun (fun x ↦ hGm) ![U, X', T + Y'] :=
+    · have : iIndepFun ![U, X', T, Y'] := h_indep'.reindex_four_dacb
+      have : iIndepFun ![U, X', T + Y'] :=
         this.apply_two_last (phi := fun a b ↦ a + b) hU hX' hT hY' (by fun_prop)
       apply this.indepFun (i := 2) (j := 0)
       simp
@@ -1193,7 +1193,7 @@ lemma phi_min_exists (hA : A.Nonempty) : ∃ (μ : Measure (G × G)), IsProbabil
 variable {X₁ X₂ X₁' X₂' : Ω → G} (h_min : phiMinimizes X₁ X₂ η A ℙ)
   (h₁ : IdentDistrib X₁ X₁')
   (h₂ : IdentDistrib X₂ X₂')
-  (h_indep : iIndepFun (fun _ ↦ hGm) ![X₁, X₂, X₁', X₂'])
+  (h_indep : iIndepFun ![X₁, X₂, X₁', X₂'])
   (hX₁ : Measurable X₁) (hX₂ : Measurable X₂) (hX₁' : Measurable X₁') (hX₂' : Measurable X₂')
 
 local notation3 "I₁" => I[X₁ + X₂ : X₁' + X₂ | X₁ + X₂ + X₁' + X₂']
@@ -1561,7 +1561,7 @@ lemma dist_le_of_sum_zero_cond' {Ω' : Type*} [MeasureSpace Ω']
 
 lemma new_gen_ineq_aux1 {Y₁ Y₂ Y₃ Y₄ : Ω → G}
     (hY₁ : Measurable Y₁) (hY₂ : Measurable Y₂) (hY₃ : Measurable Y₃) (hY₄ : Measurable Y₄)
-    (h_indep : iIndepFun (fun _ ↦ hGm) ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
+    (h_indep : iIndepFun ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
     ρ[Y₁ + Y₂ | ⟨Y₁ + Y₃, Y₁ + Y₂ + Y₃ + Y₄⟩ # A] ≤
       (ρ[Y₁ # A] + ρ[Y₂ # A] + ρ[Y₃ # A] + ρ[Y₄ # A]) / 4
         + (d[Y₁ # Y₂] + d[Y₃ # Y₄]) / 4 + (d[Y₁ + Y₂ # Y₃ + Y₄]
@@ -1588,7 +1588,7 @@ lemma new_gen_ineq_aux1 {Y₁ Y₂ Y₃ Y₄ : Ω → G}
 
 lemma new_gen_ineq_aux2 {Y₁ Y₂ Y₃ Y₄ : Ω → G}
     (hY₁ : Measurable Y₁) (hY₂ : Measurable Y₂) (hY₃ : Measurable Y₃) (hY₄ : Measurable Y₄)
-    (h_indep : iIndepFun (fun _ ↦ hGm) ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
+    (h_indep : iIndepFun ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
     ρ[Y₁ + Y₂ | ⟨Y₁ + Y₃, Y₁ + Y₂ + Y₃ + Y₄⟩ # A] ≤
        (ρ[Y₁ # A] + ρ[Y₂ # A] + ρ[Y₃ # A] + ρ[Y₄ # A]) / 4
         + (d[Y₁ # Y₃] + d[Y₂ # Y₄]) / 4 + d[Y₁ | Y₁ + Y₃ # Y₂ | Y₂ + Y₄] / 2 := by
@@ -1695,7 +1695,7 @@ lemma new_gen_ineq_aux2 {Y₁ Y₂ Y₃ Y₄ : Ω → G}
 
 lemma new_gen_ineq {Y₁ Y₂ Y₃ Y₄ : Ω → G}
     (hY₁ : Measurable Y₁) (hY₂ : Measurable Y₂) (hY₃ : Measurable Y₃) (hY₄ : Measurable Y₄)
-    (h_indep : iIndepFun (fun _ ↦ hGm) ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
+    (h_indep : iIndepFun ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
     ρ[Y₁ + Y₂ | ⟨Y₁ + Y₃, Y₁ + Y₂ + Y₃ + Y₄⟩ # A] ≤
       (ρ[Y₁ # A] + ρ[Y₂ # A] + ρ[Y₃ # A] + ρ[Y₄ # A]) / 4
         + (d[Y₁ # Y₂] + d[Y₃ # Y₄] + d[Y₁ # Y₃] + d[Y₂ # Y₄]) / 8 + (d[Y₁ + Y₂ # Y₃ + Y₄]
@@ -1711,7 +1711,7 @@ $S:=Y_1+Y_2+Y_3+Y_4$, $T_1:=Y_1+Y_2$, $T_2:=Y_1+Y_3$. Then
 -/
 lemma condRho_sum_le {Y₁ Y₂ Y₃ Y₄ : Ω → G}
     (hY₁ : Measurable Y₁) (hY₂ : Measurable Y₂) (hY₃ : Measurable Y₃) (hY₄ : Measurable Y₄)
-    (h_indep : iIndepFun (fun _ ↦ hGm) ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
+    (h_indep : iIndepFun ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
     ρ[Y₁ + Y₂ | ⟨Y₁ + Y₃, Y₁ + Y₂ + Y₃ + Y₄⟩ # A] + ρ[Y₁ + Y₃ | ⟨Y₁ + Y₂, Y₁ + Y₂ + Y₃ + Y₄⟩ # A] -
       (ρ[Y₁ # A] + ρ[Y₂ # A] + ρ[Y₃ # A] + ρ[Y₄ # A]) / 2 ≤
         (d[Y₁ # Y₂] + d[Y₃ # Y₄] + d[Y₁ # Y₃] + d[Y₂ # Y₄]) / 2 := by
@@ -1765,7 +1765,7 @@ $T_1:=Y_1+Y_2, T_2:=Y_1+Y_3, T_3:=Y_2+Y_3$ and $S:=Y_1+Y_2+Y_3+Y_4$. Then
     - \frac{1}{2}\sum_{i} \rho(Y_i))\le \sum_{1\leq i < j \leq 4}d[Y_i;Y_j]$$ -/
 lemma condRho_sum_le' {Y₁ Y₂ Y₃ Y₄ : Ω → G}
       (hY₁ : Measurable Y₁) (hY₂ : Measurable Y₂) (hY₃ : Measurable Y₃) (hY₄ : Measurable Y₄)
-      (h_indep : iIndepFun (fun _ ↦ hGm) ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
+      (h_indep : iIndepFun ![Y₁, Y₂, Y₃, Y₄]) (hA : A.Nonempty) :
     let S := Y₁ + Y₂ + Y₃ + Y₄
     let T₁ := Y₁ + Y₂
     let T₂ := Y₁ + Y₃

--- a/PFR/SecondEstimate.lean
+++ b/PFR/SecondEstimate.lean
@@ -36,7 +36,7 @@ variable (X₁ X₂ X₁' X₂' : Ω → G)
 
 variable (h₁ : IdentDistrib X₁ X₁') (h₂ : IdentDistrib X₂ X₂')
 
-variable (h_indep : iIndepFun (fun _i => hG) ![X₁, X₂, X₁', X₂'])
+variable (h_indep : iIndepFun ![X₁, X₂, X₁', X₂'])
 
 variable (h_min : tau_minimizes p X₁ X₂)
 
@@ -83,7 +83,7 @@ lemma second_estimate_aux :
       ← (IdentDistrib.refl hX₂.aemeasurable).rdist_eq h₂,
       ZModModule.sub_eq_add X₁ X₁', ZModModule.sub_eq_add X₂ X₂', ← add_assoc, add_right_comm _ X₁']
         at h
-    have h_indep' : iIndepFun (fun _i => hG) ![X₁, X₂, X₂', X₁'] :=
+    have h_indep' : iIndepFun ![X₁, X₂, X₂', X₁'] :=
       by exact h_indep.reindex_four_abdc
     have h' := ent_ofsum_le p X₁ X₂ X₁' X₂' hX₁ hX₂ hX₁' hX₂' h₁ h₂ h_indep' h_min
     convert (h.symm ▸ (sub_le_sub_right (sub_le_sub_right h' _) _)) using 1; ring
@@ -98,7 +98,7 @@ lemma second_estimate : I₂ ≤ 2 * p.η * k + (2 * p.η * (2 * p.η * k - I₁
   have hX₂_indep : IndepFun X₂ X₂' (μ := ℙ) := h_indep.indepFun (show 1 ≠ 3 by decide)
   let Y : Fin 4 → Ω → G := ![X₂, X₁, X₂', X₁']
   have hY : ∀ i, Measurable (Y i) := fun i => by fin_cases i <;> assumption
-  have hY_indep : iIndepFun (fun _ => hG) Y := by exact h_indep.reindex_four_badc
+  have hY_indep : iIndepFun Y := by exact h_indep.reindex_four_badc
   have h := sum_of_rdist_eq_char_2 Y hY_indep hY
   rw [show Y 0 = X₂ by rfl, show Y 1 = X₁ by rfl, show Y 2 = X₂' by rfl, show Y 3 = X₁' by rfl] at h
   rw [← h₂.rdist_eq h₁, rdist_symm, rdist_symm (X := X₂ + X₂'),

--- a/PFR/TorsionEndgame.lean
+++ b/PFR/TorsionEndgame.lean
@@ -43,7 +43,7 @@ lemma sum_of_z_eq_zero :Z1 + Z2 + Z3 = 0 := by
   simp
 
 variable [hΩ': MeasureSpace Ω'] [IsFiniteMeasure hΩ'.volume]
-  (h_indep : iIndepFun _ Y) (hident : ∀ i j, IdentDistrib (Y (i, j)) (X i)) {m : ℝ}
+  (h_indep : iIndepFun Y) (hident : ∀ i j, IdentDistrib (Y (i, j)) (X i)) {m : ℝ}
 
 /-- We have `I[Z_1 : Z_2 | W], I[Z_2 : Z_3 | W], I[Z_1 : Z_3 | W] ≤ 4m^2 η k`.
 -/

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "a2c4172af668783ff7b904b942f4e301dc036c99",
+   "rev": "3800f46f4b3baed8f14b0cd3a90963c5a453667b",
    "name": "mathlib",
    "manifestFile": "lake-manifest.json",
    "inputRev": null,


### PR DESCRIPTION
In #22644, I've removed useless explicit arguments in `iIndepFun`, motivated by PFR where this was just cluttering things. In this PR for PFR, I do the corresponding cleanup.