### PR TITLE
fix: point BSG blueprint lean tag at BSG_self'

### DIFF
--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -33,7 +33,7 @@
 
 \begin{lemma}[Balog--Szemer\'edi--Gowers lemma]
   \label{bsg}
-  \lean{BSG}
+  \lean{BSG_self'}
   \uses{energy-def}
   \leanok
 


### PR DESCRIPTION
## Summary
- Blueprint `\lean{BSG}` → `\lean{BSG_self'}` so the tag matches the Lean declaration

Split out of #283 per review.


Made with [Cursor](https://cursor.com)