### PR TITLE
Fix website

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,8 +89,8 @@ jobs:
           cp blueprint/print/print.pdf website/blueprint.pdf
           cp -r blueprint/web website/blueprint
 
-      # - name: Copy README.md to website/index.md
-      #   run: cp README.md website/index.md
+      - name: Append README.md to website/index.md
+        run: cat README.md >> website/index.md
 
       - name: Upstreaming dashboard
         run: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub CI](https://github.com/teorth/pfr/actions/workflows/push.yml/badge.svg)](https://github.com/teorth/pfr/actions/workflows/push.yml)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/teorth/pfr)
 
-The original purpose of this repository is to hold a Lean4 formalization of [the proof of the Polynomial Freiman-Ruzsa (PFR) conjecture](https://arxiv.org/abs/2311.05762) of Katalin Marton (see also [this blog post](https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton)).  The statement is as follows: if $A$ is a non-empty subset of ${\bf F}_2^n$ such that $|A+A| \leq K|A|$, then $A$ can be covered by at most $2K^{12}$ cosets of a subspace $H$ of ${\bf F}_2^n$ of cardinality at most $|A|$.  The proof relies on the theory of Shannon entropy, so in particular development of the Shannon entropy inequalities was needed.
+The original purpose of this repository is to hold a Lean4 formalization of [the proof of the Polynomial Freiman-Ruzsa (PFR) conjecture](https://arxiv.org/abs/2311.05762) of Katalin Marton (see also [this blog post](https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton)).  The statement is as follows: if $A$ is a non-empty subset of ${\bf F}_2^n$ such that $\lvert A+A\rvert \leq K\lvert A\rvert$, then $A$ can be covered by at most $2K^{12}$ cosets of a subspace $H$ of ${\bf F}_2^n$ of cardinality at most $\lvert A\rvert$.  The proof relies on the theory of Shannon entropy, so in particular development of the Shannon entropy inequalities was needed.
 
 After the primary purpose of the project was completed, a second stage of the project developed several consequences of PFR, as well as an argument of Jyun-Jie Liao that reduced the exponent $12$ to $11$.  This second stage has also been completed.
 
@@ -24,7 +24,7 @@ To build the project, run `lake exe cache get` and then `lake build`.
 
 ## Build the blueprint
 
-See instructions at https://github.com/PatrickMassot/leanblueprint/.
+See instructions at <https://github.com/PatrickMassot/leanblueprint/>.
 
 ## Moving material to mathlib
 

--- a/website/_includes/mathjax.html
+++ b/website/_includes/mathjax.html
@@ -2,9 +2,10 @@
 {% if page.usemathjax %}
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+  tex2jax: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
   TeX: { equationNumbers: { autoNumber: "AMS" } }
   });
 </script>
 <script type="text/javascript" async
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -11,12 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#157878">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  {% if jekyll.environment == "production" %}
-  <link rel="stylesheet"
-    href="{{ 'pfr/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-  {% else %}
-  <link rel="stylesheet" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-  {% endif %}
+  <link rel="stylesheet" href="assets/css/style.css?v={{ site.github.build_revision }}">
   {% include head-custom.html %}
 </head>
 

--- a/website/index.md
+++ b/website/index.md
@@ -8,39 +8,4 @@ usemathjax: true
 
 {% include mathjax.html %}
 
-# The Polynomial Freiman-Ruzsa Conjecture
-
-The original purpose of this repository is to hold a Lean4 formalization of [the proof of the Polynomial Freiman-Ruzsa (PFR) conjecture](https://arxiv.org/abs/2311.05762) of Katalin Marton (see also [this blog post](https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton)).  The statement is as follows: if $A$ is a non-empty subset of ${\bf F}_2^n$ such that $\vert A+A\vert \leq K\vert A\vert$, then $A$ can be covered by at most $2K^{12}$ cosets of a subspace $H$ of ${\bf F}_2^n$ of cardinality at most $\vert A\vert$.  The proof relies on the theory of Shannon entropy, so in particular development of the Shannon entropy inequalities was needed.
-
-After the primary purpose of the project was completed, a second stage of the project developed several consequences of PFR, as well as an argument of Jyun-Jie Liao that reduced the exponent $12$ to $11$.  This second stage has also been completed.
-
-Currently, the project is obtaining an extension of PFR to other bounded torsion groups, as well as formalizing a further refinement of Jyun-Jie Liao that improves the exponent further to $9$.
-
-* [Discussion of the project on Zulip](https://leanprover.zulipchat.com/#narrow/stream/412902-Polynomial-Freiman-Ruzsa-conjecture)
-* [Blueprint of the proof](https://teorth.github.io/pfr/blueprint)
-* [Documentation of the methods](https://teorth.github.io/pfr/docs)
-* [A quick "tour" of the project](https://terrytao.wordpress.com/2023/11/18/formalizing-the-proof-of-pfr-in-lean4-using-blueprint-a-short-tour)
-* [Some example Lean code to illustrate the results in the project](https://github.com/teorth/pfr/blob/master/PFR/Examples.lean)
-
-## Build the Lean files
-
-To build the Lean files of this project, you need to have a working version of Lean.
-See [the installation instructions](https://leanprover-community.github.io/get_started.html) (under Regular install).
-
-To build the project, run `lake exe cache get` and then `lake build`.
-
-## Build the blueprint
-
-See instructions at https://github.com/PatrickMassot/leanblueprint/.
-
-## Moving material to mathlib
-
-As the first two phases of the project are completed, we are currently working towards stabilising the new results and contributing them to mathlib.
-
-## Source reference
-
-`[GGMT]`: <https://arxiv.org/abs/2311.05762>
-
-`[L]` : <https://arxiv.org/abs/2404.09639>
-
-`[GGMT2]`: <https://arxiv.org/abs/2404.02244>
+{% comment %} The rest of the file will be copied from README.md. {% endcomment %}


### PR DESCRIPTION
* Avoid duplication of information in `README.md` versus `website/index.md`
* the duplication above previously caused an issue that in d7157aa7c9561385b252769351b6d66af4bfac6e , some `|` was changed to `\vert` in `README.md` but the change was not correspondingly applied in `website/index.md`. With the above change, it is less likely to forget.
* also change these to `\lvert ... \rvert`. They render the same, but this seems harmless enough.
* make the link to leanblueprint clickable.
* make math formulas on the website actually render. Note that `$...$` are not converted by default unless configured.
* update CDN. https://cdn.mathjax.org is no longer functional and just redirect to cloudflare by default now.
* modify a relative URL to a path-relative URL. From my reading of the code I understand that you can build the Jekyll pages manually and the behavior is slightly different. Jekyll does not support path-relative URL as a filter yet: `https://github.com/jekyll/jekyll/issues/9577` (you may want to check that it renders correctly when built locally as well)

the upstreaming dashboard is still broken, but this is not fixable on my side (from my reading of the code, looks like someone forget to add `website/upstreaming.md`?