### PR TITLE
Point blueprint BSG lean tag at BSG_self

### DIFF
--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -33,14 +33,14 @@
 
 \begin{lemma}[Balog--Szemer\'edi--Gowers lemma]
   \label{bsg}
-  \lean{BSG_self'}
+  \lean{BSG_self}
   \uses{energy-def}
   \leanok
 
   Let $G$ be an abelian group, and let $A$ be a finite non-empty set
   with $E(A) \geq |A|^3 / K$ for some $K \geq 1$.
   Then there is a subset $A'$ of $A$ with $|A'| \geq |A| / (C_1 K^{C_2})$ and
-  $|A'-A'| \leq C_3 K^{C_4} |A|$, where (provisionally)
+  $|A'-A'| \leq C_3 K^{C_4} |A|$, where
   $$C_1 = 2^4, C_2 = 1, C_3 = 2^{10}, C_4 = 5.$$
 \end{lemma}
 \begin{proof}

--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -33,7 +33,7 @@
 
 \begin{lemma}[Balog--Szemer\'edi--Gowers lemma]
   \label{bsg}
-  \lean{BSG}
+  \lean{BSG_self'}
   \uses{energy-def}
   \leanok
 


### PR DESCRIPTION
The BSG lemma states the `|A|`-relative dens bound with constants `C₃=2¹⁰`, `C₄=5`, which is Mathlib `BSG_self`. Retarget `\lean{BSG}` / the previous `BSG_self'` tag to `BSG_self`, and drop “provisionally” now that the constants match.