### PR TITLE
fix: remove stray space in default layout lang attribute

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: " en-US" }}">
+<html lang="{{ site.lang | default: "en-US" }}">
 
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
## Summary

The Jekyll default layout default lang value had a leading space (`" en-US"`), so pages like the upstreaming dashboard rendered invalid HTML: `lang=" en-US"`.

## Fix

Remove the stray space in the Liquid default.

Related to #246 (same page the reporter visited).

## Test plan

- [ ] Rebuild the GitHub Pages site and confirm upstreaming page has `lang="en-US"`

Made with [Cursor](https://cursor.com)