### PR TITLE
Drop the probability-measure hypothesis from prob_ge_exp_neg_entropy

### DIFF
--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -211,14 +211,11 @@ lemma entropy_eq_log_card {X : Ω → S} [Fintype S] [MeasurableSingletonClass S
   simp
 
 /-- If `X` is an `S`-valued random variable, then there exists `s ∈ S` such that
-`P[X = s] ≥ \exp(- H[X])`.
-
-TODO: remove the probability measure hypothesis, which is unnecessary here. -/
-lemma prob_ge_exp_neg_entropy [MeasurableSingletonClass S] (X : Ω → S) (μ : Measure Ω)
-    [IsProbabilityMeasure μ] (hX : Measurable X) [hX' : FiniteRange X] :
+`P[X = s] ≥ \exp(- H[X])`. -/
+lemma prob_ge_exp_neg_entropy [MeasurableSingletonClass S] [Nonempty S]
+    (X : Ω → S) (μ : Measure Ω)
+    (hX : Measurable X) [hX' : FiniteRange X] :
     ∃ s : S, μ Set.univ * (rexp (- H[X ; μ])).toNNReal ≤ μ.map X {s} := by
-  have : Nonempty Ω := μ.nonempty_of_neZero
-  have : Nonempty S := Nonempty.map X (by infer_instance)
   let μS := μ.map X
   let μs s := μS {s}
   rcases finiteSupport_of_finiteRange (X := X) with ⟨A, hA⟩

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -278,12 +278,16 @@ lemma prob_ge_exp_neg_entropy [MeasurableSingletonClass S] [Nonempty S]
   let g_lhs s := pdf s * neg_log_pdf s_max
   let g_rhs s := -pdf s * log (pdf s)
   suffices ∑ s ∈ A, g_lhs s ≤ ∑ s ∈ A, g_rhs s by
-    convert! this
-    rw [entropy_eq_sum_finset hA]
-    congr with s
-    simp only [negMulLog, neg_mul, ENNReal.toReal_mul, neg_inj, g_rhs, pdf, pdf_nn]
-    simp at h_norm
-    simp [h_norm, μs, μS, Measure.real]
+    have hA0 : (μ.map X) (A : Set S)ᶜ = 0 := ae_iff.mp hA
+    have hEnt : H[X ; μ] = ∑ s ∈ A, g_rhs s := by
+      rw [entropy_def, measureEntropy_eq_sum hA0]
+      refine Finset.sum_congr rfl fun s _ => ?_
+      have hsmul : (((μ.map X) Set.univ)⁻¹ • μ.map X).real {s} = pdf s := by
+        have huniv : (μ.map X) Set.univ = norm := by
+          rw [h_norm, Measure.map_apply hX MeasurableSet.univ]
+        simp [pdf, pdf_nn, μs, μS, Measure.real, huniv]
+      simp [g_rhs, hsmul, negMulLog]
+    rwa [← hEnt]
   have h_lhs : ∀ s, μs s = 0 → g_lhs s = 0 := by {intros _ h; simp [g_lhs, pdf, pdf_nn, h]}
   have h_rhs : ∀ s, μs s = 0 → g_rhs s = 0 := by {intros _ h; simp [g_rhs, pdf, pdf_nn, h]}
   rw [← Finset.sum_filter_of_ne (fun s _ ↦ (h_lhs s).mt),
@@ -299,7 +303,7 @@ lemma prob_ge_exp_neg_entropy' [MeasurableSingletonClass S]
     {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     [IsProbabilityMeasure μ] (X : Ω → S) (hX : Measurable X) [FiniteRange X] :
     ∃ s : S, rexp (- H[X ; μ]) ≤ μ.real (X ⁻¹' {s}) := by
-  haveI : Nonempty S := (Measure.nonempty_of_neZero μ).map X
+  have : Nonempty S := (Measure.nonempty_of_neZero μ).map X
   obtain ⟨s, hs⟩ := prob_ge_exp_neg_entropy X μ hX
   use s
   rwa [IsProbabilityMeasure.measure_univ, one_mul,

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -299,6 +299,7 @@ lemma prob_ge_exp_neg_entropy' [MeasurableSingletonClass S]
     {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     [IsProbabilityMeasure μ] (X : Ω → S) (hX : Measurable X) [FiniteRange X] :
     ∃ s : S, rexp (- H[X ; μ]) ≤ μ.real (X ⁻¹' {s}) := by
+  haveI : Nonempty S := (Measure.nonempty_of_neZero μ).map X
   obtain ⟨s, hs⟩ := prob_ge_exp_neg_entropy X μ hX
   use s
   rwa [IsProbabilityMeasure.measure_univ, one_mul,

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -284,10 +284,12 @@ lemma prob_ge_exp_neg_entropy [MeasurableSingletonClass S] [Nonempty S]
       refine Finset.sum_congr rfl fun s _ => ?_
       have hsmul : (((μ.map X) Set.univ)⁻¹ • μ.map X).real {s} = pdf s := by
         have huniv : (μ.map X) Set.univ = norm := by
-          rw [h_norm, Measure.map_apply hX MeasurableSet.univ]
+          rw [Measure.map_apply hX MeasurableSet.univ]
+          exact h_norm.symm
         simp [pdf, pdf_nn, μs, μS, Measure.real, huniv]
       simp [g_rhs, hsmul, negMulLog]
-    rwa [← hEnt]
+    rw [hEnt]
+    exact this
   have h_lhs : ∀ s, μs s = 0 → g_lhs s = 0 := by {intros _ h; simp [g_lhs, pdf, pdf_nn, h]}
   have h_rhs : ∀ s, μs s = 0 → g_rhs s = 0 := by {intros _ h; simp [g_rhs, pdf, pdf_nn, h]}
   rw [← Finset.sum_filter_of_ne (fun s _ ↦ (h_lhs s).mt),

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -278,7 +278,7 @@ lemma prob_ge_exp_neg_entropy [MeasurableSingletonClass S] [Nonempty S]
   let g_lhs s := pdf s * neg_log_pdf s_max
   let g_rhs s := -pdf s * log (pdf s)
   suffices ∑ s ∈ A, g_lhs s ≤ ∑ s ∈ A, g_rhs s by
-    have hA0 : (μ.map X) (A : Set S)ᶜ = 0 := ae_iff.mp hA
+    have hA0 : μ.map X (A : Set S)ᶜ = 0 := ae_iff.mp hA
     have hEnt : H[X ; μ] = ∑ s ∈ A, g_rhs s := by
       rw [entropy_def, measureEntropy_eq_sum hA0]
       refine Finset.sum_congr rfl fun s _ => ?_

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -279,7 +279,7 @@ lemma prob_ge_exp_neg_entropy [MeasurableSingletonClass S] [Nonempty S]
   let g_rhs s := -pdf s * log (pdf s)
   suffices ∑ s ∈ A, g_lhs s ≤ ∑ s ∈ A, g_rhs s by
     have hA0 : μ.map X (A : Set S)ᶜ = 0 := ae_iff.mp hA
-    convert this
+    convert! this
     rw [entropy_def, measureEntropy_eq_sum hA0]
     refine Finset.sum_congr rfl fun s _ => ?_
     have hsmul : (((μ.map X) Set.univ)⁻¹ • μ.map X).real {s} = pdf s := by

--- a/PFR/ForMathlib/Entropy/Basic.lean
+++ b/PFR/ForMathlib/Entropy/Basic.lean
@@ -279,17 +279,15 @@ lemma prob_ge_exp_neg_entropy [MeasurableSingletonClass S] [Nonempty S]
   let g_rhs s := -pdf s * log (pdf s)
   suffices ∑ s ∈ A, g_lhs s ≤ ∑ s ∈ A, g_rhs s by
     have hA0 : μ.map X (A : Set S)ᶜ = 0 := ae_iff.mp hA
-    have hEnt : H[X ; μ] = ∑ s ∈ A, g_rhs s := by
-      rw [entropy_def, measureEntropy_eq_sum hA0]
-      refine Finset.sum_congr rfl fun s _ => ?_
-      have hsmul : (((μ.map X) Set.univ)⁻¹ • μ.map X).real {s} = pdf s := by
-        have huniv : (μ.map X) Set.univ = norm := by
-          rw [Measure.map_apply hX MeasurableSet.univ]
-          exact h_norm.symm
-        simp [pdf, pdf_nn, μs, μS, Measure.real, huniv]
-      simp [g_rhs, hsmul, negMulLog]
-    rw [hEnt]
-    exact this
+    convert this
+    rw [entropy_def, measureEntropy_eq_sum hA0]
+    refine Finset.sum_congr rfl fun s _ => ?_
+    have hsmul : (((μ.map X) Set.univ)⁻¹ • μ.map X).real {s} = pdf s := by
+      have huniv : (μ.map X) Set.univ = norm := by
+        rw [Measure.map_apply hX MeasurableSet.univ]
+        exact h_norm.symm
+      simp [pdf, pdf_nn, μs, μS, Measure.real, huniv]
+    simp [g_rhs, hsmul, negMulLog]
   have h_lhs : ∀ s, μs s = 0 → g_lhs s = 0 := by {intros _ h; simp [g_lhs, pdf, pdf_nn, h]}
   have h_rhs : ∀ s, μs s = 0 → g_rhs s = 0 := by {intros _ h; simp [g_rhs, pdf, pdf_nn, h]}
   rw [← Finset.sum_filter_of_ne (fun s _ ↦ (h_lhs s).mt),


### PR DESCRIPTION
## Summary
- `prob_ge_exp_neg_entropy` never uses `μ univ = 1`; it only needs a point of `S` (for the zero-measure case) and already handled `μ = 0`.
- Replace `[IsProbabilityMeasure μ]` with `[Nonempty S]`. The primed probability-measure wrapper synthesizes that instance from `μ` and is otherwise unchanged.

## Test plan
- Could not `lake build` locally (disk is full). CI is the compiler check.
- Call sites in `Main` / `TorsionEndgame` / `ImprovedPFR` still go through the primed lemma.


Made with [Cursor](https://cursor.com)