### PR TITLE
Blueprint: three \uses edges and the approx-hom constants left at the exponent-11 values

### DIFF
--- a/blueprint/src/chapter/approx_hom_pfr.tex
+++ b/blueprint/src/chapter/approx_hom_pfr.tex
@@ -57,7 +57,7 @@ such that $f(x) = \phi(x)+c$ for at least $|G| / (2 ^ {144} * K ^ {122})$
 values of $x \in G$.
 \end{theorem}
 
-\begin{proof}\uses{goursat, cs-bound, bsg, pfr_aux-improv}\leanok Consider the graph $A \subset G \times G'$ defined by
+\begin{proof}\uses{goursat, cs-bound, bsg, pfr-9-aux'}\leanok Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have $a+a' \in A$ for at least
 $|A|^2/K$ pairs $(a,a') \in A^2$. By \Cref{cs-bound}, this implies that $E(A)
@@ -115,10 +115,10 @@ With a bit more effort, we can remove the constant term $c$, at the cost of redu
   Let $f: G \to G'$ be a function, and suppose that there are at least $|G|^2 / K$ pairs $(x,y) \in G^2$ such that
 $$ f(x+y) = f(x) + f(y).$$
 Then there exists a homomorphism $\phi'': G \to G'$
-such that $f(x) = \phi''(x)$ for at least $(|G| / (2 ^ {172} * K ^ {146}) - 1)/2$ values of $x \in G$.
+such that $f(x) = \phi''(x)$ for at least $(|G| / (2 ^ {144} * K ^ {122}) - 1)/2$ values of $x \in G$.
 \end{corollary}
 
-\begin{proof}\uses{approx-hom-pfr, gslice}\leanok By Theorem \ref{approx-hom-pfr}, there exists a homomorphism $\phi: G \to G'$ and a constant $c \in G'$ such that the set $A := \{ x \in G: f(x) = \phi(x) + c\}$ has cardinality at least $|G| / (2 ^ {172} * K ^ {146})$.  By Lemma \ref{gslice}, there exists a homomorphism $\phi': G \to \Z/2\Z$ such that
-$$ |A \cap \phi'^{-1}(1)| \geq (|A|-1)/2 \geq |G| / (2 ^ {173} * K ^ {146}).$$
+\begin{proof}\uses{approx-hom-pfr, gslice}\leanok By Theorem \ref{approx-hom-pfr}, there exists a homomorphism $\phi: G \to G'$ and a constant $c \in G'$ such that the set $A := \{ x \in G: f(x) = \phi(x) + c\}$ has cardinality at least $|G| / (2 ^ {144} * K ^ {122})$.  By Lemma \ref{gslice}, there exists a homomorphism $\phi': G \to \Z/2\Z$ such that
+$$ |A \cap \phi'^{-1}(1)| \geq (|A|-1)/2 \geq (|G| / (2 ^ {144} * K ^ {122}) - 1)/2.$$
 Then the claim follows by taking $\phi'' = \phi + \phi' \bullet c$ (where we view $G'$ as a $\Z/2\Z$-module).
 \end{proof}

--- a/blueprint/src/chapter/further_improvement.tex
+++ b/blueprint/src/chapter/further_improvement.tex
@@ -377,6 +377,6 @@ of \Cref{pfr_aux}.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{pfr-9-aux,ruz-cov}
+  \uses{pfr-9-aux',ruz-cov}
 Given \Cref{pfr-9-aux'}, the proof is the same as that of \Cref{pfr}.
 \end{proof}

--- a/blueprint/src/chapter/hom_pfr.tex
+++ b/blueprint/src/chapter/hom_pfr.tex
@@ -22,7 +22,7 @@ Then there exists a homomorphism $\phi: G \to G'$ such that
 $$ |\{ f(x) - \phi(x): x \in G \}| \leq |S|^{10}.$$
 \end{theorem}
 
-\begin{proof}\uses{goursat, pfr_aux-improv}\leanok
+\begin{proof}\uses{goursat, pfr-9-aux'}\leanok
 Consider the graph $A \subset G \times G'$ defined by
 $$ A := \{ (x,f(x)): x \in G \}.$$
 Clearly, $|A| = |G|$.  By hypothesis, we have


### PR DESCRIPTION
Three `\uses` edges in the blueprint still name the exponent-11 auxiliary, and the constants in one corollary are the pre-#232 ones. All of it is fallout from #232, which improved the bounds those two chapters quote.

The dependency edges. #232 changed `PFR/HomPFR.lean` and `PFR/ApproxHomPFR.lean` to call `better_PFR_conjecture_aux` instead of `PFR_conjecture_improv_aux`, and it updated the prose of the corresponding blueprint proofs from `\Cref{pfr_aux-improv}` to `\Cref{pfr-9-aux'}`. It did not touch the `\uses` lists, so `hom_pfr.tex:25` still reads `\uses{goursat, pfr_aux-improv}` and `approx_hom_pfr.tex:60` still reads `\uses{goursat, cs-bound, bsg, pfr_aux-improv}` while both proof bodies apply `\Cref{pfr-9-aux'}` two lines later. The graph consequently gives `hom-pfr` and `approx-hom-pfr` an edge to `pfr_aux-improv` (`PFR_conjecture_improv_aux`, `PFR/ImprovedPFR.lean:858`) and no edge to `pfr-9-aux'` (`better_PFR_conjecture_aux`, `PFR/RhoFunctional.lean:2006`), which is what `PFR/HomPFR.lean:100` and `PFR/ApproxHomPFR.lean:72` actually invoke.

`pfr-9` has the same shape of mismatch, though not from the same commit: its proof reads `\uses{pfr-9-aux,ruz-cov}` but says "Given `\Cref{pfr-9-aux'}`", and `better_PFR_conjecture` (`PFR/RhoFunctional.lean:2062`) is discharged from `better_PFR_conjecture_aux`, not from `better_PFR_conjecture_aux0`. I changed that one edge and left `ruz-cov` alone. Nothing is disconnected by this: `pfr-9-aux'` already uses `pfr-9-aux`.

The constants. #232 improved `approx_hom_pfr` from `|G| / (2^172 * K^146)` to `|G| / (2^144 * K^122)`, in the Lean statement, its docstring, and the blueprint theorem `approx-hom-pfr`. The corollary `approx-hom-pfr-no-const` was drafted later, in 6a2fa25, from the older wording, so it kept `2^172 * K^146` and `2^173 * K^146`. The Lean side then went the other way: `approx_hom_pfr'` (`PFR/ApproxHomPFR.lean:287`) concludes `(Nat.card G / (2 ^ 144 * K ^ 122) - 1)/2`, and the corollary is tagged `\lean{approx_hom_pfr'}\leanok`. So the published blueprint states a strictly weaker bound than the theorem it is marked as formalizing, and its proof attributes to `\Cref{approx-hom-pfr}`, on the same page, a bound that theorem does not claim.

One more thing in that proof: the display

    |A ∩ φ'^{-1}(1)| ≥ (|A|-1)/2 ≥ |G| / (2^173 * K^146)

drops the `-1`, which does not follow from `|A| ≥ |G| / (2^172 * K^146)` — the corollary's own statement keeps it. I replaced the right-hand side with `(|G| / (2^144 * K^122) - 1)/2`, which is the corollary's conclusion and is exactly the chain `approx_hom_pfr'` runs: `card_of_slice` gives `(#A - 1)/2`, and `#A` is bounded below by `approx_hom_pfr`.

What I checked. I read the Lean statements and proofs of `homomorphism_pfr`, `approx_hom_pfr`, `approx_hom_pfr'`, `better_PFR_conjecture`, `better_PFR_conjecture_aux` and `PFR_conjecture_improv_aux` directly, and confirmed against the #232 diff that the theorem's constants and the two call sites moved while the `\uses` lists and the later corollary did not. I also swept every `\begin{proof}` in `blueprint/src/chapter/` for labels that appear in the prose but not in that proof's `\uses`; apart from definition references, which the blueprint deliberately leaves out of the graph, these three are the only cases where the missing label has a superseded sibling sitting in the `\uses` list. Every `\uses` and `\ref` label in the blueprint resolves before and after.

What I did not check. `blueprint/src/print.tex` builds with xelatex here, with no undefined references after two passes, before and after the change, but I could not run leanblueprint or plastex (not installed) and so did not render the dependency graph itself, and I could not run `lake build` — there is no Mathlib cache on this machine and not enough disk to fetch one. No Lean file is touched by this PR, so the build is unaffected either way.
