### PR TITLE
fix: preserve site MathJax and README install wording

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,8 +52,15 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
-      - name: Copy README.md to website/index.md
-        run: cp README.md website/index.md
+      - name: Merge README.md into website/index.md
+        run: |
+          # Preserve Jekyll front matter + MathJax include; append README body.
+          {
+            sed -n '1,/^{% comment %} The rest of the file will be copied from README.md. {% endcomment %}$/p' website/index.md
+            echo
+            cat README.md
+          } > /tmp/pfr-index.md
+          mv /tmp/pfr-index.md website/index.md
 
       - name: Build and lint the project
         id: build-lean

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, the project is obtaining an extension of PFR to other bounded torsion
 ## Build the Lean files
 
 To build the Lean files of this project, you need to have a working version of Lean.
-See [the installation instructions](https://leanprover-community.github.io/get_started.html) (under Regular install).
+See [the installation instructions](https://leanprover-community.github.io/get_started.html).
 
 To build the project, run `lake exe cache get` and then `lake build`.
 

--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -33,7 +33,7 @@
 
 \begin{lemma}[Balog--Szemer\'edi--Gowers lemma]
   \label{bsg}
-  \lean{BSG_self'}
+  \lean{BSG}
   \uses{energy-def}
   \leanok
 

--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -33,7 +33,7 @@
 
 \begin{lemma}[Balog--Szemer\'edi--Gowers lemma]
   \label{bsg}
-  \lean{BSG}
+  \lean{BSG_self'}
   \uses{energy-def}
   \leanok
 


### PR DESCRIPTION
## Summary
- Preserve Jekyll front matter + MathJax when copying README into `website/index.md`
- Drop outdated Regular install wording from README

BSG blueprint lean tag split to #285.