### PR TITLE
Add Palomar registration files

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,8 +27,8 @@ authors:
     given-names: Rob
   - family-names: Lez
     given-names: Paul
-  - family-names: Lorenzo
-    given-names: Luccioli
+  - family-names: Luccioli
+    given-names: Lorenzo
   - family-names: Macbeth
     given-names: Heather
   - family-names: Massot

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,7 @@ authors:
     given-names: Kalle
   - family-names: Lewis
     given-names: Rob
-  - family-names: Lez
+  - family-names: Lezeau
     given-names: Paul
   - family-names: Luccioli
     given-names: Lorenzo

--- a/PFR/WeakPFR.lean
+++ b/PFR/WeakPFR.lean
@@ -85,7 +85,7 @@ open Real ProbabilityTheory MeasureTheory
 
 variable {G : Type*} [AddCommGroup G] [MeasurableSpace G] [MeasurableSingletonClass G]
   [Countable G] {Ω Ω' : Type*} [MeasurableSpace Ω] [MeasurableSpace Ω'] (X : Ω → G) (Y : Ω' → G)
-  (μ : Measure Ω := by volume_tac) (μ' : Measure Ω' := by volume_tac)
+  (μ : Measure Ω) (μ' : Measure Ω')
   [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
 
 /-- If `G` is torsion-free and `X, Y` are `G`-valued random variables then `d[X; 2Y] ≤ 5d[X; Y]`. -/
@@ -282,7 +282,7 @@ lemma app_ent_PFR' [mΩ : MeasureSpace Ω] [mΩ' : MeasureSpace Ω'] (X : Ω →
   exact ⟨by linarith, by linarith⟩
 
 variable [MeasurableSpace Ω] [MeasurableSpace Ω'] (X : Ω → G) (Y : Ω' → G)
-  (μ : Measure Ω := by volume_tac) (μ' : Measure Ω' := by volume_tac)
+  (μ : Measure Ω) (μ' : Measure Ω')
   [IsProbabilityMeasure μ] [IsProbabilityMeasure μ']
 
 lemma app_ent_PFR (α : ℝ) (hent : 20 * d[X; μ # Y; μ'] < α * (H[X; μ] + H[Y; μ']))

--- a/Palomar/Challenge.lean
+++ b/Palomar/Challenge.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Terence Tao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Group.Pointwise.Set.Card
+import Mathlib.Algebra.Module.ZMod
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Defs
+import Mathlib.LinearAlgebra.Dimension.Finrank
+import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+
+/-!
+# Marton's conjecture (the polynomial Freiman–Ruzsa conjecture)
+
+This file states, in Mathlib-only terms, the headline theorems of three papers:
+
+* `[GGMT]` W. T. Gowers, Ben Green, Freddie Manners, Terence Tao,
+  *On a conjecture of Marton*, arXiv:2311.05762.
+* `[GGMT2]` W. T. Gowers, Ben Green, Freddie Manners, Terence Tao,
+  *Marton's conjecture in abelian groups with bounded torsion*, arXiv:2404.02244.
+* `[L]` Jyun-Jie Liao, *Improved exponent for Marton's conjecture in $\mathbf{F}_2^n$*,
+  arXiv:2404.09639.
+
+Marton's conjecture, widely known as the polynomial Freiman–Ruzsa conjecture, asserts that a
+subset `A` of an abelian group with small doubling, `|A + A| ≤ K * |A|`, is efficiently covered
+by cosets of a subgroup no larger than `A`, with a number of cosets polynomial in `K`.
+
+The six statements below are:
+
+* `Marton.pfr_conjecture` — `[GGMT]`, Theorem 1.2: the conjecture in `𝔽₂ⁿ`, with `2 * K ^ 12`
+  cosets.
+* `Marton.pfr_conjecture_nine` — `[L]`, main theorem: the same conclusion with `2 * K ^ 9`
+  cosets. This strengthens `Marton.pfr_conjecture`, which is retained because it is the
+  headline theorem of a different paper.
+* `Marton.torsion_pfr_conjecture` — `[GGMT2]`, Theorem 1.1: the conjecture in an arbitrary
+  abelian group of torsion `m`, with `m * K ^ (256 * m ^ 3 + 1)` cosets.
+* `Marton.weak_pfr_int` — `[GGMT]`, Theorem 1.3: a set of small doubling in a finitely
+  generated free `ℤ`-module has a large subset of logarithmically small affine dimension.
+* `Marton.homomorphism_pfr` — `[GGMT]`, Corollary 1.4: a map whose additive defects take few
+  values differs from a homomorphism by a map with small range.
+* `Marton.approx_hom_pfr` — `[GGMT]`, Corollary 1.5: a map that is additive on a positive
+  proportion of pairs agrees with a homomorphism on a positive proportion of points.
+
+All statements are phrased with `Nat.card`, `Set` pointwise arithmetic, `AddSubgroup`,
+`vectorSpan` and `Module.finrank`, so that no definition of this project is needed in order to
+read them. Torsion hypotheses are stated as `∀ x : G, m • x = 0` rather than through a
+`Module (ZMod m) G` instance, so that the statements do not depend on which `ZMod`-algebra
+instance path is in scope.
+-/
+
+open Pointwise
+
+namespace Marton
+
+/-- **Marton's conjecture in characteristic 2**, `[GGMT]`, Theorem 1.2.
+
+If `A` is a finite non-empty subset of an abelian group `G` of exponent `2` — that is,
+`2 • x = 0` for every `x : G`, so that `G` is an `𝔽₂`-vector space — and `|A + A| ≤ K * |A|`,
+then `A` is covered by fewer than `2 * K ^ 12` cosets of a subgroup `H` of `G` with
+`|H| ≤ |A|`.
+
+The ambient group `G` is not required to be finite; the covering set `c` and the subgroup `H`
+produced are then finite. This statement is superseded by `Marton.pfr_conjecture_nine`, and is
+recorded separately because it is the headline theorem of `[GGMT]`. -/
+theorem pfr_conjecture {G : Type*} [AddCommGroup G] (h2 : ∀ x : G, 2 • x = 0) {A : Set G}
+    (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ} (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < 2 * K ^ 12 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  sorry
+
+/-- **Marton's conjecture in characteristic 2 with exponent 9**, `[L]`, main theorem.
+
+If `A` is a finite non-empty subset of an abelian group `G` of exponent `2` — that is,
+`2 • x = 0` for every `x : G`, so that `G` is an `𝔽₂`-vector space — and `|A + A| ≤ K * |A|`,
+then `A` is covered by fewer than `2 * K ^ 9` cosets of a subgroup `H` of `G` with
+`|H| ≤ |A|`.
+
+The ambient group `G` is not required to be finite; the covering set `c` and the subgroup `H`
+produced are then finite. -/
+theorem pfr_conjecture_nine {G : Type*} [AddCommGroup G] (h2 : ∀ x : G, 2 • x = 0) {A : Set G}
+    (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ} (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < 2 * K ^ 9 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  sorry
+
+/-- **Marton's conjecture in abelian groups of bounded torsion**, `[GGMT2]`, Theorem 1.1.
+
+Let `G` be an abelian group of torsion `m ≥ 2`, meaning that `m • x = 0` for every `x : G`.
+If `A` is a finite non-empty subset of `G` with `|A + A| ≤ K * |A|`, then `A` is covered by
+fewer than `m * K ^ (256 * m ^ 3 + 1)` cosets of a subgroup `H` of `G` with `|H| ≤ |A|`.
+
+The ambient group `G` is not required to be finite; the covering set `c` and the subgroup `H`
+produced are then finite. -/
+theorem torsion_pfr_conjecture {G : Type*} [AddCommGroup G] {m : ℕ} (hm : 2 ≤ m)
+    (htorsion : ∀ x : G, m • x = 0) {A : Set G} (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ}
+    (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < m * K ^ (256 * m ^ 3 + 1) ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  sorry
+
+/-- **Weak Marton's conjecture over the integers**, `[GGMT]`, Theorem 1.3.
+
+Let `G` be a finitely generated free `ℤ`-module, that is, a copy of `ℤ ^ D`. If `A` is a
+finite non-empty subset of `G` with `|A + A| ≤ K * |A|`, then `A` has a subset `A'` with
+`|A'| ≥ K ^ (-34) * |A|` whose affine dimension — the rank of the `ℤ`-span of its difference
+set — is at most `(80 / log 2) * log K`.
+
+This realises the constants `C₁ = 68` and `C₂ = 80 / log 2` of `[GGMT]`, Theorem 1.3, which
+is stated there for unspecified absolute constants. -/
+theorem weak_pfr_int {G : Type*} [AddCommGroup G] [Module.Free ℤ G] [Module.Finite ℤ G]
+    {A : Set G} (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ}
+    (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ A' ⊆ A, K ^ (-34 : ℝ) * Nat.card A ≤ Nat.card A' ∧
+      (Module.finrank ℤ (vectorSpan ℤ A') : ℝ) ≤ (80 / Real.log 2) * Real.log K := by
+  sorry
+
+/-- **The homomorphism form of Marton's conjecture**, `[GGMT]`, Corollary 1.4.
+
+Let `G` and `G'` be finite abelian groups of exponent `2` and let `f : G → G'` be a function
+whose additive defects `f (x + y) - f x - f y` all lie in a set `S`. Then `f` differs from a
+group homomorphism `φ : G →+ G'` by a function taking at most `|S| ^ 10` values. -/
+theorem homomorphism_pfr {G G' : Type*} [AddCommGroup G] [AddCommGroup G'] [Finite G] [Finite G']
+    (h2 : ∀ x : G, 2 • x = 0) (h2' : ∀ y : G', 2 • y = 0) (f : G → G') (S : Set G')
+    (hS : ∀ x y : G, f (x + y) - f x - f y ∈ S) :
+    ∃ (φ : G →+ G') (T : Set G'), Nat.card T ≤ Nat.card S ^ 10 ∧ ∀ x : G, f x - φ x ∈ T := by
+  sorry
+
+/-- **The approximate homomorphism form of Marton's conjecture**, `[GGMT]`, Corollary 1.5.
+
+Let `G` and `G'` be finite abelian groups of exponent `2` and let `f : G → G'` be a function
+such that `f (x + y) = f x + f y` for at least a proportion `K⁻¹` of the pairs
+`(x, y) ∈ G × G`, written here as `|G| ^ 2 ≤ K * |{(x, y) | f (x + y) = f x + f y}|`. Then
+there is a group homomorphism `φ : G →+ G'` agreeing with `f` on at least
+`(|G| / (2 ^ 144 * K ^ 122) - 1) / 2` points of `G`. -/
+theorem approx_hom_pfr {G G' : Type*} [AddCommGroup G] [AddCommGroup G'] [Finite G] [Finite G']
+    (h2 : ∀ x : G, 2 • x = 0) (h2' : ∀ y : G', 2 • y = 0) (f : G → G') {K : ℝ} (hK : 0 < K)
+    (hf : (Nat.card G : ℝ) ^ 2 ≤ K * Nat.card {x : G × G | f (x.1 + x.2) = f x.1 + f x.2}) :
+    ∃ φ : G →+ G',
+      (Nat.card G / (2 ^ 144 * K ^ 122) - 1) / 2 ≤ Nat.card {x : G | f x = φ x} := by
+  sorry
+
+end Marton

--- a/Palomar/Solution.lean
+++ b/Palomar/Solution.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 Terence Tao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
+import PFR.ApproxHomPFR
+import PFR.HomPFR
+import PFR.Main
+import PFR.RhoFunctional
+import PFR.TorsionEndgame
+import PFR.WeakPFR
+
+/-!
+# Marton's conjecture: proofs
+
+Proofs of the statements of `Palomar.Challenge`, obtained from the corresponding results of
+the `PFR` library.
+-/
+
+set_option linter.style.haveILetI false
+
+open Pointwise Function Set
+
+namespace Marton
+
+private theorem pfr_conjecture_aux {G : Type*} [AddCommGroup G] [Module (ZMod 2) G]
+    {A : Set G} (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ}
+    (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < 2 * K ^ 12 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  obtain ⟨H, c, hc, hH, hcard, hHA, hsub⟩ := PFR_conjecture' hA₀ hA hAK
+  exact ⟨H.toAddSubgroup, c, hc, hH, by exact_mod_cast hcard, hHA, hsub⟩
+
+theorem pfr_conjecture {G : Type*} [AddCommGroup G] (h2 : ∀ x : G, 2 • x = 0) {A : Set G}
+    (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ} (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < 2 * K ^ 12 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  letI := AddCommGroup.zmodModule h2
+  exact pfr_conjecture_aux hA hA₀ hAK
+
+private theorem pfr_conjecture_nine_aux {G : Type*} [AddCommGroup G] [Module (ZMod 2) G]
+    {A : Set G} (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ}
+    (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < 2 * K ^ 9 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  obtain ⟨H, c, hc, hH, hcard, hHA, hsub⟩ := better_PFR_conjecture' hA₀ hA hAK
+  exact ⟨H.toAddSubgroup, c, hc, hH, hcard, hHA, hsub⟩
+
+theorem pfr_conjecture_nine {G : Type*} [AddCommGroup G] (h2 : ∀ x : G, 2 • x = 0) {A : Set G}
+    (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ} (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < 2 * K ^ 9 ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  letI := AddCommGroup.zmodModule h2
+  exact pfr_conjecture_nine_aux hA hA₀ hAK
+
+private theorem torsion_pfr_aux {G : Type*} [AddCommGroup G] {m : ℕ} [NeZero m]
+    [Module (ZMod m) G] (hm : 2 ≤ m) (htorsion : ∀ x : G, m • x = 0) {A : Set G}
+    (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ} (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < m * K ^ (256 * m ^ 3 + 1) ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  let G' := Submodule.span (ZMod m) A
+  let G'fin : Fintype G' := (hA.submoduleSpan _).fintype
+  let ι : G' →ₗ[ZMod m] G := G'.subtype
+  have ι_inj : Injective ι := G'.toAddSubgroup.subtype_injective
+  let f : G' →+ G := (ι : G' →ₗ[ZMod m] G).toAddMonoidHom
+  let A' : Set G' := ι ⁻¹' A
+  have A_rg : A ⊆ range ι := by simp [G', ι]
+  have cardA' : Nat.card A' = Nat.card A := Nat.card_preimage_of_injective ι_inj A_rg
+  have hA' : Nat.card (A' + A') ≤ K * Nat.card A' := by
+    rwa [cardA', ← preimage_add _ ι_inj A_rg A_rg,
+      Nat.card_preimage_of_injective ι_inj (add_subset_range _ A_rg A_rg)]
+  have htorsion' : ∀ x : G', m • x = 0 := fun x ↦ by
+    ext
+    push_cast
+    exact htorsion x.1
+  obtain ⟨H', c', hc', hH'A, hsub⟩ := torsion_PFR hm htorsion' (hA₀.preimage' A_rg) hA'
+  have hHmap : ((H'.map f : AddSubgroup G) : Set G) = ι '' (H' : Set G') := by
+    rw [AddSubgroup.coe_map]; rfl
+  refine ⟨H'.map f, ι '' c', toFinite _,
+    by rw [hHmap]; exact (toFinite (H' : Set G')).image ι, ?_, ?_, fun x hx ↦ ?_⟩
+  · rwa [Nat.card_image_of_injective ι_inj]
+  · rw [show Nat.card (H'.map f : AddSubgroup G)
+      = ((H'.map f : AddSubgroup G) : Set G).ncard from rfl, hHmap]
+    simpa [Set.ncard_image_of_injective _ ι_inj, ← cardA'] using hH'A
+  · rw [hHmap, ← image_add]
+    exact ⟨⟨x, Submodule.subset_span hx⟩, hsub hx, rfl⟩
+
+theorem torsion_pfr_conjecture {G : Type*} [AddCommGroup G] {m : ℕ} (hm : 2 ≤ m)
+    (htorsion : ∀ x : G, m • x = 0) {A : Set G} (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ}
+    (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ (H : AddSubgroup G) (c : Set G), c.Finite ∧ (H : Set G).Finite ∧
+      Nat.card c < m * K ^ (256 * m ^ 3 + 1) ∧ Nat.card H ≤ Nat.card A ∧ A ⊆ c + H := by
+  have hne : NeZero m := ⟨by omega⟩
+  letI := AddCommGroup.zmodModule htorsion
+  exact torsion_pfr_aux hm htorsion hA hA₀ hAK
+
+theorem weak_pfr_int {G : Type*} [AddCommGroup G] [Module.Free ℤ G] [Module.Finite ℤ G]
+    {A : Set G} (hA : A.Finite) (hA₀ : A.Nonempty) {K : ℝ}
+    (hAK : Nat.card (A + A) ≤ K * Nat.card A) :
+    ∃ A' ⊆ A, K ^ (-34 : ℝ) * Nat.card A ≤ Nat.card A' ∧
+      (Module.finrank ℤ (vectorSpan ℤ A') : ℝ) ≤ (80 / Real.log 2) * Real.log K := by
+  classical
+  obtain ⟨s, rfl⟩ : ∃ s : Finset G, (↑s : Set G) = A := ⟨hA.toFinset, hA.coe_toFinset⟩
+  have hsne : s.Nonempty := by simpa using hA₀
+  have hs₀ : (0 : ℝ) < s.card := by exact_mod_cast Finset.card_pos.2 hsne
+  have hcoe : ∀ t : Finset G, Nat.card (↑t : Set G) = t.card := fun t ↦ by simp
+  rw [show ((↑s : Set G) + ↑s) = ((s + s : Finset G) : Set G) by simp, hcoe, hcoe] at hAK
+  have hsum₀ : (0 : ℝ) ≤ (s + s).card := by positivity
+  have hK₁ : (1 : ℝ) ≤ K := by
+    have h1 : (s.card : ℝ) ≤ ((s + s).card : ℝ) := by
+      exact_mod_cast Finset.card_le_card_add_left hsne
+    nlinarith
+  have hruzsa : ((s - s).card : ℝ) * s.card ≤ ((s + s).card : ℝ) * ((s + s).card : ℝ) := by
+    exact_mod_cast Finset.ruzsa_triangle_inequality_sub_add_add s s s
+  have hcoesub : ((s : Set G) - (s : Set G)) = ((s - s : Finset G) : Set G) := by
+    simp
+  have hdiff : (Nat.card ((s : Set G) - (s : Set G)) : ℝ) ≤ K ^ 2 * Nat.card (s : Set G) := by
+    rw [hcoesub, hcoe, hcoe]
+    nlinarith
+  obtain ⟨A', hA'sub, hcard, hdim⟩ := weak_PFR_int (K := K ^ 2) hA₀ hdiff
+  refine ⟨A', hA'sub, ?_, ?_⟩
+  · refine le_trans (le_of_eq ?_) hcard
+    rw [← Real.rpow_natCast K 2, ← Real.rpow_mul (by linarith : (0:ℝ) ≤ K)]
+    norm_num
+  · refine le_trans hdim (le_of_eq ?_)
+    rw [Real.log_pow]
+    push_cast
+    ring
+
+private theorem homomorphism_pfr_aux {G G' : Type*} [AddCommGroup G] [AddCommGroup G']
+    [Module (ZMod 2) G] [Module (ZMod 2) G'] [Finite G] [Finite G'] (f : G → G') (S : Set G')
+    (hS : ∀ x y : G, f (x + y) - f x - f y ∈ S) :
+    ∃ (φ : G →+ G') (T : Set G'), Nat.card T ≤ Nat.card S ^ 10 ∧ ∀ x : G, f x - φ x ∈ T :=
+  _root_.homomorphism_pfr f S hS
+
+theorem homomorphism_pfr {G G' : Type*} [AddCommGroup G] [AddCommGroup G'] [Finite G] [Finite G']
+    (h2 : ∀ x : G, 2 • x = 0) (h2' : ∀ y : G', 2 • y = 0) (f : G → G') (S : Set G')
+    (hS : ∀ x y : G, f (x + y) - f x - f y ∈ S) :
+    ∃ (φ : G →+ G') (T : Set G'), Nat.card T ≤ Nat.card S ^ 10 ∧ ∀ x : G, f x - φ x ∈ T := by
+  letI := AddCommGroup.zmodModule h2
+  letI := AddCommGroup.zmodModule h2'
+  exact homomorphism_pfr_aux f S hS
+
+private theorem approx_hom_pfr_aux {G G' : Type*} [AddCommGroup G] [AddCommGroup G']
+    [Module (ZMod 2) G] [Module (ZMod 2) G'] [Finite G] [Finite G'] (f : G → G') {K : ℝ}
+    (hK : 0 < K)
+    (hf : (Nat.card G : ℝ) ^ 2 ≤ K * Nat.card {x : G × G | f (x.1 + x.2) = f x.1 + f x.2}) :
+    ∃ φ : G →+ G',
+      (Nat.card G / (2 ^ 144 * K ^ 122) - 1) / 2 ≤ Nat.card {x : G | f x = φ x} := by
+  classical
+  have _ : Fintype G := Fintype.ofFinite G
+  have hGcard : (0 : ℝ) < Fintype.card G := by
+    exact_mod_cast Fintype.card_pos (α := G)
+  have hfilter : Nat.card {x : G × G | f (x.1 + x.2) = f x.1 + f x.2}
+      = ({x : G × G | f (x.1 + x.2) = f x.1 + f x.2} : Finset (G × G)).card := by
+    simp [Nat.card_eq_fintype_card, Fintype.card_subtype]
+  have hdens : K⁻¹ ≤ Finset.dens {x : G × G | f (x.1 + x.2) = f x.1 + f x.2} := by
+    rw [Finset.nnratCast_dens, Fintype.card_prod, le_div_iff₀ (by positivity)]
+    rw [hfilter, Nat.card_eq_fintype_card] at hf
+    push_cast
+    rw [inv_mul_le_iff₀ hK]
+    nlinarith
+  exact _root_.approx_hom_pfr' f K hK hdens
+
+theorem approx_hom_pfr {G G' : Type*} [AddCommGroup G] [AddCommGroup G'] [Finite G] [Finite G']
+    (h2 : ∀ x : G, 2 • x = 0) (h2' : ∀ y : G', 2 • y = 0) (f : G → G') {K : ℝ} (hK : 0 < K)
+    (hf : (Nat.card G : ℝ) ^ 2 ≤ K * Nat.card {x : G × G | f (x.1 + x.2) = f x.1 + f x.2}) :
+    ∃ φ : G →+ G',
+      (Nat.card G / (2 ^ 144 * K ^ 122) - 1) / 2 ≤ Nat.card {x : G | f x = φ x} := by
+  letI := AddCommGroup.zmodModule h2
+  letI := AddCommGroup.zmodModule h2'
+  exact approx_hom_pfr_aux f hK hf
+
+end Marton

--- a/README.md
+++ b/README.md
@@ -30,6 +30,29 @@ See instructions at <https://github.com/PatrickMassot/leanblueprint/>.
 
 As the first two phases of the project are completed, we are currently working towards stabilising the new results and contributing them to mathlib.
 
+## Palomar registration
+
+[`Palomar/Challenge.lean`](Palomar/Challenge.lean) states, in Lean-core-and-Mathlib
+terms only, the six headline theorems of the three source papers, and
+[`Palomar/Solution.lean`](Palomar/Solution.lean) proves each of them from the
+corresponding result in `PFR/`. The pair is the [Palomar](https://palomar-registry.org)
+Challenge/Solution record for this project; [`comparator.json`](comparator.json) names the
+six compared declarations and [`formalization.yaml`](formalization.yaml) carries the
+structured provenance, the correspondence with the papers, and the limitations.
+
+The six are: Marton's conjecture in characteristic 2 with exponent 12 (`[GGMT]`,
+Theorem 1.2) and with exponent 9 (`[L]`), Marton's conjecture in abelian groups of
+bounded torsion (`[GGMT2]`, Theorem 1.1), weak PFR over the integers (`[GGMT]`,
+Theorem 1.3), and the homomorphism and approximate homomorphism forms (`[GGMT]`,
+Corollaries 1.4 and 1.5). The entropy forms of the conjecture are proved here too but
+are not among the compared declarations, because a Palomar Challenge module may not
+import anything outside Lean core and Mathlib, and Mathlib has no Shannon entropy or
+entropic Ruzsa distance.
+
+`Palomar/Challenge.lean` contains six deliberate `sorry`s, one per compared theorem;
+that is the Comparator convention, and it is the only place in the repository where
+`sorry` occurs.
+
 ## Source reference
 
 `[GGMT]`: <https://arxiv.org/abs/2311.05762>

--- a/comparator.json
+++ b/comparator.json
@@ -1,0 +1,13 @@
+{
+  "challenge_module": "Palomar.Challenge",
+  "solution_module": "Palomar.Solution",
+  "theorem_names": [
+    "Marton.pfr_conjecture",
+    "Marton.pfr_conjecture_nine",
+    "Marton.torsion_pfr_conjecture",
+    "Marton.weak_pfr_int",
+    "Marton.homomorphism_pfr",
+    "Marton.approx_hom_pfr"
+  ],
+  "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"]
+}

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -39,7 +39,7 @@ project:
     - "Sébastien Gouëzel"
     - "Kalle Kytölä"
     - "Rob Lewis"
-    - "Paul Lez"
+    - "Paul Lezeau"
     - "Lorenzo Luccioli"
     - "Heather Macbeth"
     - "Patrick Massot"

--- a/formalization.yaml
+++ b/formalization.yaml
@@ -1,0 +1,406 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/mathlib-initiative/formalization.yaml/main/schema/formalization.schema.json
+version: "v0.4"
+
+project:
+  name: "Marton's conjecture (the polynomial Freiman-Ruzsa conjecture)"
+  description: >-
+    A Lean formalization of Marton's conjecture, widely known as the
+    polynomial Freiman-Ruzsa conjecture, together with its principal
+    consequences. If A is a non-empty subset of an abelian group of exponent 2
+    with |A + A| <= K|A|, then A is covered by fewer than 2K^12 cosets of a
+    subgroup of cardinality at most |A|; the same conclusion holds with 2K^9
+    cosets. For an abelian group in which mx = 0 for every x, with m >= 2, the
+    covering number is m * K^(256m^3 + 1). Three consequences are also
+    recorded: a finite set of small doubling in Z^D has a subset of at least
+    K^(-34) of its size whose affine dimension is at most (80/log 2) log K; a
+    map between finite groups of exponent 2 whose additive defects
+    f(x+y) - f(x) - f(y) all lie in a set S differs from a homomorphism by a
+    map taking at most |S|^10 values; and a map that is additive on at least a
+    proportion 1/K of pairs agrees with a homomorphism on at least
+    (|G| / (2^144 K^122) - 1)/2 points. The proofs are by an entropy method:
+    one minimizes a functional of the entropic Ruzsa distance between two
+    random variables and shows the minimum is attained at a uniform
+    distribution on a subgroup, so the development also builds a substantial
+    theory of Shannon entropy, entropic Ruzsa distance, and, for the bounded
+    torsion case, a multidistance for m-tuples. The repository is a
+    collaborative formalization project begun in November 2023; the
+    mathematics is due to the cited papers and nothing here is claimed to be
+    new. The compared theorems depend on propext, Classical.choice and
+    Quot.sound and on nothing else, and there is no sorry outside the six
+    deliberate holes in Palomar/Challenge.lean.
+  authors:
+    - "Aaron Anderson"
+    - "Mantas Bakšys"
+    - "Jonas Bayer"
+    - "Mauricio Collares"
+    - "Rémy Degenne"
+    - "Yaël Dillies"
+    - "Ben Eltschig"
+    - "Sébastien Gouëzel"
+    - "Kalle Kytölä"
+    - "Rob Lewis"
+    - "Paul Lez"
+    - "Lorenzo Luccioli"
+    - "Heather Macbeth"
+    - "Patrick Massot"
+    - "Arend Mellendijk"
+    - "Kyle Miller"
+    - "Pietro Monticone"
+    - "Kim Morrison"
+    - "Oliver Nash"
+    - "Utensil Song"
+    - "Terence Tao"
+    - "Floris van Doorn"
+    - "Sky Wilshaw"
+    - "Lawrence Wu"
+  license: "Apache-2.0"
+  responsible_maintainers:
+    - "Terence Tao"
+    - "Yaël Dillies"
+
+repository:
+  role: substantive-development
+
+classification:
+  arxiv: [math.CO, math.NT]
+  msc2020: ["11B30", "11P70", "20K01", "94A17"]
+
+status:
+  scope: >-
+    Complete, with no unproved step, for each of the six compared theorems.
+    Three families of results are formalized but are not among the compared
+    declarations, because Palomar requires the Challenge module to import only
+    Lean core and Mathlib, and Mathlib has no Shannon entropy or entropic
+    Ruzsa distance: the entropy form of the conjecture in characteristic 2
+    (Theorem 1.8 of the arXiv:2311.05762 entry below, formalized as
+    entropic_PFR_conjecture and entropic_PFR_conjecture'), the entropy form in
+    the bounded torsion case (formalized as dist_of_X_U_H_le), and the
+    Kullback-Leibler and rho-functional machinery of the arXiv:2404.09639
+    entry (rho_PFR_conjecture and its supporting theory). The exponent-11
+    intermediate result of an earlier version of arXiv:2404.09639 is likewise
+    formalized (PFR_conjecture_improv) but not compared, being superseded by
+    the exponent-9 statement. Corollary 1.6 and Corollary 1.7 of
+    arXiv:2311.05762 and Corollary 1.2 of arXiv:2404.02244 are not formalized
+    at all.
+  # The proof development contains no sorry at all. The only six in the
+  # repository are the deliberate placeholders in Palomar/Challenge.lean,
+  # which these counts exclude by convention.
+  sorry_count: 0
+  sorry_in_definitions: 0
+  axioms: ["propext", "Classical.choice", "Quot.sound"]
+  main_results:
+    - declaration: "Marton.pfr_conjecture"
+      file: "Palomar/Solution.lean"
+      sorry_count: 0
+      axioms: ["propext", "Classical.choice", "Quot.sound"]
+      comparator_config: "comparator.json"
+      literature_dependencies: []
+    - declaration: "Marton.pfr_conjecture_nine"
+      file: "Palomar/Solution.lean"
+      sorry_count: 0
+      axioms: ["propext", "Classical.choice", "Quot.sound"]
+      comparator_config: "comparator.json"
+      literature_dependencies: []
+    - declaration: "Marton.torsion_pfr_conjecture"
+      file: "Palomar/Solution.lean"
+      sorry_count: 0
+      axioms: ["propext", "Classical.choice", "Quot.sound"]
+      comparator_config: "comparator.json"
+      literature_dependencies: []
+    - declaration: "Marton.weak_pfr_int"
+      file: "Palomar/Solution.lean"
+      sorry_count: 0
+      axioms: ["propext", "Classical.choice", "Quot.sound"]
+      comparator_config: "comparator.json"
+      literature_dependencies: []
+    - declaration: "Marton.homomorphism_pfr"
+      file: "Palomar/Solution.lean"
+      sorry_count: 0
+      axioms: ["propext", "Classical.choice", "Quot.sound"]
+      comparator_config: "comparator.json"
+      literature_dependencies: []
+    - declaration: "Marton.approx_hom_pfr"
+      file: "Palomar/Solution.lean"
+      sorry_count: 0
+      axioms: ["propext", "Classical.choice", "Quot.sound"]
+      comparator_config: "comparator.json"
+      literature_dependencies: []
+
+fidelity:
+  divergences: >-
+    Faithful to the sources, and in three respects stronger than them. First,
+    the two characteristic-2 statements and the bounded-torsion statement are
+    proved for an arbitrary abelian group in which every element satisfies
+    2x = 0 (respectively mx = 0), with A merely finite, rather than for a
+    finite group; the papers state them for F_2^n and for a group of torsion
+    m. The bounded-torsion generalization is not present in the library
+    itself, whose torsion_PFR assumes a finite ambient group; it is obtained
+    in Palomar/Solution.lean by passing to the span of A over ZMod m, which is
+    finite because A is. Second, every constant is explicit where the papers
+    leave one unspecified: Theorem 1.3 of arXiv:2311.05762 asserts the
+    existence of absolute constants C_1 and C_2, and Marton.weak_pfr_int
+    realizes C_1 = 68 and C_2 = 80/log 2; Corollary 1.4 and Corollary 1.5 of
+    the same paper assert bounds O(K^{C_3}) and >> K^{-C_4}, and the
+    corresponding statements here give |S|^10 and (|G|/(2^144 K^122) - 1)/2;
+    Theorem 1.1 of arXiv:2404.02244 asserts (2K)^{O(m^3)} and
+    Marton.torsion_pfr_conjecture gives m K^{256m^3+1}. Third,
+    Marton.pfr_conjecture_nine implies Marton.pfr_conjecture, since a
+    non-empty A forces K >= 1; the weaker exponent 12 is nevertheless recorded
+    separately because it is the headline theorem of a different paper.
+    In one respect the compared statement is weaker than what the library
+    proves: weak_PFR_int in the library hypothesises |A - A| <= K|A| and
+    concludes with K^(-17) and (40/log 2) log K, whereas the compared
+    Marton.weak_pfr_int hypothesises |A + A| <= K|A| as Theorem 1.3 of
+    arXiv:2311.05762 does, which is obtained from the library statement in
+    Palomar/Solution.lean by Ruzsa's triangle inequality at the cost of
+    squaring K. Hypotheses are phrased for a reader rather than for the
+    library: torsion is stated as a universally quantified equation rather
+    than through a Module (ZMod m) instance, subgroups are returned as
+    AddSubgroup rather than as Submodule (ZMod 2), and affine dimension is
+    expressed as Module.finrank of a vectorSpan rather than through the
+    project's AffineSpace.finrank abbreviation. Declaration names in the
+    library differ from those in Palomar/Challenge.lean; the alignment section
+    below records the correspondence, and blueprint/src/chapter/ records the
+    correspondence with the informal arguments.
+
+# ---------------------------------------------------------------------------
+# Mathematical sources.
+#
+# This is a source-based formalization. None of the results is new, none is
+# claimed to be new, and no literature search was performed: the three papers
+# below are the published sources of every compared theorem, and the
+# repository exists to formalize them.
+# ---------------------------------------------------------------------------
+sources:
+  - title: "On a conjecture of Marton"
+    authors: ["W. T. Gowers", "Ben Green", "Freddie Manners", "Terence Tao"]
+    type: "preprint"
+    id: "arXiv:2311.05762"
+    relationship: formalizes
+    note: >-
+      The source of four of the six compared theorems: Theorem 1.2 is
+      Marton.pfr_conjecture, Theorem 1.3 is Marton.weak_pfr_int, Corollary 1.4
+      is Marton.homomorphism_pfr and Corollary 1.5 is Marton.approx_hom_pfr.
+      Its Theorem 1.8, the entropy form, is formalized in the repository as
+      entropic_PFR_conjecture but is not compared, for the reason given under
+      status.scope. Its Corollary 1.6 (an inverse theorem for the Gowers U^3
+      norm) and Corollary 1.7 (a sum-product consequence attributed there to
+      Mudgal) are not formalized.
+
+  - title: "Marton's conjecture in abelian groups with bounded torsion"
+    authors: ["W. T. Gowers", "Ben Green", "Freddie Manners", "Terence Tao"]
+    type: "preprint"
+    id: "arXiv:2404.02244"
+    relationship: formalizes
+    note: >-
+      The source of Marton.torsion_pfr_conjecture, which is its Theorem 1.1
+      with the implied constant made explicit. Its Theorem 1.3, the entropy
+      form in the bounded torsion case, is formalized in the repository as
+      dist_of_X_U_H_le but is not compared. Its Corollary 1.2 (an inverse
+      theorem for the U^3 norm over F_p^n) is not formalized.
+
+  - title: "Improved Exponent for Marton's Conjecture in $\\mathbb{F}_2^n$"
+    authors: ["Jyun-Jie Liao"]
+    type: "preprint"
+    id: "arXiv:2404.09639"
+    relationship: formalizes
+    note: >-
+      The source of Marton.pfr_conjecture_nine, its main theorem, which
+      improves the exponent in the characteristic-2 case from 12 to 9. The
+      Kullback-Leibler divergence and rho-functional machinery its proof
+      introduces is formalized in PFR/Kullback.lean and PFR/RhoFunctional.lean.
+      An earlier version of this paper obtained the exponent 11; that
+      intermediate result is formalized as PFR_conjecture_improv and is not
+      compared, being superseded.
+
+# ---------------------------------------------------------------------------
+# How this was produced.
+# ---------------------------------------------------------------------------
+automation:
+  methods:
+    - method: manual
+      role: >-
+        The formalization in PFR/ was written by hand by the contributors
+        listed under project.authors, between November 2023 and 2025, as a
+        collaborative open project coordinated through a LaTeX blueprint in
+        blueprint/ and a Zulip stream. No automated proof generation was used
+        for it.
+    - method: agent
+      models: ["Claude Opus 5 (Anthropic)"]
+      framework: "Claude Code"
+      role: >-
+        Wrote the two Palomar files, Palomar/Challenge.lean and
+        Palomar/Solution.lean, under the direction and review of the
+        responsible maintainer: selecting which library results correspond to
+        the headline theorems of the three sources, restating them in
+        Mathlib-only terms, and supplying the two bridging arguments recorded
+        under fidelity.divergences (the passage to a finite span for the
+        bounded torsion case, and the Ruzsa triangle inequality step for the
+        weak statement over the integers). It also made the two-line change to
+        PFR/WeakPFR.lean described under limitations. It did not write, and
+        did not modify, any of the mathematical development in PFR/.
+
+review:
+  status: self-assessed
+  reviewers:
+    - "Terence Tao"
+  notes: >-
+    The development in PFR/ was produced in the open: contributions arrived as
+    pull requests reviewed by project participants, were tracked against a
+    blueprint whose dependency graph is published, and were discussed on a
+    public Zulip stream. That is ordinary open-source project review, not
+    referee review of the formalization, and no external body has certified
+    it. The Palomar files and the correspondence between the compared
+    statements and the three sources were checked by the responsible
+    maintainer. Every step is checked by Lean.
+
+# ---------------------------------------------------------------------------
+# Limitations, stated so that a reader can calibrate the claim.
+# ---------------------------------------------------------------------------
+known_gaps: []
+
+limitations:
+  - >-
+    No novelty is claimed. All three sources predate this formalization, and
+    the repository exists to formalize them. No literature search beyond the
+    three sources was performed, and no claim is made about whether the
+    statements have been formalized elsewhere.
+  - >-
+    The compared theorems depend on propext, Classical.choice and Quot.sound,
+    and on nothing else. There is no sorry in the development, no
+    project-defined axiom, no native_decide, no unsafe declaration, no
+    @[implemented_by] and no Float anywhere in PFR/ or Palomar/. The six
+    sorries in Palomar/Challenge.lean are the deliberate Comparator holes, one
+    per compared theorem.
+  - >-
+    The Lakefile sets warn.sorry = false, so `lake build` is silent about
+    those six deliberate holes. It would be equally silent about an accidental
+    one in Palomar/Solution.lean; that case is caught by Comparator's axiom
+    check rather than by the build.
+  - >-
+    Two lines of PFR/WeakPFR.lean were changed in preparation for this
+    submission, at the two `variable` lines that carried
+    `(mu : Measure Omega := by volume_tac)`. Under the Lean module system the
+    auto-generated helper holding that tactic is not exposed across the module
+    boundary, so an importing module saw `autoParam (Measure Omega) sorry` in
+    the type, and nine declarations in that file, including weak_PFR_int,
+    consequently reported sorryAx even though the file contains no sorry. The
+    defaults were removed; every call site already passed the measures
+    explicitly, no statement changed, and the whole project still builds. Only
+    that file was affected.
+  - >-
+    Marton.weak_pfr_int is stated for a finitely generated free Z-module,
+    which is the Lean rendering of Z^D, rather than for an arbitrary abelian
+    group; that matches Theorem 1.3 of arXiv:2311.05762.
+  - >-
+    Palomar/Challenge.lean states the six results but does not prove them;
+    that is the Comparator convention, and Palomar/Solution.lean supplies the
+    proofs.
+
+# ---------------------------------------------------------------------------
+# How the cited statements correspond to Lean declarations.
+#
+# This is the source-to-formal map, not a lemma index. The full roadmap of
+# intermediate lemmas is the blueprint in blueprint/src/chapter/, whose every
+# statement carries the name of the Lean declaration proving it.
+# ---------------------------------------------------------------------------
+alignment:
+  # The development lives in the root namespace. The six compared declarations
+  # live in `Marton`, which is what comparator.json names and what
+  # Palomar/Challenge.lean states.
+  namespace: ""
+  statements:
+    - source: "arXiv:2311.05762, Theorem 1.2: Marton's conjecture in F_2^n with C = 12"
+      lean: "Marton.pfr_conjecture"
+      module: "Palomar.Challenge (statement), Palomar.Solution (proof)"
+      status: extends-source
+      note: >-
+        Discharged from PFR_conjecture' (PFR/Main.lean), which is the
+        infinite-ambient-group corollary of PFR_conjecture. Stated here for any
+        abelian group of exponent 2 rather than for F_2^n, and with the
+        subgroup returned as an AddSubgroup rather than a Submodule (ZMod 2).
+
+    - source: "arXiv:2404.09639, main theorem: Marton's conjecture in F_2^n with C = 9"
+      lean: "Marton.pfr_conjecture_nine"
+      module: "Palomar.Challenge (statement), Palomar.Solution (proof)"
+      status: extends-source
+      note: >-
+        Discharged from better_PFR_conjecture' (PFR/RhoFunctional.lean). The
+        same generalization of the ambient group as the row above. This
+        statement implies the previous one.
+
+    - source: "arXiv:2404.02244, Theorem 1.1: Marton's conjecture in abelian groups of torsion m"
+      lean: "Marton.torsion_pfr_conjecture"
+      module: "Palomar.Challenge (statement), Palomar.Solution (proof)"
+      status: extends-source
+      note: >-
+        Discharged from torsion_PFR (PFR/TorsionEndgame.lean), which assumes a
+        finite ambient group; the compared statement removes that assumption by
+        passing to the ZMod m-span of A, finite because A is. The paper's
+        (2K)^{O(m^3)} is made explicit as m K^{256m^3+1}.
+
+    - source: "arXiv:2311.05762, Theorem 1.3: weak Marton's conjecture over Z^D"
+      lean: "Marton.weak_pfr_int"
+      module: "Palomar.Challenge (statement), Palomar.Solution (proof)"
+      status: proved
+      note: >-
+        Discharged from weak_PFR_int (PFR/WeakPFR.lean), which hypothesises
+        |A - A| <= K|A|; the compared statement hypothesises |A + A| <= K|A| as
+        the paper does, and is obtained by Ruzsa's triangle inequality
+        (Finset.ruzsa_triangle_inequality_sub_add_add), which gives
+        |A - A| <= K^2|A| and so squares K. This is what turns the library's
+        K^(-17) and (40/log 2) log K into the compared K^(-34) and
+        (80/log 2) log K, realizing the paper's unspecified C_1 = 68 and
+        C_2 = 80/log 2. Affine dimension is expressed as
+        Module.finrank Z (vectorSpan Z A'), which is by definition the
+        project's AffineSpace.finrank Z A'.
+
+    - source: "arXiv:2311.05762, Corollary 1.4: the homomorphism form"
+      lean: "Marton.homomorphism_pfr"
+      module: "Palomar.Challenge (statement), Palomar.Solution (proof)"
+      status: proved
+      note: >-
+        Discharged from homomorphism_pfr (PFR/HomPFR.lean). The paper's
+        O(K^{C_3}) is made explicit as |S|^10, with the hypothesis given as
+        membership of every additive defect in a set S rather than as a
+        cardinality bound on the defect set.
+
+    - source: "arXiv:2311.05762, Corollary 1.5: the approximate homomorphism form"
+      lean: "Marton.approx_hom_pfr"
+      module: "Palomar.Challenge (statement), Palomar.Solution (proof)"
+      status: proved
+      note: >-
+        Discharged from approx_hom_pfr' (PFR/ApproxHomPFR.lean), which is the
+        form matching the paper, with a homomorphism and no additive constant.
+        The library states the density hypothesis with Finset.dens; the
+        compared statement writes it as |G|^2 <= K |{(x,y) : f(x+y) = f x + f y}|
+        to avoid decidability instances in the statement of record. The
+        variant with a constant term, approx_hom_pfr, is also in the library
+        and is not compared.
+
+    - source: "arXiv:2311.05762, Theorem 1.8: the entropy form in characteristic 2"
+      lean: "entropic_PFR_conjecture, entropic_PFR_conjecture'"
+      module: "PFR.EntropyPFR"
+      status: proved-not-compared
+      note: >-
+        Both halves are formalized, with the constants 11 and 6 of the paper.
+        Not compared: the statement needs Shannon entropy and entropic Ruzsa
+        distance, neither of which is in Mathlib, so it cannot be phrased in a
+        Challenge module whose import closure must be Lean core and Mathlib.
+
+    - source: "arXiv:2404.02244, Theorem 1.3: the entropy form in the bounded torsion case"
+      lean: "dist_of_X_U_H_le"
+      module: "PFR.TorsionEndgame"
+      status: proved-not-compared
+      note: >-
+        Formalized with the explicit constant 64 m^3. Not compared, for the
+        same reason as the row above.
+
+    - source: "arXiv:2404.09639, the rho-functional form"
+      lean: "rho_PFR_conjecture"
+      module: "PFR.RhoFunctional"
+      status: proved-not-compared
+      note: >-
+        The rho-functional statement that drives the exponent-9 proof, with
+        the Kullback-Leibler theory it rests on in PFR/Kullback.lean. Not
+        compared, for the same reason as the two rows above.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "PFR"
 keywords = ["math", "additive-combinatorics", "information-theory"]
-defaultTargets = ["PFR"]
+defaultTargets = ["PFR", "Palomar"]
 
 [leanOptions]
 # Pretty-prints `fun a ↦ b`
@@ -31,3 +31,7 @@ rev = "v4.34.0-rc2"
 
 [[lean_lib]]
 name = "PFR"
+
+[[lean_lib]]
+name = "Palomar"
+roots = ["Palomar.Challenge", "Palomar.Solution"]


### PR DESCRIPTION
Prepares the repository for registration at the [Palomar registry](https://palomar-registry.org), which certifies a Lean formalization by mechanically checking that a recorded proof proves a recorded statement and then publishing an immutable citable record.

Nothing mathematical in `PFR/` changes. **I would like contributor feedback before submitting** — in particular on the metadata in `formalization.yaml`, which names all 24 of us as authors.

## What is added

- **`Palomar/Challenge.lean`** — the statement of record. It states six theorems and proves none of them; the six `sorry`s are the Comparator convention and are the only ones in the repository. Its transitive import closure is Lean core and Mathlib only, which Palomar requires, so it is readable without any definition of this project.
- **`Palomar/Solution.lean`** — proves each of the six from the corresponding result in `PFR/`.
- **`comparator.json`** — names the six compared declarations.
- **`formalization.yaml`** — structured provenance, the source-to-formal map, and the limitations.
- A `Palomar registration` section in the README, and a `Palomar` Lake target so CI compiles both files.

## The six compared theorems

| Paper | Statement | `PFR/` declaration it is proved from |
|---|---|---|
| [GGMT] Thm 1.2 | `Marton.pfr_conjecture` — char. 2, `2K^12` cosets | `PFR_conjecture'` |
| [L] main thm | `Marton.pfr_conjecture_nine` — char. 2, `2K^9` cosets | `better_PFR_conjecture'` |
| [GGMT2] Thm 1.1 | `Marton.torsion_pfr_conjecture` — torsion `m`, `m·K^(256m³+1)` cosets | `torsion_PFR` |
| [GGMT] Thm 1.3 | `Marton.weak_pfr_int` — weak PFR over `ℤ^D` | `weak_PFR_int` |
| [GGMT] Cor 1.4 | `Marton.homomorphism_pfr` | `homomorphism_pfr` |
| [GGMT] Cor 1.5 | `Marton.approx_hom_pfr` | `approx_hom_pfr'` |

The entropy forms ([GGMT] Thm 1.8, [GGMT2] Thm 1.3, and the ρ-functional statement of [L]) are proved here too but are not among the compared declarations: they need Shannon entropy and entropic Ruzsa distance, neither of which is in Mathlib, so they cannot be stated in a Challenge module. `formalization.yaml` says so explicitly.

## Two bridges, supplied in `Solution.lean`

- **The bounded-torsion statement is generalized.** `torsion_PFR` assumes a finite ambient group; [GGMT2] Thm 1.1 does not. The compared statement drops the assumption by passing to the `ZMod m`-span of `A`, which is finite because `A` is.
- **Weak PFR is restated with the paper's hypothesis.** `weak_PFR_int` hypothesises `|A - A| ≤ K|A|`; [GGMT] Thm 1.3 hypothesises `|A + A| ≤ K|A|`. Ruzsa's triangle inequality gives `|A - A| ≤ K²|A|`, which squares `K` and turns the library's `K^(-17)` and `(40/log 2)·log K` into `K^(-34)` and `(80/log 2)·log K` — realizing the paper's unspecified `C₁ = 68` and `C₂ = 80/log 2`.

Hypotheses are also phrased for a reader rather than for the library: torsion is `∀ x, m • x = 0` rather than a `Module (ZMod m) G` instance, subgroups come back as `AddSubgroup`, and affine dimension is `Module.finrank ℤ (vectorSpan ℤ A')`.

## One real fix to `PFR/WeakPFR.lean`

`#print axioms weak_PFR_int` on master returns **`sorryAx`**, and so do eight other declarations in that file — `torsion_free_doubling`, `torsion_dist_shrinking`, `app_ent_PFR`, `PFR_projection`, `PFR_projection'`, `weak_PFR_asymm_prelim`, `weak_PFR_asymm`, `weak_PFR`. There is no `sorry` anywhere in the source.

The cause is that two `variable` lines carried `(μ : Measure Ω := by volume_tac)`. Under the Lean module system the auto-generated helper holding that tactic is not exposed across the module boundary, so an importing module sees `autoParam (Measure Ω) sorry` in the type. Declaration-level auto-params, as in `RuzsaDist.lean`, are unaffected — only the `variable`-level ones.

The fix is to drop the two defaults. Every call site already passes the measures explicitly, no statement changed, and the full build stays green. `Examples.lean` never checked axioms for the WeakPFR results, which is why this went unnoticed.

## Verified locally

- Challenge and Solution declare **identical types** under `set_option pp.all true`, for all six.
- All six compared declarations depend on exactly `propext`, `Classical.choice`, `Quot.sound`.
- The Challenge's transitive import closure contains **no** non-Mathlib module.
- `formalization.yaml` is accepted by Palomar's own `load_formalization_metadata`, as `source-based` / `substantive-development`.
- Full `lake build` green, Challenge and Solution included.

Comparator itself needs Linux Landlock and cannot run on Windows; these are its three guarantees checked directly.

## Note on `lakefile.toml`

It sets `warn.sorry = false`, so `lake build` is silent about the six deliberate holes — and would be equally silent about an accidental one in `Solution.lean`. Comparator's axiom check catches that case; `formalization.yaml` records the caveat.

Also corrects the reversal of Lorenzo Luccioli's given and family names in `CITATION.cff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
