### PR TITLE
fix: point the Ruzsa covering lean tag at the additive lemma

### DIFF
--- a/blueprint/src/chapter/pfr.tex
+++ b/blueprint/src/chapter/pfr.tex
@@ -2,7 +2,7 @@
 
 \begin{lemma}[Ruzsa covering lemma]
 \label{ruz-cov}
-\lean{Finset.ruzsa_covering_mul}
+\lean{Finset.ruzsa_covering_add}
 \leanok
 If $A,B$ are finite non-empty subsets of a group $G$, then $A$ can be covered by at most $|A+B|/|B|$ translates of $B-B$.
 \end{lemma}


### PR DESCRIPTION
The blueprint Ruzsa covering lemma is additive (`|A+B|/|B|`, translates of `B-B`) but pointed to the multiplicative version. PFR only ever uses the additive version.

Made with [Cursor](https://cursor.com)