### PR TITLE
fix: site-root nav links on blueprint pages

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -22,11 +22,11 @@
     <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
     <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline
       }}</h2>
-    <a href="docs" class="btn">Documentation</a>
-    <a href="blueprint" class="btn">Blueprint</a>
-    <a href="blueprint.pdf" class="btn">Paper</a>
-    <a href="upstreaming" class="btn">Upstreaming dashboard</a>
-    <a href="file_deps.pdf" class="btn">File dependencies</a>
+    <a href="{{ site.github.repository_name | append: '/docs' | relative_url }}" class="btn">Documentation</a>
+    <a href="{{ site.github.repository_name | append: '/blueprint' | relative_url }}" class="btn">Blueprint</a>
+    <a href="{{ site.github.repository_name | append: '/blueprint.pdf' | relative_url }}" class="btn">Paper</a>
+    <a href="{{ site.github.repository_name | append: '/upstreaming' | relative_url }}" class="btn">Upstreaming dashboard</a>
+    <a href="{{ site.github.repository_name | append: '/file_deps.pdf' | relative_url }}" class="btn">File dependencies</a>
     {% if site.github.is_project_page %}
     <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
     {% endif %}


### PR DESCRIPTION
## Summary
Header buttons used relative paths (`href="docs"`, etc.), so from blueprint subpages they resolved under `/blueprint/` and 404'd (e.g. `/pfr/blueprint/upstreaming`).

## Root cause
Jekyll resolves bare relative links against the current page URL, not the site root.

## Fix
Prefix nav targets with `site.github.repository_name` and `relative_url`, matching the existing stylesheet pattern.

Fixes the remaining case from #246.


Made with [Cursor](https://cursor.com)